### PR TITLE
integration: make the test output readable

### DIFF
--- a/.github/scripts/integration_test_summary.js
+++ b/.github/scripts/integration_test_summary.js
@@ -1,0 +1,97 @@
+const fs = require('fs')
+const readline = require('readline')
+
+// Reads the `go test -json` event stream written by gotestsum --jsonfile and
+// reports the failed tests as a job summary table plus one annotation each, so
+// that failures are visible without opening the raw log.
+module.exports = async ({ core }) => {
+    const file =
+        process.env['TEST_OUTPUT_FILE_PREFIX'] + '_integration.json'
+
+    if (!fs.existsSync(file)) {
+        core.warning(`No integration test report found at ${file}`)
+        return
+    }
+
+    const failures = []
+    const finished = new Set()
+
+    const stream = readline.createInterface({
+        input: fs.createReadStream(file),
+        crlfDelay: Infinity,
+    })
+
+    for await (const line of stream) {
+        if (!line.trim()) {
+            continue
+        }
+
+        let event
+        try {
+            event = JSON.parse(line)
+        } catch {
+            // gotestsum writes build errors into the stream verbatim.
+            continue
+        }
+
+        if (!event.Test) {
+            continue
+        }
+        if (event.Action === 'pass' || event.Action === 'fail') {
+            finished.add(event.Test)
+        }
+        if (event.Action === 'fail') {
+            failures.push({
+                test: event.Test,
+                elapsed: event.Elapsed ?? 0,
+            })
+        }
+    }
+
+    // A parent test fails whenever a subtest does, and every case is a subtest
+    // of Test_Integration. Counting and reporting only the leaves keeps the
+    // table to the tests that actually broke.
+    const parents = new Set(
+        [...finished].flatMap((test) => {
+            const parts = test.split('/')
+            return parts
+                .slice(0, -1)
+                .map((_, i) => parts.slice(0, i + 1).join('/'))
+        })
+    )
+    const total = [...finished].filter((test) => !parents.has(test)).length
+    const leaves = failures.filter(({ test }) => !parents.has(test))
+
+    const os = process.env['GOOS'] || process.platform
+    const arch = process.env['GOARCH'] || process.arch
+    const title = `Integration tests (${os}/${arch})`
+
+    if (leaves.length === 0) {
+        await core.summary
+            .addHeading(title, 3)
+            .addRaw(`All ${total} integration tests passed.`)
+            .write()
+        return
+    }
+
+    for (const { test, elapsed } of leaves) {
+        core.error(`${test} failed after ${elapsed.toFixed(2)}s`, {
+            title: `Integration test failure: ${test}`,
+        })
+    }
+
+    await core.summary
+        .addHeading(title, 3)
+        .addRaw(`${leaves.length} of ${total} integration tests failed.`)
+        .addTable([
+            [
+                { data: 'Test', header: true },
+                { data: 'Duration', header: true },
+            ],
+            ...leaves.map(({ test, elapsed }) => [
+                test,
+                `${elapsed.toFixed(2)}s`,
+            ]),
+        ])
+        .write()
+}

--- a/.github/scripts/integration_test_summary.js
+++ b/.github/scripts/integration_test_summary.js
@@ -15,6 +15,8 @@ module.exports = async ({ core }) => {
 
     const failures = []
     const finished = new Set()
+    const buildErrors = []
+    const failedPackages = new Set()
 
     const stream = readline.createInterface({
         input: fs.createReadStream(file),
@@ -30,11 +32,16 @@ module.exports = async ({ core }) => {
         try {
             event = JSON.parse(line)
         } catch {
-            // gotestsum writes build errors into the stream verbatim.
+            // gotestsum writes build errors into the stream verbatim, so a line
+            // that is not an event is itself a sign the build broke.
+            buildErrors.push(line.trim())
             continue
         }
 
         if (!event.Test) {
+            if (event.Action === 'fail') {
+                failedPackages.add(event.Package || 'unknown')
+            }
             continue
         }
         if (event.Action === 'pass' || event.Action === 'fail') {
@@ -66,12 +73,28 @@ module.exports = async ({ core }) => {
     const arch = process.env['GOARCH'] || process.arch
     const title = `Integration tests (${os}/${arch})`
 
+    // A package always fails when one of its tests does, so its failure is only
+    // news when no test accounts for it: a build error, a panic during init, or
+    // a timeout. Reporting success in that case would be a lie.
+    const packageErrors = buildErrors.slice()
     if (leaves.length === 0) {
+        for (const pkg of failedPackages) {
+            packageErrors.push(`${pkg} failed without any test failing`)
+        }
+    }
+
+    if (leaves.length === 0 && packageErrors.length === 0) {
         await core.summary
             .addHeading(title, 3)
             .addRaw(`All ${total} integration tests passed.`)
             .write()
         return
+    }
+
+    // Surfaced before the per-test table: a package that did not build, or that
+    // died outside a test, explains every test that never ran.
+    for (const err of packageErrors) {
+        core.error(err, { title: `Integration test failure (${os}/${arch})` })
     }
 
     for (const { test, elapsed } of leaves) {
@@ -80,8 +103,21 @@ module.exports = async ({ core }) => {
         })
     }
 
-    await core.summary
-        .addHeading(title, 3)
+    const summary = core.summary.addHeading(title, 3)
+
+    if (packageErrors.length > 0) {
+        summary.addRaw(
+            'The package itself failed, so some tests may never have run:'
+        )
+        summary.addList(packageErrors)
+    }
+
+    if (leaves.length === 0) {
+        await summary.write()
+        return
+    }
+
+    await summary
         .addRaw(`${leaves.length} of ${total} integration tests failed.`)
         .addTable([
             [

--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -296,6 +296,21 @@ jobs:
           go-version-file: "go.mod"
       - name: Run workflow suite in ${{ matrix.mode }} mode
         run: make test-integration-parallel ARGS="-focus workflow"
+      - name: Summarise integration test failures
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const script = require('./.github/scripts/integration_test_summary.js')
+            await script({ core })
+      - name: Upload integration test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.target_os }}_${{ matrix.target_arch }}_test_integration
+          path: |
+            ${{ env.TEST_OUTPUT_FILE_PREFIX }}_integration.json
+            ${{ env.TEST_OUTPUT_FILE_PREFIX }}_integration.xml
   build:
     name: "Build artifacts on ${{ matrix.job_name }} - ${{ matrix.sidecar_flavor }}"
     runs-on: "${{ matrix.os }}"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -70,6 +70,16 @@ linters:
     - noinlineerr
     - wsl_v5
   settings:
+    forbidigo:
+      forbid:
+        - pattern: ^fmt\.Print(|f|ln)$
+        - pattern: ^print(|ln)$
+        # durabletask's default logger captures os.Stderr when its package is
+        # initialised, so it cannot be redirected afterwards. In the integration
+        # tests that means its output bypasses the framework and lands on the
+        # terminal, attributed to no test.
+        - pattern: ^backend\.DefaultLogger$
+          msg: pass a per test logger instead, e.g. logger.New(t) from tests/integration/framework/iowriter/logger
     depguard:
       rules:
         master:

--- a/Makefile
+++ b/Makefile
@@ -390,21 +390,41 @@ else
 TEST_ADDITIONAL_TAGS:=
 endif
 
+# Process logs are written to one file per failed test (see
+# tests/docs/writing-integration-test.md), so what reaches the terminal is the
+# assertion, a pointer to that file, and a summary of failures at the end.
+#
+# --format testname prints one line per test, and the output of failed tests
+# only. Under GitHub Actions gotestsum upgrades it to the github-actions format,
+# which additionally collapses each test's output into a log group.
+GOTESTSUM_INTEGRATION_FLAGS := \
+	--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
+	--junitfile $(TEST_OUTPUT_FILE_PREFIX)_integration.xml \
+	--format testname
+
 .PHONY: test-integration
 test-integration: test-deps
 		CGO_ENABLED=1 gotestsum \
-			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
-			--format testname \
+			$(GOTESTSUM_INTEGRATION_FLAGS) \
 			-- \
 			./tests/integration -timeout=30m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=false $(ARGS)
 
 .PHONY: test-integration-parallel
 test-integration-parallel: test-deps
 		CGO_ENABLED=1 gotestsum \
-			--jsonfile $(TEST_OUTPUT_FILE_PREFIX)_integration.json \
-			--format testname \
+			$(GOTESTSUM_INTEGRATION_FLAGS) \
 			-- \
 			./tests/integration -timeout=30m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=true $(ARGS)
+
+# Local runs. Prints a live dot per test rather than a line, so a full suite run
+# fits on one screen. Pass a focus regex with FOCUS, e.g.
+#   make test-integration-dots FOCUS=actors/reminders
+.PHONY: test-integration-dots
+test-integration-dots: test-deps
+		CGO_ENABLED=1 gotestsum \
+			--format dots-v2 \
+			-- \
+			./tests/integration -timeout=30m -count=1 -v -tags="integration$(TEST_ADDITIONAL_TAGS)" -integration-parallel=true -focus="$(or $(FOCUS),.*)" $(ARGS)
 
 ################################################################################
 # Target: lint                                                                 #

--- a/go.mod
+++ b/go.mod
@@ -65,6 +65,7 @@ require (
 	go.opentelemetry.io/proto/otlp v1.10.0
 	go.uber.org/automaxprocs v1.6.0
 	go.uber.org/ratelimit v0.3.0
+	go.uber.org/zap v1.27.0
 	golang.org/x/crypto v0.55.0
 	golang.org/x/net v0.58.0
 	golang.org/x/oauth2 v0.36.0
@@ -463,7 +464,6 @@ require (
 	go.starlark.net v0.0.0-20230525235612-a134d8f9ddca // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/exp v0.0.0-20250408133849-7e4ce0ab07d0 // indirect
 	golang.org/x/image v0.43.0 // indirect
 	golang.org/x/mod v0.40.0 // indirect

--- a/pkg/internal/loader/disk/dirdata/deletepending_other.go
+++ b/pkg/internal/loader/disk/dirdata/deletepending_other.go
@@ -1,0 +1,23 @@
+//go:build !windows
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dirdata
+
+// isDeletePending is always false away from Windows, where unlinking a file
+// takes effect immediately and a delete observed mid scan surfaces as
+// fs.ErrNotExist.
+func isDeletePending(error) bool {
+	return false
+}

--- a/pkg/internal/loader/disk/dirdata/deletepending_windows.go
+++ b/pkg/internal/loader/disk/dirdata/deletepending_windows.go
@@ -1,0 +1,32 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dirdata
+
+import (
+	"errors"
+	"syscall"
+)
+
+// isDeletePending reports whether err is Windows refusing to open a file which
+// has been deleted but whose handles are not all closed yet.
+//
+// Deleting a file another process still holds open does not remove it on
+// Windows. The file enters a delete pending state: it keeps appearing in the
+// directory listing, but opening it fails with ERROR_ACCESS_DENIED until the
+// last handle closes. A resource file being watched by dapr is exactly that
+// case, so a delete observed mid scan surfaces here rather than as the
+// fs.ErrNotExist a POSIX system would return.
+func isDeletePending(err error) bool {
+	return errors.Is(err, syscall.ERROR_ACCESS_DENIED)
+}

--- a/pkg/internal/loader/disk/dirdata/deletepending_windows_test.go
+++ b/pkg/internal/loader/disk/dirdata/deletepending_windows_test.go
@@ -1,0 +1,52 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dirdata
+
+import (
+	"os"
+	"path/filepath"
+	"syscall"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestIsDeletePendingWindows(t *testing.T) {
+	t.Run("should recognise access denied", func(t *testing.T) {
+		assert.True(t, isDeletePending(syscall.ERROR_ACCESS_DENIED))
+	})
+
+	t.Run("should skip a file deleted while another handle holds it open", func(t *testing.T) {
+		// Removing a file that is still open leaves it delete pending: it
+		// stays in the directory listing, but opening it fails with access
+		// denied until the last handle closes. This is the state a resource
+		// file is in when the hot reload watcher still has it open, and the
+		// scan has to tolerate it rather than fail the whole reload.
+		dir := t.TempDir()
+		path := filepath.Join(dir, "1.yaml")
+		require.NoError(t, os.WriteFile(path, []byte("a"), 0o600))
+
+		f, err := os.Open(path)
+		require.NoError(t, err)
+		t.Cleanup(func() { f.Close() })
+
+		require.NoError(t, os.Remove(path))
+
+		data, err := ReadDirs([]string{dir})
+		require.NoError(t, err, "a delete pending file must not fail the scan")
+		require.Len(t, data.Entries, 1)
+		assert.Empty(t, data.Entries[0].Files)
+	})
+}

--- a/pkg/internal/loader/disk/dirdata/dirdata.go
+++ b/pkg/internal/loader/disk/dirdata/dirdata.go
@@ -84,7 +84,11 @@ func readDir(dir string) (*DirEntry, error) {
 			// File may have been deleted between the directory listing and
 			// the read (e.g. during a rapid write/delete cycle or shutdown).
 			// Skip it; the next FSWatcher event will re-trigger a scan.
-			if errors.Is(err, fs.ErrNotExist) {
+			//
+			// Windows reports the same race as a delete pending file rather
+			// than a missing one, since the watcher's own handle keeps the
+			// entry in the listing until it closes.
+			if errors.Is(err, fs.ErrNotExist) || isDeletePending(err) {
 				continue
 			}
 			return nil, fmt.Errorf("failed to read file %s: %w", filepath.Join(dir, f.Name()), err)

--- a/pkg/internal/loader/disk/dirdata/dirdata_test.go
+++ b/pkg/internal/loader/disk/dirdata/dirdata_test.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dirdata
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestReadDirs(t *testing.T) {
+	t.Run("should read yaml files", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "1.yaml"), []byte("a"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "2.yml"), []byte("b"), 0o600))
+
+		data, err := ReadDirs([]string{dir})
+		require.NoError(t, err)
+		require.Len(t, data.Entries, 1)
+		assert.ElementsMatch(t, []FileEntry{
+			{Name: "1.yaml", Content: []byte("a")},
+			{Name: "2.yml", Content: []byte("b")},
+		}, data.Entries[0].Files)
+	})
+
+	t.Run("should ignore files which are not yaml", func(t *testing.T) {
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("a"), 0o600))
+		require.NoError(t, os.Mkdir(filepath.Join(dir, "nested"), 0o750))
+
+		data, err := ReadDirs([]string{dir})
+		require.NoError(t, err)
+		require.Len(t, data.Entries, 1)
+		assert.Empty(t, data.Entries[0].Files)
+	})
+
+	t.Run("should error when a directory is missing", func(t *testing.T) {
+		_, err := ReadDirs([]string{filepath.Join(t.TempDir(), "nope")})
+		require.Error(t, err)
+	})
+
+	t.Run("should skip a file deleted between listing and read", func(t *testing.T) {
+		// The race this stands in for is a resource file removed while the
+		// hot reload watcher is scanning. Reading a name that is no longer
+		// there must not fail the whole scan, since the watcher event which
+		// follows re-runs it.
+		dir := t.TempDir()
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "1.yaml"), []byte("a"), 0o600))
+		require.NoError(t, os.WriteFile(filepath.Join(dir, "2.yaml"), []byte("b"), 0o600))
+		require.NoError(t, os.Remove(filepath.Join(dir, "2.yaml")))
+
+		data, err := ReadDirs([]string{dir})
+		require.NoError(t, err)
+		require.Len(t, data.Entries, 1)
+		assert.Equal(t, []FileEntry{{Name: "1.yaml", Content: []byte("a")}}, data.Entries[0].Files)
+	})
+}
+
+func TestIsDeletePending(t *testing.T) {
+	t.Run("should not treat a missing file as delete pending", func(t *testing.T) {
+		_, err := os.ReadFile(filepath.Join(t.TempDir(), "nope"))
+		require.Error(t, err)
+		assert.False(t, isDeletePending(err))
+	})
+
+	t.Run("should not treat a nil error as delete pending", func(t *testing.T) {
+		assert.False(t, isDeletePending(nil))
+	})
+}

--- a/tests/docs/writing-integration-test.md
+++ b/tests/docs/writing-integration-test.md
@@ -195,5 +195,18 @@ Finally, include your integration test directory with a blank identifier to
 You may need to extend the framework options to suit your test scenario. These
 are defined in `tests/integration/framework`.
 
+Anything in your test that takes a logger should be given `logger.New(t)` from
+`tests/integration/framework/iowriter/logger`, so its output is captured with
+the rest of the test's rather than printed to the terminal. This matters most
+for workflow clients:
+
+```go
+client.NewTaskHubGrpcClient(daprd.GRPCConn(t, ctx), logger.New(t))
+dworkflow.NewClientWithLogger(daprd.GRPCConn(t, ctx), logger.New(t))
+```
+
+`backend.DefaultLogger()` writes straight to stderr and cannot be redirected
+afterwards, so a lint rule rejects it.
+
 Take a look at `tests/integration/suite/ports/ports.go` as a "hello world"
 example to base your test on.

--- a/tests/docs/writing-integration-test.md
+++ b/tests/docs/writing-integration-test.md
@@ -14,22 +14,58 @@ You can find out more about the background and design decisions of the integrati
 ## Invoking the test
 
 ```bash
-go test -v -race -tags integration ./tests/integration
+go test -race -tags integration ./tests/integration
 ```
 
-You can also run a subset of tests by specifying the `-focus` flag, which takes a [Go regular expression](https://github.com/google/re2/wiki/Syntax).
+**Do not pass `-v`.** It makes Go print a `=== RUN` and a `--- PASS` line for
+every test and subtest, which is over eight thousand lines across the suite and
+buries the failures.
+
+Without it, the run draws a progress line on your terminal instead:
+
+```
+ ⠹ 512/1347  ok 510  fail 2  1m04s  actors/reminders/period
+```
+
+It updates in place as tests finish, so the run is never silent, and failures
+are printed above it the moment they happen:
+
+```
+  FAIL  actors/deactivation/move
+```
+
+The line is drawn on the terminal, not on stdout, so `go test > out.txt` still
+gets clean output while you watch progress on screen. It turns itself off when
+there is no terminal, on CI, and under `-v`. `DAPR_INTEGRATION_PROGRESS=false`
+disables it.
+
+When everything passes, all that is left behind is:
+
+```
+ok  	github.com/dapr/dapr/tests/integration	204.534s
+```
+
+Run a subset with the `-focus` flag, which takes a [Go regular expression](https://github.com/google/re2/wiki/Syntax).
 
 ```bash
 # Run all sentry related tests.
-go test -v -race -tags integration ./tests/integration -focus sentry
+go test -race -tags integration ./tests/integration -focus sentry
 
 # Run all sentry related tests whilst skipping the sentry jwks validator test.
-go test -v -race -tags integration ./tests/integration -test.skip Test_Integration/sentry/validator/jwks -focus sentry
+go test -race -tags integration ./tests/integration -test.skip Test_Integration/sentry/validator/jwks -focus sentry
 ```
 
 To run integration tests several times for debugging purposes use this configuration and change the focus and count as needed:
 ```bash
-go test -v -race -tags integration ./tests/integration -focus scheduler/authz --count=100 -failfast
+go test -race -tags integration ./tests/integration -focus scheduler/authz --count=100 -failfast
+```
+
+For a live view of a long run, use the dots format, which prints one character
+per test as it completes:
+
+```bash
+make test-integration-dots
+make test-integration-dots FOCUS=sentry
 ```
 
 Rather than building from source, you can also set a custom daprd, sentry, or placement binary path with the environment variables:
@@ -37,9 +73,84 @@ Rather than building from source, you can also set a custom daprd, sentry, or pl
 - `DAPR_INTEGRATION_PLACEMENT_PATH`
 - `DAPR_INTEGRATION_SENTRY_PATH`
 
-By default, binary logs will not be printed unless the test fails. You can force
-logs to always be printed with the environment variable
-`DAPR_INTEGRATION_LOGS=true`.
+## Reading the output
+
+A passing test prints nothing beyond its own result line. A failing test prints
+its assertion and one more line, pointing at the log file for that test:
+
+```
+    daprd.go:60: Error: Not equal: expected 1234, actual 1027
+    logs: /tmp/dapr_integration_logs/ports.daprd.log
+```
+
+Process logs are never dumped into the terminal, because a full suite run
+produces tens of thousands of lines of them. At the end of the run every failure
+is listed again with its log file:
+
+```
+1 of 1347 test cases failed:
+  ports/daprd  /tmp/dapr_integration_logs/ports.daprd.log
+Read all of them with: less /tmp/dapr_integration_logs/*.log
+```
+
+The directory is emptied at the start of each run. Set
+`DAPR_INTEGRATION_LOGS_DIR` to change it, which is also how to run two suites at
+once without them overwriting each other.
+
+Inside a log file is what the harness did, followed by one block per process,
+each line prefixed with how long after the test started it was written:
+
+```
+──── logs: scheduler/authz/Authz (FAIL after 4.21s) ─────────────────────────
+── framework ──
+    0.000s  starting 3 processes
+    0.004s  exec scheduler: /tmp/dapr_integration_tests/scheduler --port=41231
+    4.208s  scheduler exited (code 0, want 0)
+── daprd app_id=myapp ──
+    0.402s  INFO   dapr.runtime  dapr initialized. Status: Running
+    1.190s  ERROR  dapr.runtime  failed to connect to scheduler
+─────────────────────────────────────────────────────────────────────────────
+```
+
+Where a test runs several instances of the same process, the second and later
+instances are reported as `daprd-1`, `daprd-2` and so on.
+
+Log files are written whether or not `go test` is verbose, so
+`DAPR_INTEGRATION_LOGS=true` gives you a directory of logs to browse after a run
+without putting a single extra line on your terminal:
+
+```bash
+DAPR_INTEGRATION_LOGS=true go test -race -tags integration ./tests/integration -focus actors/reminders
+less /tmp/dapr_integration_logs/*.log
+```
+
+Some dapr packages, such as `pkg/security`, run inside the test binary rather
+than inside a process a test started. They register a logger at init and write
+straight to stderr, which belongs to no particular test and which `go test` will
+happily print in the middle of a run:
+
+```
+INFO[0002] Starting workload identity expiry watcher; cert expires on: ...  scope=dapr.runtime.security ver=unknown
+```
+
+Those go to `in-process.log` in the same directory instead. Set
+`DAPR_INTEGRATION_INPROCESS_LOGS=true` to leave them on stderr.
+
+The report is controlled by these environment variables:
+
+- `DAPR_INTEGRATION_LOGS=true` writes a report even when the test passes.
+- `DAPR_INTEGRATION_LOGS_INLINE=true` puts the report in the test output instead
+  of a file. This is already the default on GitHub Actions, which collapses each
+  test's output into a log group, so a CI failure can be read without
+  downloading anything. Locally it is only sensible for a small focus.
+- `DAPR_INTEGRATION_LOGS=stream` writes lines to stderr as they arrive instead of
+  at the end. Useful when focused on a single test, since the output of tests
+  running in parallel interleaves.
+- `DAPR_INTEGRATION_LOGS_DIR` sets the directory log files are written to.
+- `DAPR_INTEGRATION_LOGS_RAW=true` disables log line parsing, so each line is
+  shown exactly as the process wrote it.
+- `DAPR_INTEGRATION_LOGS_COLOR=false` disables colour, which is otherwise used on
+  a terminal and on GitHub Actions. `NO_COLOR` is also honoured.
 
 You can override the directory that is used to read the CRD definitions that are served by the Kubernetes process with the environment variable `DAPR_INTEGRATION_CRD_DIRECTORY`.
 

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -130,7 +130,7 @@ func build(t *testing.T, name string, opts options) {
 	}
 
 	if _, ok := os.LookupEnv(EnvKey(name)); !ok {
-		t.Logf("%q not set, building %q binary", EnvKey(name), name)
+		iowriter.Eventf(t, "%s not set, building %q binary", EnvKey(name), name)
 
 		// Use a consistent temp dir for the binary so that the binary is cached on
 		// subsequent runs.
@@ -145,11 +145,10 @@ func build(t *testing.T, name string, opts options) {
 			binPath += ".exe"
 		}
 
-		ioout := iowriter.New(t, name)
-		ioerr := iowriter.New(t, name)
+		// Both streams share one writer so the build appears as a single block.
+		iow := iowriter.New(t, name)
 
-		t.Logf("Root dir: %q", opts.dir)
-		t.Logf("Compiling %q binary to: %q", name, binPath)
+		iowriter.Eventf(t, "compiling %q from %q to %q", name, opts.dir, binPath)
 
 		// get go build args
 		goBuildArgs := []string{"build"}
@@ -168,20 +167,19 @@ func build(t *testing.T, name string, opts options) {
 
 		cmd := exec.Command("go", goBuildArgs...)
 		cmd.Dir = opts.dir
-		cmd.Stdout = ioout
-		cmd.Stderr = ioerr
+		cmd.Stdout = iow
+		cmd.Stderr = iow
 		// Ensure CGO is disabled to avoid linking against system libraries.
 		cmd.Env = append(os.Environ(), "CGO_ENABLED=0")
 		assert.NoError(t, cmd.Run())
 
-		assert.NoError(t, ioout.Close())
-		assert.NoError(t, ioerr.Close())
+		assert.NoError(t, iow.Close())
 
 		// TODO: @joshvanl: check if we can use `t.Setenv`
 		//nolint:usetesting
 		assert.NoError(t, os.Setenv(EnvKey(name), binPath))
 	} else {
-		t.Logf("%q set, using %q pre-built binary", EnvKey(name), EnvValue(name))
+		iowriter.Eventf(t, "%s set, using pre-built binary %q", EnvKey(name), EnvValue(name))
 	}
 }
 

--- a/tests/integration/framework/client/etcd.go
+++ b/tests/integration/framework/client/etcd.go
@@ -27,7 +27,7 @@ type EtcdClient struct {
 
 // Returns an adapted Etcd client for tests.
 func Etcd(t *testing.T, cfg clientv3.Config) *EtcdClient {
-	etcdClient, err := clientv3.New(cfg)
+	etcdClient, err := clientv3.New(WithEtcdLogger(t, cfg))
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, etcdClient.Close()) })
 

--- a/tests/integration/framework/client/etcdlogger.go
+++ b/tests/integration/framework/client/etcdlogger.go
@@ -1,0 +1,53 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package client
+
+import (
+	"testing"
+
+	clientv3 "go.etcd.io/etcd/client/v3"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
+)
+
+// EtcdLogger returns a logger for an in-process etcd client which writes into
+// the test's captured output.
+//
+// Left unset, clientv3 builds its own logger straight to stderr, which `go
+// test` cannot attribute to a test and so prints in the middle of a run:
+//
+//	{"level":"warn",...,"logger":"etcd-client","msg":"retrying of unary invoker failed",...}
+func EtcdLogger(t *testing.T) *zap.Logger {
+	t.Helper()
+
+	return zap.New(zapcore.NewCore(
+		zapcore.NewJSONEncoder(zap.NewProductionEncoderConfig()),
+		zapcore.AddSync(iowriter.New(t, "etcd-client")),
+		zapcore.WarnLevel,
+	))
+}
+
+// WithEtcdLogger returns cfg with a logger attached, unless the caller already
+// chose one.
+func WithEtcdLogger(t *testing.T, cfg clientv3.Config) clientv3.Config {
+	t.Helper()
+
+	if cfg.Logger == nil {
+		cfg.Logger = EtcdLogger(t)
+	}
+
+	return cfg
+}

--- a/tests/integration/framework/framework.go
+++ b/tests/integration/framework/framework.go
@@ -17,6 +17,8 @@ import (
 	"context"
 	"os"
 	"testing"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 )
 
 var inGHAction = false
@@ -39,7 +41,7 @@ func Run(t *testing.T, ctx context.Context, opts ...Option) {
 		t.Skip("skipping io-intensive test in GH Action environment")
 	}
 
-	t.Logf("starting %d processes", len(o.procs))
+	iowriter.Eventf(t, "starting %d processes", len(o.procs))
 
 	for i, proc := range o.procs {
 		proc.Run(t, ctx)

--- a/tests/integration/framework/iowriter/collector.go
+++ b/tests/integration/framework/iowriter/collector.go
@@ -1,0 +1,379 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iowriter
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	kitstrings "github.com/dapr/kit/strings"
+)
+
+// eventsBlock is the name of the block holding framework events, i.e. what the
+// test harness did rather than what a process printed.
+const eventsBlock = "framework"
+
+// bannerWidth is the width the log banner is padded to.
+const bannerWidth = 78
+
+// collectors holds the collector for each test. Entries outlive their test so
+// that late output from a process finds a collector to discard it, but the
+// captured lines themselves are released once the test has reported.
+var collectors sync.Map
+
+// streaming reports whether lines should be written to stderr as they arrive
+// rather than buffered until the test finishes. Only useful when focused on a
+// single test, since parallel tests interleave.
+func streaming() bool {
+	return strings.EqualFold(os.Getenv("DAPR_INTEGRATION_LOGS"), "stream")
+}
+
+// alwaysLog reports whether logs should be emitted even when the test passed.
+func alwaysLog() bool {
+	return kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_LOGS"))
+}
+
+type line struct {
+	at   time.Duration
+	text string
+}
+
+// block is the captured output of a single source: one process, or the
+// framework itself.
+type block struct {
+	c    *collector
+	name string
+
+	lock  sync.Mutex
+	lines []line
+}
+
+func (b *block) append(at time.Duration, text string) {
+	// A process can outlive the test which started it. Dropping its late output
+	// is far better than the panic a t.Log after test completion would cause.
+	if b.c != nil && b.c.finished() {
+		return
+	}
+
+	// Streamed lines carry the test they belong to, since tests running in
+	// parallel share stderr.
+	if streaming() {
+		fmt.Fprintf(os.Stderr, "%s %s %s %s\n",
+			offset(at), b.c.shortName(), pad(b.name, 10),
+			parseEntry(text).format(maxScopeWidth),
+		)
+		return
+	}
+
+	b.lock.Lock()
+	defer b.lock.Unlock()
+	b.lines = append(b.lines, line{at: at, text: text})
+}
+
+// collector gathers every block belonging to a single test, and emits them as
+// one pretty printed report if the test fails.
+type collector struct {
+	t  Logger
+	t0 time.Time
+
+	lock    sync.Mutex
+	events  *block
+	blocks  []*block
+	names   map[string]int
+	writers []*stdwriter
+	notes   []string
+	done    atomic.Bool
+}
+
+// finished reports whether the report has already been emitted, after which
+// further output is dropped rather than recorded.
+func (c *collector) finished() bool {
+	return c.done.Load()
+}
+
+// collectorFor returns the collector for t, creating it on first use. Creation
+// registers the flush cleanup, which is why it must happen before any process
+// registers its own cleanup: cleanups run last in, first out, so the flush runs
+// after every process has exited and drained its output.
+func collectorFor(t Logger) *collector {
+	if c, ok := collectors.Load(t); ok {
+		return c.(*collector)
+	}
+
+	c := &collector{
+		t:     t,
+		t0:    time.Now(),
+		names: make(map[string]int),
+	}
+	c.events = &block{c: c, name: eventsBlock}
+
+	actual, loaded := collectors.LoadOrStore(t, c)
+	if loaded {
+		return actual.(*collector)
+	}
+
+	t.Cleanup(c.flush)
+
+	return c
+}
+
+func (c *collector) since() time.Duration {
+	return time.Since(c.t0)
+}
+
+// shortName is the test name without the suite prefix every case shares.
+func (c *collector) shortName() string {
+	return strings.TrimPrefix(c.t.Name(), "Test_Integration/")
+}
+
+// newBlock registers a source with the collector. Repeated names are
+// suffixed with an index so that, say, three daprds in one test are
+// distinguishable as daprd, daprd-1 and daprd-2.
+func (c *collector) newBlock(name string) *block {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	n := c.names[name]
+	c.names[name]++
+	if n > 0 {
+		name += "-" + strconv.Itoa(n)
+	}
+
+	b := &block{c: c, name: name}
+	c.blocks = append(c.blocks, b)
+
+	return b
+}
+
+func (c *collector) addWriter(w *stdwriter) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.writers = append(c.writers, w)
+}
+
+// note records a message shown in the report banner, for conditions which
+// explain the whole failure such as a blown deadline.
+func (c *collector) note(msg string) {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+	c.notes = append(c.notes, msg)
+}
+
+func (c *collector) flush() {
+	c.lock.Lock()
+	writers := make([]*stdwriter, len(c.writers))
+	copy(writers, c.writers)
+	c.lock.Unlock()
+
+	// Move any trailing partial line into its block. Processes which exited
+	// without a final newline would otherwise lose their last, often most
+	// interesting, line.
+	for _, w := range writers {
+		w.Close()
+	}
+
+	if !streaming() && (c.t.Failed() || alwaysLog()) {
+		c.report()
+	}
+
+	// The entry is kept so that a process outliving its test finds a collector
+	// which drops its output, rather than one which registers a cleanup on an
+	// already finished test. Only the captured lines are released.
+	c.done.Store(true)
+	c.release()
+}
+
+func (c *collector) release() {
+	c.lock.Lock()
+	defer c.lock.Unlock()
+
+	for _, b := range append([]*block{c.events}, c.blocks...) {
+		b.lock.Lock()
+		b.lines = nil
+		b.lock.Unlock()
+	}
+	c.blocks = nil
+	c.writers = nil
+	c.notes = nil
+}
+
+// report writes the collected logs to their own file and leaves a single line
+// in the test output pointing at it. A full suite run produces tens of
+// thousands of log lines, which drown the failures they are meant to explain
+// when written to the terminal.
+func (c *collector) report() {
+	var sb strings.Builder
+	c.render(&sb)
+	if sb.Len() == 0 {
+		return
+	}
+
+	if inline() {
+		fmt.Fprint(c.t.Output(), sb.String())
+		if c.t.Failed() {
+			recordFailure(c.shortName(), "")
+		}
+		return
+	}
+
+	path, err := writeReport(c.shortName(), sb.String())
+	if err != nil {
+		// Falling back to the test output is noisy, but losing the logs
+		// entirely would be worse.
+		fmt.Fprintf(c.t.Output(), "could not write log file (%v), falling back to inline logs\n", err)
+		fmt.Fprint(c.t.Output(), sb.String())
+		return
+	}
+
+	fmt.Fprintf(c.t.Output(), "logs: %s\n", path)
+	if c.t.Failed() {
+		recordFailure(c.shortName(), path)
+	}
+}
+
+func (c *collector) render(w io.Writer) {
+	c.lock.Lock()
+	blocks := append([]*block{c.events}, c.blocks...)
+	notes := make([]string, len(c.notes))
+	copy(notes, c.notes)
+	c.lock.Unlock()
+
+	var body strings.Builder
+	for _, note := range notes {
+		body.WriteString("  " + colorize(note, ansiRed, ansiBold) + "\n")
+	}
+	for _, b := range blocks {
+		b.render(&body)
+	}
+
+	// An empty report is worse than none: it is two lines of banner saying
+	// nothing happened.
+	if body.Len() == 0 {
+		return
+	}
+
+	fmt.Fprint(w, c.banner()+body.String()+colorize(rule(bannerWidth), ansiDim)+"\n")
+}
+
+func (c *collector) banner() string {
+	status, color := "PASS", ansiGreen
+	if c.t.Failed() {
+		status, color = "FAIL", ansiRed
+	}
+
+	head := fmt.Sprintf("%s logs: %s (%s after %s) ",
+		rule(4), c.shortName(), colorize(status, color, ansiBold), c.since().Truncate(time.Millisecond*10),
+	)
+
+	// Pad to the banner width, accounting for the invisible escapes the status
+	// colouring added.
+	visible := len([]rune(head)) - len([]rune(colorize(status, color, ansiBold))) + len(status)
+	if visible < bannerWidth {
+		head += rule(bannerWidth - visible)
+	}
+
+	return colorize(head, ansiDim) + "\n"
+}
+
+func (b *block) render(sb *strings.Builder) {
+	b.lock.Lock()
+	lines := make([]line, len(b.lines))
+	copy(lines, b.lines)
+	b.lock.Unlock()
+
+	if len(lines) == 0 {
+		return
+	}
+
+	entries := make([]entry, len(lines))
+	var scopeWidth int
+	for i, l := range lines {
+		entries[i] = parseEntry(l.text)
+		if w := len(entries[i].scope); w > scopeWidth {
+			scopeWidth = min(w, maxScopeWidth)
+		}
+	}
+
+	header, lifted := b.header(entries)
+
+	// Anything not lifted into the header stays on the line it came from.
+	for i, e := range entries {
+		for _, p := range e.hoist {
+			if !lifted[p.key] {
+				entries[i].extra = append(entries[i].extra, p)
+			}
+		}
+	}
+
+	sb.WriteString(header)
+	for i, e := range entries {
+		sb.WriteString("  " + colorize(offset(lines[i].at), ansiDim) + "  " + e.format(scopeWidth) + "\n")
+	}
+}
+
+// header names the block, lifting any field which is constant across the whole
+// block (such as the app ID of a daprd) out of the per line output. It returns
+// the set of fields it lifted.
+func (b *block) header(entries []entry) (string, map[string]bool) {
+	var parsed int
+	vals := make(map[string]string)
+	counts := make(map[string]int)
+	conflict := make(map[string]bool)
+
+	for _, e := range entries {
+		if !e.parsed {
+			continue
+		}
+		parsed++
+		for _, p := range e.hoist {
+			if prev, ok := vals[p.key]; ok && prev != p.val {
+				conflict[p.key] = true
+			}
+			vals[p.key] = p.val
+			counts[p.key]++
+		}
+	}
+
+	// Only lift a field out of the lines if every parsed line carries it with
+	// the same value, otherwise dropping it from the lines would lose data.
+	lifted := make(map[string]bool, len(vals))
+	keys := make([]string, 0, len(vals))
+	for key := range vals {
+		if !conflict[key] && counts[key] == parsed {
+			lifted[key] = true
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+
+	var head strings.Builder
+	head.WriteString(rule(2) + " " + b.name)
+	for _, key := range keys {
+		head.WriteString(" " + key + "=" + vals[key])
+	}
+	head.WriteString(" " + rule(2))
+
+	return colorize(head.String(), ansiDim, ansiBold) + "\n", lifted
+}
+
+func offset(d time.Duration) string {
+	return fmt.Sprintf("%7.3fs", d.Seconds())
+}

--- a/tests/integration/framework/iowriter/color.go
+++ b/tests/integration/framework/iowriter/color.go
@@ -1,0 +1,73 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iowriter
+
+import (
+	"os"
+	"runtime"
+	"strings"
+
+	kitstrings "github.com/dapr/kit/strings"
+)
+
+const (
+	ansiReset  = "\x1b[0m"
+	ansiBold   = "\x1b[1m"
+	ansiDim    = "\x1b[2m"
+	ansiRed    = "\x1b[31m"
+	ansiGreen  = "\x1b[32m"
+	ansiYellow = "\x1b[33m"
+	ansiBlue   = "\x1b[34m"
+	ansiCyan   = "\x1b[36m"
+)
+
+var (
+	useColor   = detectColor()
+	useUnicode = runtime.GOOS != "windows"
+)
+
+// detectColor reports whether ANSI escapes should be emitted.
+// DAPR_INTEGRATION_LOGS_COLOR forces the decision either way, otherwise colour
+// is used on GitHub Actions (which renders ANSI) and on a local terminal.
+func detectColor() bool {
+	if v, ok := os.LookupEnv("DAPR_INTEGRATION_LOGS_COLOR"); ok {
+		return kitstrings.IsTruthy(v)
+	}
+	if _, ok := os.LookupEnv("NO_COLOR"); ok {
+		return false
+	}
+	if os.Getenv("GITHUB_ACTIONS") == "true" {
+		return true
+	}
+	fi, err := os.Stdout.Stat()
+	return err == nil && fi.Mode()&os.ModeCharDevice != 0
+}
+
+// colorize wraps s in the given ANSI codes. Callers must pad s to its final
+// width first, since the escapes are invisible but still count as bytes.
+func colorize(s string, codes ...string) string {
+	if !useColor || len(codes) == 0 || len(s) == 0 {
+		return s
+	}
+	return strings.Join(codes, "") + s + ansiReset
+}
+
+// rule returns a horizontal rule of n cells, falling back to ASCII where the
+// terminal cannot be trusted to render box drawing characters.
+func rule(n int) string {
+	if useUnicode {
+		return strings.Repeat("─", n)
+	}
+	return strings.Repeat("-", n)
+}

--- a/tests/integration/framework/iowriter/iowriter.go
+++ b/tests/integration/framework/iowriter/iowriter.go
@@ -15,84 +15,109 @@ package iowriter
 
 import (
 	"bytes"
-	"errors"
+	"fmt"
 	"io"
-	"os"
 	"strings"
 	"sync"
-
-	kitstrings "github.com/dapr/kit/strings"
 )
 
-// Logger is an interface that provides a Log method and a Name method. The Log
-// method is used to write a log message to the logger. The Name method returns
-// the name of the logger which will be prepended to each log message.
+// Logger is the subset of *testing.T needed to capture and report test output.
+// Output is used rather than Log so that captured lines are not stamped with
+// the source location of this package.
 type Logger interface {
 	Log(args ...any)
 	Name() string
 	Cleanup(func())
 	Failed() bool
+	Output() io.Writer
 }
 
-// stdwriter is an io.WriteCloser that writes to the test logger. It buffers
-// writes until a newline is encountered, at which point it flushes the buffer
-// to the test logger.
+// WriteCloser captures the output of a single process. Name reports the label
+// the output is reported under, which may differ from the requested name when
+// several instances of the same process take part in a test.
+type WriteCloser interface {
+	io.WriteCloser
+	Name() string
+}
+
+// stdwriter is an io.WriteCloser which captures process output into the
+// collector for a test. Output is buffered and only reported if the test
+// fails, or if DAPR_INTEGRATION_LOGS asks for it unconditionally.
 type stdwriter struct {
-	t        Logger
-	procName string
-	buf      bytes.Buffer
-	lock     sync.Mutex
+	c *collector
+	b *block
+
+	lock sync.Mutex
+	buf  bytes.Buffer
 }
 
-func New(t Logger, procName string) io.WriteCloser {
-	s := &stdwriter{
-		t:        t,
-		procName: procName,
-	}
+// New returns a writer which captures the output of procName for t. Calling it
+// more than once with the same name for the same test appends an index to the
+// name, so that multiple instances of a process stay distinguishable.
+func New(t Logger, procName string) WriteCloser {
+	c := collectorFor(t)
+	w := &stdwriter{c: c, b: c.newBlock(procName)}
+	c.addWriter(w)
 
-	t.Cleanup(s.flush)
-
-	return s
+	return w
 }
 
-// Write writes the input bytes to the buffer. If the input contains a newline,
-// the buffer is flushed to the test logger.
-func (w *stdwriter) Write(inp []byte) (n int, err error) {
+// Name returns the label this writer's output is reported under.
+func (w *stdwriter) Name() string {
+	return w.b.name
+}
+
+// Eventf records something the framework did, as opposed to something a process
+// printed. Events share the report of the process output they interleave with,
+// and like it are only shown when the test fails.
+func Eventf(t Logger, format string, args ...any) {
+	c := collectorFor(t)
+	c.events.append(c.since(), fmt.Sprintf(format, args...))
+}
+
+// Notef records a message shown at the top of the report. Reserve it for
+// conditions which explain an entire failure, such as a blown deadline.
+func Notef(t Logger, format string, args ...any) {
+	collectorFor(t).note(fmt.Sprintf(format, args...))
+}
+
+// Write captures the input, timestamping each complete line as it arrives.
+func (w *stdwriter) Write(inp []byte) (int, error) {
 	w.lock.Lock()
 	defer w.lock.Unlock()
-	return w.buf.Write(inp)
+
+	n, err := w.buf.Write(inp)
+	w.drain(false)
+
+	return n, err
 }
 
-// Close is a no-op.
+// Close captures any trailing line which was not newline terminated. It is
+// safe to call more than once.
 func (w *stdwriter) Close() error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+	w.drain(true)
+
 	return nil
 }
 
-// flush writes the buffer to the test logger. Expects the lock to be held
-// before calling.
-func (w *stdwriter) flush() {
-	w.lock.Lock()
-	defer w.lock.Unlock()
-	defer w.buf.Reset()
-
-	// Don't log if the test hasn't failed and the user hasn't requested logs to
-	// always be printed.
-	if !w.t.Failed() &&
-		!kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_LOGS")) {
-		return
-	}
+// drain moves whole lines from the buffer into the block. When final is set,
+// a trailing line without a newline is moved too.
+func (w *stdwriter) drain(final bool) {
+	at := w.c.since()
 
 	for {
-		line, err := w.buf.ReadBytes('\n')
-		if len(line) > 0 {
-			w.t.Log(w.t.Name() + "/" + w.procName + ": " +
-				strings.TrimSuffix(string(line), "\n"))
-		}
-		if err != nil {
-			if !errors.Is(err, io.EOF) {
-				w.t.Log(w.t.Name() + "/" + w.procName + ": " + err.Error())
-			}
+		i := bytes.IndexByte(w.buf.Bytes(), '\n')
+		if i < 0 {
 			break
 		}
+		text := string(w.buf.Next(i + 1)[:i])
+		w.b.append(at, strings.TrimSuffix(text, "\r"))
+	}
+
+	if final && w.buf.Len() > 0 {
+		w.b.append(at, strings.TrimSuffix(w.buf.String(), "\r"))
+		w.buf.Reset()
 	}
 }

--- a/tests/integration/framework/iowriter/iowriter.go
+++ b/tests/integration/framework/iowriter/iowriter.go
@@ -38,6 +38,10 @@ type Logger interface {
 type WriteCloser interface {
 	io.WriteCloser
 	Name() string
+
+	// Stream returns a second writer reporting under the same name, for another
+	// stream of the same process.
+	Stream() WriteCloser
 }
 
 // stdwriter is an io.WriteCloser which captures process output into the
@@ -65,6 +69,19 @@ func New(t Logger, procName string) WriteCloser {
 // Name returns the label this writer's output is reported under.
 func (w *stdwriter) Name() string {
 	return w.b.name
+}
+
+// Stream returns a second writer feeding the same block, with a line buffer of
+// its own.
+//
+// A process' stdout and stderr must not share one buffer. Closing either would
+// flush a partial line the other was still writing, and a read from one can be
+// concatenated onto an unterminated line from the other.
+func (w *stdwriter) Stream() WriteCloser {
+	s := &stdwriter{c: w.c, b: w.b}
+	w.c.addWriter(s)
+
+	return s
 }
 
 // Eventf records something the framework did, as opposed to something a process

--- a/tests/integration/framework/iowriter/iowriter_test.go
+++ b/tests/integration/framework/iowriter/iowriter_test.go
@@ -17,17 +17,44 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	stdlog "log"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/kit/logger"
 )
 
+func init() {
+	// Keep expectations stable regardless of the terminal the tests run in.
+	useColor = false
+	useUnicode = false
+}
+
+func TestMain(m *testing.M) {
+	// Keep these tests out of the directory a real suite run writes to.
+	dir, err := os.MkdirTemp("", "iowriter-test")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	os.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
+
+	m.Run()
+}
+
 type mockLogger struct {
-	msgs   []string
-	failed bool
 	t      *testing.T
+	name   string
+	failed bool
+	out    bytes.Buffer
+	msgs   []string
 }
 
 func (m *mockLogger) Log(args ...any) {
@@ -35,6 +62,9 @@ func (m *mockLogger) Log(args ...any) {
 }
 
 func (m *mockLogger) Name() string {
+	if m.name != "" {
+		return m.name
+	}
 	return "TestLogger"
 }
 
@@ -46,6 +76,34 @@ func (m *mockLogger) Failed() bool {
 	return m.failed
 }
 
+func (m *mockLogger) Output() io.Writer {
+	return &m.out
+}
+
+// report runs fn as a subtest and returns the report it produced, following the
+// pointer line to the log file when one was written.
+func report(t *testing.T, logger *mockLogger, fn func()) string {
+	t.Helper()
+
+	t.Setenv("DAPR_INTEGRATION_LOGS_DIR", t.TempDir())
+
+	t.Run("test", func(t *testing.T) {
+		logger.t = t
+		fn()
+	})
+
+	out := logger.out.String()
+	path, ok := strings.CutPrefix(strings.TrimSpace(out), "logs: ")
+	if !ok {
+		return out
+	}
+
+	b, err := os.ReadFile(path)
+	require.NoError(t, err)
+
+	return string(b)
+}
+
 func TestNew(t *testing.T) {
 	t.Run("should return new stdwriter", func(t *testing.T) {
 		writer := New(&mockLogger{t: t}, "proc")
@@ -53,90 +111,231 @@ func TestNew(t *testing.T) {
 		assert.True(t, ok)
 	})
 
-	var buf bytes.Buffer
-	logger := &mockLogger{failed: true}
-	t.Run("should flush on Cleanup (failed)", func(t *testing.T) {
-		logger.t = t
-		writer := New(logger, "proc").(*stdwriter)
-		writer.buf = buf
-		writer.Write([]byte("test"))
-		assert.Equal(t, "test", writer.buf.String())
-	})
-	_ = assert.Len(t, logger.msgs, 1) &&
-		assert.Equal(t, "TestLogger/proc: test", logger.msgs[0])
-	assert.Empty(t, buf.Len())
+	t.Run("should report captured lines on failure", func(t *testing.T) {
+		logger := &mockLogger{failed: true}
+		out := report(t, logger, func() {
+			fmt.Fprint(New(logger, "proc"), "hello\nworld\n")
+		})
 
-	buf = bytes.Buffer{}
-	logger = &mockLogger{failed: false}
-	t.Run("should flush on Cleanup (env)", func(t *testing.T) {
-		t.Setenv("DAPR_INTEGRATION_LOGS", "true")
-		logger.t = t
-		writer := New(logger, "proc").(*stdwriter)
-		writer.buf = buf
-		writer.Write([]byte("test"))
-		assert.Equal(t, "test", writer.buf.String())
+		assert.Contains(t, out, "-- proc --")
+		assert.Contains(t, out, "hello")
+		assert.Contains(t, out, "world")
+		assert.Contains(t, out, "FAIL")
 	})
-	_ = assert.Len(t, logger.msgs, 1) &&
-		assert.Equal(t, "TestLogger/proc: test", logger.msgs[0])
-	assert.Empty(t, buf.Len())
 
-	buf = bytes.Buffer{}
-	logger = &mockLogger{failed: false}
-	t.Run("should not flush on Cleanup by default", func(t *testing.T) {
-		logger.t = t
-		writer := New(logger, "proc").(*stdwriter)
-		writer.buf = buf
-		writer.Write([]byte("test"))
-		assert.Equal(t, "test", writer.buf.String())
+	t.Run("should point at the log file rather than inline the report", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
+
+		logger := &mockLogger{failed: true, name: "Test_Integration/ports/Ports"}
+		t.Run("test", func(t *testing.T) {
+			logger.t = t
+			fmt.Fprint(New(logger, "proc"), "hello\n")
+		})
+
+		want := filepath.Join(dir, "ports.Ports.log")
+		assert.Equal(t, "logs: "+want+"\n", logger.out.String())
+		assert.FileExists(t, want)
 	})
-	assert.Empty(t, logger.msgs)
-	assert.Empty(t, buf.Len())
+
+	t.Run("should inline the report when asked", func(t *testing.T) {
+		logger := &mockLogger{failed: true, name: "Test_Integration/inlined/case"}
+		t.Run("test", func(t *testing.T) {
+			t.Setenv("DAPR_INTEGRATION_LOGS_INLINE", "true")
+			logger.t = t
+			fmt.Fprint(New(logger, "proc"), "hello\n")
+		})
+
+		assert.Contains(t, logger.out.String(), "-- proc --")
+		assert.Contains(t, logger.out.String(), "hello")
+
+		// Still listed in the end of run summary, just without a file to read.
+		assert.Contains(t, Failures(), Failure{Test: "inlined/case", Path: ""})
+	})
+
+	t.Run("should report captured lines when always logging", func(t *testing.T) {
+		logger := &mockLogger{}
+		out := report(t, logger, func() {
+			t.Setenv("DAPR_INTEGRATION_LOGS", "true")
+			fmt.Fprint(New(logger, "proc"), "hello\n")
+		})
+
+		assert.Contains(t, out, "hello")
+		assert.Contains(t, out, "PASS")
+	})
+
+	t.Run("should report nothing by default", func(t *testing.T) {
+		logger := &mockLogger{}
+		t.Run("test", func(t *testing.T) {
+			logger.t = t
+			fmt.Fprint(New(logger, "proc"), "hello\n")
+		})
+
+		assert.Empty(t, logger.out.String())
+		assert.Empty(t, logger.msgs)
+	})
+
+	t.Run("should index repeated process names", func(t *testing.T) {
+		logger := &mockLogger{failed: true}
+		out := report(t, logger, func() {
+			for i := range 3 {
+				fmt.Fprintf(New(logger, "daprd"), "line %d\n", i)
+			}
+		})
+
+		assert.Contains(t, out, "-- daprd --")
+		assert.Contains(t, out, "-- daprd-1 --")
+		assert.Contains(t, out, "-- daprd-2 --")
+	})
+
+	t.Run("should share one report between processes and events", func(t *testing.T) {
+		logger := &mockLogger{failed: true}
+		out := report(t, logger, func() {
+			Eventf(logger, "starting %d processes", 2)
+			Notef(logger, "context deadline exceeded")
+			fmt.Fprint(New(logger, "daprd"), "from daprd\n")
+		})
+
+		assert.Equal(t, 1, strings.Count(out, "logs:"), out)
+		assert.Contains(t, out, "-- framework --")
+		assert.Contains(t, out, "starting 2 processes")
+		assert.Contains(t, out, "context deadline exceeded")
+		assert.Contains(t, out, "from daprd")
+	})
+
+	t.Run("should strip the suite prefix from the report name", func(t *testing.T) {
+		logger := &mockLogger{failed: true, name: "Test_Integration/ports/Ports"}
+		assert.Contains(t, report(t, logger, func() {
+			fmt.Fprint(New(logger, "proc"), "hi\n")
+		}), "logs: ports/Ports ")
+	})
+
+	t.Run("should record failures with their log path", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
+
+		logger := &mockLogger{failed: true, name: "Test_Integration/actors/call/non200"}
+		t.Run("test", func(t *testing.T) {
+			logger.t = t
+			fmt.Fprint(New(logger, "proc"), "boom\n")
+		})
+
+		assert.Contains(t, Failures(), Failure{
+			Test: "actors/call/non200",
+			Path: filepath.Join(dir, "actors.call.non200.log"),
+		})
+	})
+
+	t.Run("should not record a passing test as a failure", func(t *testing.T) {
+		logger := &mockLogger{name: "Test_Integration/passing/case"}
+		report(t, logger, func() {
+			t.Setenv("DAPR_INTEGRATION_LOGS", "true")
+			fmt.Fprint(New(logger, "proc"), "fine\n")
+		})
+
+		for _, f := range Failures() {
+			assert.NotEqual(t, "passing/case", f.Test)
+		}
+	})
+}
+
+func TestInline(t *testing.T) {
+	t.Run("should write files by default", func(t *testing.T) {
+		t.Setenv("GITHUB_ACTIONS", "")
+		assert.False(t, inline())
+	})
+
+	t.Run("should inline on GitHub Actions, where output is grouped", func(t *testing.T) {
+		t.Setenv("GITHUB_ACTIONS", "true")
+		assert.True(t, inline())
+	})
+
+	t.Run("should let the env var win either way", func(t *testing.T) {
+		t.Setenv("GITHUB_ACTIONS", "true")
+		t.Setenv("DAPR_INTEGRATION_LOGS_INLINE", "false")
+		assert.False(t, inline())
+
+		t.Setenv("GITHUB_ACTIONS", "")
+		t.Setenv("DAPR_INTEGRATION_LOGS_INLINE", "true")
+		assert.True(t, inline())
+	})
+}
+
+func TestStripANSI(t *testing.T) {
+	tests := map[string]string{
+		"":                          "",
+		"plain":                     "plain",
+		"\x1b[31mred\x1b[0m":        "red",
+		"\x1b[2m\x1b[1mboth\x1b[0m": "both",
+		"a\x1b[33mb\x1b[0mc":        "abc",
+	}
+
+	for in, exp := range tests {
+		assert.Equal(t, exp, stripANSI(in), in)
+	}
+}
+
+func TestLogFileName(t *testing.T) {
+	tests := map[string]string{
+		"ports/Ports":         "ports.Ports.log",
+		"actors/call/non200":  "actors.call.non200.log",
+		"a b/c":               "a.b.c.log",
+		"weird:name*with?bad": "weird.name.with.bad.log",
+	}
+
+	for in, exp := range tests {
+		assert.Equal(t, exp, logFileName(in), in)
+	}
 }
 
 func TestWrite(t *testing.T) {
-	t.Run("should write to buffer", func(t *testing.T) {
+	t.Run("should buffer until a newline arrives", func(t *testing.T) {
 		logger := &mockLogger{t: t, failed: true}
 		writer := New(logger, "proc").(*stdwriter)
 
-		_, err := writer.Write([]byte("test"))
+		_, err := writer.Write([]byte("par"))
 		require.NoError(t, err)
-		assert.Equal(t, "test", writer.buf.String())
+		assert.Empty(t, writer.b.lines)
+
+		_, err = writer.Write([]byte("tial\n"))
+		require.NoError(t, err)
+		require.Len(t, writer.b.lines, 1)
+		assert.Equal(t, "partial", writer.b.lines[0].text)
 	})
 
-	t.Run("should not flush on newline or on close", func(t *testing.T) {
+	t.Run("should capture a trailing line on close", func(t *testing.T) {
 		logger := &mockLogger{t: t, failed: true}
 		writer := New(logger, "proc").(*stdwriter)
 
-		_, err := writer.Write([]byte("test\n"))
+		_, err := writer.Write([]byte("no newline"))
 		require.NoError(t, err)
-
-		assert.Equal(t, 5, writer.buf.Len())
-
-		assert.Empty(t, logger.msgs)
+		assert.Empty(t, writer.b.lines)
 
 		require.NoError(t, writer.Close())
-
-		assert.Equal(t, 5, writer.buf.Len())
+		require.Len(t, writer.b.lines, 1)
+		assert.Equal(t, "no newline", writer.b.lines[0].text)
 	})
 
-	t.Run("should not return error on write when closed", func(t *testing.T) {
-		writer := New(&mockLogger{t: t}, "proc").(*stdwriter)
-		require.NoError(t, writer.Close())
-
-		_, err := writer.Write([]byte("test\n"))
-		require.NotErrorIs(t, err, io.ErrClosedPipe)
-		assert.Equal(t, "test\n", writer.buf.String())
-	})
-}
-
-func TestClose(t *testing.T) {
-	t.Run("should be a noop", func(t *testing.T) {
+	t.Run("should be idempotent on close", func(t *testing.T) {
 		logger := &mockLogger{t: t, failed: true}
 		writer := New(logger, "proc").(*stdwriter)
-		writer.Write([]byte("test"))
-		writer.Close()
 
-		assert.Equal(t, 4, writer.buf.Len())
+		_, err := writer.Write([]byte("line"))
+		require.NoError(t, err)
+		require.NoError(t, writer.Close())
+		require.NoError(t, writer.Close())
+
+		assert.Len(t, writer.b.lines, 1)
+	})
+
+	t.Run("should strip carriage returns", func(t *testing.T) {
+		logger := &mockLogger{t: t, failed: true}
+		writer := New(logger, "proc").(*stdwriter)
+
+		_, err := writer.Write([]byte("windows\r\n"))
+		require.NoError(t, err)
+		require.Len(t, writer.b.lines, 1)
+		assert.Equal(t, "windows", writer.b.lines[0].text)
 	})
 }
 
@@ -144,33 +343,87 @@ func TestConcurrency(t *testing.T) {
 	t.Run("should handle concurrent writes", func(t *testing.T) {
 		logger := &mockLogger{t: t, failed: true}
 		writer := New(logger, "proc").(*stdwriter)
-		wg := sync.WaitGroup{}
+
+		var wg sync.WaitGroup
 		wg.Add(2)
-
-		go func() {
-			defer wg.Done()
-			for i := range 1000 {
-				fmt.Fprintf(writer, "test %d\n", i)
-			}
-		}()
-
-		go func() {
-			defer wg.Done()
-			for i := range 1000 {
-				fmt.Fprintf(writer, "test %d\n", i)
-			}
-		}()
-
+		for range 2 {
+			go func() {
+				defer wg.Done()
+				for i := range 1000 {
+					fmt.Fprintf(writer, "test %d\n", i)
+				}
+			}()
+		}
 		wg.Wait()
 
 		require.NoError(t, writer.Close())
-
-		writer.flush()
-		assert.Equal(t, 0, writer.buf.Len())
-		assert.Len(t, logger.msgs, 2000)
-
-		for _, msg := range logger.msgs {
-			assert.Contains(t, msg, "TestLogger/proc: test ")
+		assert.Len(t, writer.b.lines, 2000)
+		for _, l := range writer.b.lines {
+			assert.Contains(t, l.text, "test ")
 		}
+	})
+
+	t.Run("should handle concurrent process registration", func(t *testing.T) {
+		logger := &mockLogger{t: t, failed: false}
+
+		var wg sync.WaitGroup
+		wg.Add(10)
+		for range 10 {
+			go func() {
+				defer wg.Done()
+				fmt.Fprint(New(logger, "daprd"), "line\n")
+			}()
+		}
+		wg.Wait()
+
+		c := collectorFor(logger)
+		assert.Len(t, c.blocks, 10)
+		assert.Equal(t, 10, c.names["daprd"])
+	})
+}
+
+func TestRedirectInProcessLogs(t *testing.T) {
+	t.Run("should send package logs to a file", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
+
+		// Registered before the redirect, the way a package level logger such as
+		// the one in pkg/security is registered at init.
+		log := logger.NewLogger("test.inprocess.scope")
+
+		path, err := RedirectInProcessLogs()
+		require.NoError(t, err)
+		assert.Equal(t, filepath.Join(dir, inProcessLog), path)
+
+		log.Info("not for the terminal")
+
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "not for the terminal")
+	})
+
+	t.Run("should send standard library logs to the same file", func(t *testing.T) {
+		dir := t.TempDir()
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
+
+		path, err := RedirectInProcessLogs()
+		require.NoError(t, err)
+
+		// net/http reports things like TLS handshake errors through this logger
+		// whenever a server has no ErrorLog of its own.
+		stdlog.Printf("http: TLS handshake error from 127.0.0.1:41900")
+
+		b, err := os.ReadFile(path)
+		require.NoError(t, err)
+		assert.Contains(t, string(b), "TLS handshake error")
+	})
+
+	t.Run("should leave logs alone when asked", func(t *testing.T) {
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", t.TempDir())
+		t.Setenv("DAPR_INTEGRATION_INPROCESS_LOGS", "true")
+
+		path, err := RedirectInProcessLogs()
+		require.NoError(t, err)
+		assert.Empty(t, path)
 	})
 }

--- a/tests/integration/framework/iowriter/iowriter_test.go
+++ b/tests/integration/framework/iowriter/iowriter_test.go
@@ -397,8 +397,9 @@ func TestRedirectInProcessLogs(t *testing.T) {
 		// the one in pkg/security is registered at init.
 		log := logger.NewLogger("test.inprocess.scope")
 
-		path, err := RedirectInProcessLogs()
+		path, restore, err := RedirectInProcessLogs()
 		require.NoError(t, err)
+		t.Cleanup(restore)
 		assert.Equal(t, filepath.Join(dir, inProcessLog), path)
 
 		log.Info("not for the terminal")
@@ -412,8 +413,9 @@ func TestRedirectInProcessLogs(t *testing.T) {
 		dir := t.TempDir()
 		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
 
-		path, err := RedirectInProcessLogs()
+		path, restore, err := RedirectInProcessLogs()
 		require.NoError(t, err)
+		t.Cleanup(restore)
 
 		// net/http reports things like TLS handshake errors through this logger
 		// whenever a server has no ErrorLog of its own.
@@ -424,12 +426,31 @@ func TestRedirectInProcessLogs(t *testing.T) {
 		assert.Contains(t, string(b), "TLS handshake error")
 	})
 
+	t.Run("should release the file so it can be deleted", func(t *testing.T) {
+		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", t.TempDir())
+
+		path, restore, err := RedirectInProcessLogs()
+		require.NoError(t, err)
+
+		stdlog.Printf("something")
+		restore()
+
+		// Windows refuses to delete a file which is still open, which is what
+		// broke t.TempDir cleanup before restore existed.
+		require.NoError(t, os.Remove(path))
+
+		// Restoring must also stop further output reaching the deleted file.
+		stdlog.Printf("after restore")
+		assert.NoFileExists(t, path)
+	})
+
 	t.Run("should leave logs alone when asked", func(t *testing.T) {
 		t.Setenv("DAPR_INTEGRATION_LOGS_DIR", t.TempDir())
 		t.Setenv("DAPR_INTEGRATION_INPROCESS_LOGS", "true")
 
-		path, err := RedirectInProcessLogs()
+		path, restore, err := RedirectInProcessLogs()
 		require.NoError(t, err)
+		t.Cleanup(restore)
 		assert.Empty(t, path)
 	})
 }

--- a/tests/integration/framework/iowriter/iowriter_test.go
+++ b/tests/integration/framework/iowriter/iowriter_test.go
@@ -427,3 +427,44 @@ func TestRedirectInProcessLogs(t *testing.T) {
 		assert.Empty(t, path)
 	})
 }
+
+func TestStream(t *testing.T) {
+	t.Run("should report under the same name", func(t *testing.T) {
+		logger := &mockLogger{t: t, failed: true}
+		out := New(logger, "daprd")
+		assert.Equal(t, out.Name(), out.Stream().Name())
+	})
+
+	t.Run("should not let one stream flush the other's partial line", func(t *testing.T) {
+		logger := &mockLogger{failed: true}
+		out := report(t, logger, func() {
+			stdout := New(logger, "daprd")
+			stderr := stdout.Stream()
+
+			// stderr is mid-line when stdout reaches EOF and closes.
+			fmt.Fprint(stderr, "partial stderr line")
+			require.NoError(t, stdout.Close())
+			fmt.Fprint(stderr, " completed\n")
+			require.NoError(t, stderr.Close())
+		})
+
+		assert.Contains(t, out, "partial stderr line completed")
+	})
+
+	t.Run("should not concatenate the two streams into one line", func(t *testing.T) {
+		logger := &mockLogger{failed: true}
+		out := report(t, logger, func() {
+			stdout := New(logger, "daprd")
+			stderr := stdout.Stream()
+
+			fmt.Fprint(stdout, "from stdout")
+			fmt.Fprint(stderr, "from stderr")
+			require.NoError(t, stdout.Close())
+			require.NoError(t, stderr.Close())
+		})
+
+		assert.NotContains(t, out, "from stdoutfrom stderr")
+		assert.Contains(t, out, "from stdout")
+		assert.Contains(t, out, "from stderr")
+	})
+}

--- a/tests/integration/framework/iowriter/iowriter_test.go
+++ b/tests/integration/framework/iowriter/iowriter_test.go
@@ -46,6 +46,12 @@ func TestMain(m *testing.M) {
 
 	os.Setenv("DAPR_INTEGRATION_LOGS_DIR", dir)
 
+	// These tests are about what the package does, not about where they happen
+	// to be running. CI sets GITHUB_ACTIONS, which switches reports to inline,
+	// so leaving it set would make the suite pass locally and fail on CI. Tests
+	// which care about that behaviour set it themselves.
+	os.Unsetenv("GITHUB_ACTIONS")
+
 	m.Run()
 }
 

--- a/tests/integration/framework/iowriter/logger/logger.go
+++ b/tests/integration/framework/iowriter/logger/logger.go
@@ -22,7 +22,7 @@ import (
 
 func New(t *testing.T) logger.Logger {
 	log := logger.NewLogger(t.Name())
-	log.SetOutput(iowriter.New(t, t.Name()))
+	log.SetOutput(iowriter.New(t, "logger"))
 	log.SetOutputLevel(logger.DebugLevel)
 	return log
 }

--- a/tests/integration/framework/iowriter/render.go
+++ b/tests/integration/framework/iowriter/render.go
@@ -1,0 +1,241 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iowriter
+
+import (
+	"os"
+	"strconv"
+	"strings"
+
+	kitstrings "github.com/dapr/kit/strings"
+)
+
+// Field names emitted by dapr/kit/logger. `time` is replaced by the offset the
+// line was captured at, the rest carry no information worth a column.
+var droppedFields = map[string]bool{
+	"time":     true,
+	"instance": true,
+	"type":     true,
+	"ver":      true,
+}
+
+// hoistedFields are lifted into the block header when every parsed line in the
+// block agrees on their value, rather than repeated on each line.
+var hoistedFields = map[string]bool{
+	"app_id": true,
+}
+
+var rawLogs = kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_LOGS_RAW"))
+
+type kv struct {
+	key string
+	val string
+}
+
+// entry is a parsed dapr log line. Lines which are not dapr log lines (panics,
+// stack traces, etcd output, `go build` package lists) have ok false and are
+// rendered verbatim.
+type entry struct {
+	level  string
+	scope  string
+	msg    string
+	hoist  []kv
+	extra  []kv
+	raw    string
+	parsed bool
+}
+
+// parseEntry best-effort parses a logfmt line as written by the logrus text
+// formatter. A line only counts as a dapr log line if it carries both a level
+// and a message.
+func parseEntry(raw string) entry {
+	e := entry{raw: raw}
+	if rawLogs {
+		return e
+	}
+
+	pairs, ok := parseLogfmt(raw)
+	if !ok {
+		return e
+	}
+
+	var haveLevel, haveMsg bool
+	for _, p := range pairs {
+		switch {
+		case p.key == "level":
+			e.level, haveLevel = p.val, true
+		case p.key == "msg":
+			e.msg, haveMsg = p.val, true
+		case p.key == "scope":
+			e.scope = p.val
+		case droppedFields[p.key]:
+		case hoistedFields[p.key]:
+			e.hoist = append(e.hoist, p)
+		default:
+			e.extra = append(e.extra, p)
+		}
+	}
+
+	if !haveLevel || !haveMsg {
+		return entry{raw: raw}
+	}
+
+	e.parsed = true
+	return e
+}
+
+// parseLogfmt scans `key=value` pairs, honouring double quoted values. It
+// returns false the moment the input stops looking like logfmt, so that
+// arbitrary process output is never mangled.
+func parseLogfmt(s string) ([]kv, bool) {
+	var pairs []kv
+
+	for i := 0; i < len(s); {
+		for i < len(s) && s[i] == ' ' {
+			i++
+		}
+		if i >= len(s) {
+			break
+		}
+
+		start := i
+		for i < len(s) && s[i] != '=' && s[i] != ' ' {
+			i++
+		}
+		if i >= len(s) || s[i] != '=' {
+			return nil, false
+		}
+		key := s[start:i]
+		if !validKey(key) {
+			return nil, false
+		}
+		i++
+
+		var val string
+		if i < len(s) && s[i] == '"' {
+			j := i + 1
+			for j < len(s) && s[j] != '"' {
+				if s[j] == '\\' {
+					j++
+				}
+				j++
+			}
+			if j >= len(s) {
+				return nil, false
+			}
+			unquoted, err := strconv.Unquote(s[i : j+1])
+			if err != nil {
+				return nil, false
+			}
+			val, i = unquoted, j+1
+		} else {
+			start = i
+			for i < len(s) && s[i] != ' ' {
+				i++
+			}
+			val = s[start:i]
+		}
+
+		pairs = append(pairs, kv{key: key, val: val})
+	}
+
+	return pairs, len(pairs) > 0
+}
+
+func validKey(key string) bool {
+	if len(key) == 0 {
+		return false
+	}
+	for _, r := range key {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '_', r == '-', r == '.':
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+const (
+	// levelWidth is the width of the level column, sized for the longest level
+	// name dapr emits.
+	levelWidth = 5
+
+	// maxScopeWidth caps the scope column so that one unusually deep scope
+	// cannot push every message in the block off to the right. Scopes longer
+	// than this overflow their column rather than widening it.
+	maxScopeWidth = 26
+)
+
+// normalLevel upper cases the level and shortens the only name logrus emits
+// which does not fit the level column.
+func normalLevel(level string) string {
+	if strings.EqualFold(level, "warning") {
+		return "WARN"
+	}
+	return strings.ToUpper(level)
+}
+
+func levelColor(level string) string {
+	switch strings.ToLower(level) {
+	case "fatal", "panic", "error":
+		return ansiRed
+	case "warn", "warning":
+		return ansiYellow
+	case "debug", "trace":
+		return ansiDim
+	default:
+		return ansiCyan
+	}
+}
+
+// format renders the entry, aligning the scope column to scopeWidth. Unparsed
+// lines are indented to the same column so they stay visually attached to the
+// surrounding log.
+func (e entry) format(scopeWidth int) string {
+	if !e.parsed {
+		return e.raw
+	}
+
+	var sb strings.Builder
+	sb.WriteString(colorize(pad(normalLevel(e.level), levelWidth), levelColor(e.level)))
+	sb.WriteString("  ")
+	if scopeWidth > 0 {
+		sb.WriteString(colorize(pad(e.scope, scopeWidth), ansiBlue))
+		sb.WriteString("  ")
+	}
+	sb.WriteString(e.msg)
+
+	for _, p := range e.extra {
+		sb.WriteString(" ")
+		sb.WriteString(colorize(p.key+"="+quoteIfNeeded(p.val), ansiDim))
+	}
+
+	return sb.String()
+}
+
+func quoteIfNeeded(val string) string {
+	if strings.ContainsAny(val, " \t\"") {
+		return strconv.Quote(val)
+	}
+	return val
+}
+
+func pad(s string, width int) string {
+	if len(s) >= width {
+		return s
+	}
+	return s + strings.Repeat(" ", width-len(s))
+}

--- a/tests/integration/framework/iowriter/render_test.go
+++ b/tests/integration/framework/iowriter/render_test.go
@@ -1,0 +1,216 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iowriter
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestParseLogfmt(t *testing.T) {
+	tests := map[string]struct {
+		in    string
+		exp   []kv
+		expOK bool
+	}{
+		"empty": {
+			in: "", expOK: false,
+		},
+		"bare words": {
+			in: "panic: runtime error", expOK: false,
+		},
+		"stack trace": {
+			in: "\tgithub.com/dapr/dapr/pkg/runtime.(*Runtime).Run(0x1234)", expOK: false,
+		},
+		"unquoted pairs": {
+			in:    "level=info scope=dapr.runtime",
+			exp:   []kv{{"level", "info"}, {"scope", "dapr.runtime"}},
+			expOK: true,
+		},
+		"quoted value with spaces": {
+			in:    `level=info msg="dapr initialized. Status: Running"`,
+			exp:   []kv{{"level", "info"}, {"msg", "dapr initialized. Status: Running"}},
+			expOK: true,
+		},
+		"escaped quote in value": {
+			in:    `msg="he said \"hi\"" level=warning`,
+			exp:   []kv{{"msg", `he said "hi"`}, {"level", "warning"}},
+			expOK: true,
+		},
+		"empty value": {
+			in:    "app_id= level=info",
+			exp:   []kv{{"app_id", ""}, {"level", "info"}},
+			expOK: true,
+		},
+		"unterminated quote": {
+			in: `msg="never closed`, expOK: false,
+		},
+		"missing equals": {
+			in: "level=info orphan", expOK: false,
+		},
+		"invalid key": {
+			in: "not a key=value", expOK: false,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, ok := parseLogfmt(test.in)
+			assert.Equal(t, test.expOK, ok)
+			if test.expOK {
+				assert.Equal(t, test.exp, got)
+			}
+		})
+	}
+}
+
+func TestParseEntry(t *testing.T) {
+	const daprLine = `time="2026-08-13T12:00:00.123456789Z" level=info ` +
+		`msg="dapr initialized. Status: Running" app_id=myapp instance=host ` +
+		`scope=dapr.runtime type=log ver=edge`
+
+	t.Run("should parse a dapr log line", func(t *testing.T) {
+		e := parseEntry(daprLine)
+		assert.True(t, e.parsed)
+		assert.Equal(t, "info", e.level)
+		assert.Equal(t, "dapr.runtime", e.scope)
+		assert.Equal(t, "dapr initialized. Status: Running", e.msg)
+		assert.Equal(t, []kv{{"app_id", "myapp"}}, e.hoist)
+		assert.Empty(t, e.extra)
+	})
+
+	t.Run("should keep unrecognised fields", func(t *testing.T) {
+		e := parseEntry(`level=error msg=boom component=statestore attempt=3`)
+		assert.True(t, e.parsed)
+		assert.Equal(t, []kv{{"component", "statestore"}, {"attempt", "3"}}, e.extra)
+	})
+
+	t.Run("should not parse without a level and message", func(t *testing.T) {
+		for _, line := range []string{
+			`level=info scope=dapr.runtime`,
+			`msg="no level here"`,
+			`{"level":"info","msg":"json not logfmt"}`,
+			`panic: close of closed channel`,
+		} {
+			e := parseEntry(line)
+			assert.False(t, e.parsed, line)
+			assert.Equal(t, line, e.raw)
+		}
+	})
+
+	t.Run("should not parse when raw logs are requested", func(t *testing.T) {
+		rawLogs = true
+		t.Cleanup(func() { rawLogs = false })
+
+		e := parseEntry(daprLine)
+		assert.False(t, e.parsed)
+		assert.Equal(t, daprLine, e.raw)
+	})
+}
+
+func TestEntryFormat(t *testing.T) {
+	t.Run("should render level, scope and message", func(t *testing.T) {
+		e := parseEntry(`level=info msg="all good" scope=dapr.runtime`)
+		assert.Equal(t, "INFO   dapr.runtime  all good", e.format(len("dapr.runtime")))
+	})
+
+	t.Run("should align scopes across a block", func(t *testing.T) {
+		short := parseEntry(`level=error msg=boom scope=dapr.api`)
+		assert.Equal(t, "ERROR  dapr.api      boom", short.format(len("dapr.runtime")))
+	})
+
+	t.Run("should append extra fields", func(t *testing.T) {
+		e := parseEntry(`level=warning msg=slow scope=dapr.api took="1.5 s"`)
+		assert.Equal(t, `WARN   dapr.api  slow took="1.5 s"`, e.format(len("dapr.api")))
+	})
+
+	t.Run("should pass unparsed lines through verbatim", func(t *testing.T) {
+		const raw = "goroutine 1 [running]:"
+		assert.Equal(t, raw, parseEntry(raw).format(12))
+	})
+}
+
+func TestBlockHeader(t *testing.T) {
+	newBlockWith := func(t *testing.T, lines ...string) (*block, []entry) {
+		t.Helper()
+		b := &block{name: "daprd"}
+		entries := make([]entry, len(lines))
+		for i, l := range lines {
+			entries[i] = parseEntry(l)
+		}
+		return b, entries
+	}
+
+	t.Run("should hoist a field constant across the block", func(t *testing.T) {
+		b, entries := newBlockWith(t,
+			`level=info msg=one app_id=myapp`,
+			`level=info msg=two app_id=myapp`,
+		)
+		header, lifted := b.header(entries)
+		assert.Equal(t, "-- daprd app_id=myapp --\n", header)
+		assert.True(t, lifted["app_id"])
+	})
+
+	t.Run("should not hoist a field which varies", func(t *testing.T) {
+		b, entries := newBlockWith(t,
+			`level=info msg=one app_id=a`,
+			`level=info msg=two app_id=b`,
+		)
+		header, lifted := b.header(entries)
+		assert.Equal(t, "-- daprd --\n", header)
+		assert.False(t, lifted["app_id"])
+	})
+
+	t.Run("should not hoist a field missing from some lines", func(t *testing.T) {
+		b, entries := newBlockWith(t,
+			`level=info msg=one app_id=a`,
+			`level=info msg=two`,
+		)
+		header, lifted := b.header(entries)
+		assert.Equal(t, "-- daprd --\n", header)
+		assert.False(t, lifted["app_id"])
+	})
+}
+
+func TestBlockRender(t *testing.T) {
+	t.Run("should keep unhoisted fields on their line", func(t *testing.T) {
+		c := &collector{}
+		b := &block{c: c, name: "daprd"}
+		b.append(0, `level=info msg=one app_id=a`)
+		b.append(0, `level=info msg=two app_id=b`)
+
+		var sb strings.Builder
+		b.render(&sb)
+
+		out := sb.String()
+		assert.Contains(t, out, "app_id=a")
+		assert.Contains(t, out, "app_id=b")
+	})
+
+	t.Run("should prefix each line with its offset", func(t *testing.T) {
+		c := &collector{}
+		b := &block{c: c, name: "proc"}
+		b.append(0, "first")
+		b.append(1500000000, "second")
+
+		var sb strings.Builder
+		b.render(&sb)
+
+		assert.Contains(t, sb.String(), fmt.Sprintf("  %s  first\n", offset(0)))
+		assert.Contains(t, sb.String(), "  1.500s  second\n")
+	})
+}

--- a/tests/integration/framework/iowriter/report.go
+++ b/tests/integration/framework/iowriter/report.go
@@ -1,0 +1,212 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package iowriter
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/dapr/kit/logger"
+	kitstrings "github.com/dapr/kit/strings"
+)
+
+// Failure is a test which produced a log report, and the file it was written
+// to.
+type Failure struct {
+	Test string
+	Path string
+}
+
+var (
+	failuresLock sync.Mutex
+	failures     []Failure
+)
+
+// LogDir is the directory reports are written to. It is deliberately outside
+// t.TempDir() so that the files survive the test run that produced them.
+func LogDir() string {
+	if dir := os.Getenv("DAPR_INTEGRATION_LOGS_DIR"); dir != "" {
+		return dir
+	}
+	return filepath.Join(os.TempDir(), "dapr_integration_logs")
+}
+
+// ResetLogDir removes the log files of the previous run, so that
+// `less <dir>/*.log` shows this run and not the last one. Concurrent runs on one
+// machine should set DAPR_INTEGRATION_LOGS_DIR to keep out of each other's way.
+//
+// Only files this package wrote are removed. DAPR_INTEGRATION_LOGS_DIR may point
+// anywhere, so emptying the directory wholesale is not something to do.
+func ResetLogDir() error {
+	dir := LogDir()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return err
+	}
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return err
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".log") {
+			continue
+		}
+		if err := os.Remove(filepath.Join(dir, entry.Name())); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// inProcessLog holds the output of dapr packages running inside the test
+// binary, as opposed to inside one of the processes a test starts.
+const inProcessLog = "in-process.log"
+
+// RedirectInProcessLogs sends the output of code running inside the test binary
+// itself, rather than inside a process a test started, to a file. It reports
+// where it wrote.
+//
+// This output belongs to no particular test, so the framework cannot attribute
+// it to one, and it lands on the terminal in the middle of a run. Two sources
+// produce it:
+//
+//   - dapr's own logger, which packages such as pkg/security register at init
+//     and which writes to stderr;
+//   - the standard library logger, used directly by a handful of test apps and,
+//     more importantly, by net/http for things like "TLS handshake error" when
+//     a server has no ErrorLog of its own.
+//
+// Only dapr loggers already registered are redirected. Packages register theirs
+// at init, so calling this before the run starts covers them; a logger created
+// later still writes to stderr. The standard library redirect has no such
+// caveat, since there is a single logger behind log.Printf.
+//
+// Set DAPR_INTEGRATION_INPROCESS_LOGS to leave everything on stderr.
+func RedirectInProcessLogs() (string, error) {
+	if kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_INPROCESS_LOGS")) {
+		return "", nil
+	}
+
+	if err := os.MkdirAll(LogDir(), 0o750); err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(LogDir(), inProcessLog)
+
+	// Deliberately left open: it is wanted for the lifetime of the process, and
+	// the process is a test binary that is about to exit anyway.
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
+	if err != nil {
+		return "", err
+	}
+	log.SetOutput(f)
+
+	opts := logger.DefaultOptions()
+	opts.OutputFile = path
+	if err := logger.ApplyOptionsToLoggers(&opts); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+// inline reports whether reports go to the test output rather than to a file.
+//
+// A full suite run writes tens of thousands of log lines, which drown the
+// failures they explain, so locally they go to files. GitHub Actions collapses
+// each test's output into a log group, so there inlining costs nothing and
+// saves downloading an artifact to read a failure.
+func inline() bool {
+	if v, ok := os.LookupEnv("DAPR_INTEGRATION_LOGS_INLINE"); ok {
+		return kitstrings.IsTruthy(v)
+	}
+	return os.Getenv("GITHUB_ACTIONS") == "true"
+}
+
+// Failures returns every test which wrote a report, in the order they finished.
+func Failures() []Failure {
+	failuresLock.Lock()
+	defer failuresLock.Unlock()
+
+	out := make([]Failure, len(failures))
+	copy(out, failures)
+
+	return out
+}
+
+func recordFailure(test, path string) {
+	failuresLock.Lock()
+	defer failuresLock.Unlock()
+	failures = append(failures, Failure{Test: test, Path: path})
+}
+
+// writeReport writes the report for a test to its own file, returning the path.
+func writeReport(test, report string) (string, error) {
+	dir := LogDir()
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		return "", err
+	}
+
+	path := filepath.Join(dir, logFileName(test))
+	if err := os.WriteFile(path, []byte(stripANSI(report)), 0o600); err != nil {
+		return "", err
+	}
+
+	return path, nil
+}
+
+// logFileName turns a test name into a flat file name, so that the whole run
+// lands in one directory that is easy to grep and easy to delete.
+func logFileName(test string) string {
+	var sb strings.Builder
+	for _, r := range test {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			sb.WriteRune(r)
+		case r == '-', r == '_', r == '.':
+			sb.WriteRune(r)
+		default:
+			sb.WriteRune('.')
+		}
+	}
+
+	return sb.String() + ".log"
+}
+
+// stripANSI removes colour escapes, which help in a terminal but only get in
+// the way of grep and of an editor opening the file.
+func stripANSI(s string) string {
+	var sb strings.Builder
+	sb.Grow(len(s))
+
+	for i := 0; i < len(s); i++ {
+		if s[i] != 0x1b {
+			sb.WriteByte(s[i])
+			continue
+		}
+		// Skip up to and including the escape's terminating letter.
+		for i++; i < len(s); i++ {
+			if (s[i] >= 'a' && s[i] <= 'z') || (s[i] >= 'A' && s[i] <= 'Z') {
+				break
+			}
+		}
+	}
+
+	return sb.String()
+}

--- a/tests/integration/framework/iowriter/report.go
+++ b/tests/integration/framework/iowriter/report.go
@@ -45,13 +45,21 @@ func LogDir() string {
 	return filepath.Join(os.TempDir(), "dapr_integration_logs")
 }
 
-// ResetLogDir removes the log files of the previous run, so that
-// `less <dir>/*.log` shows this run and not the last one. Concurrent runs on one
-// machine should set DAPR_INTEGRATION_LOGS_DIR to keep out of each other's way.
+// Reset clears the state of the previous run: the recorded failures, and the
+// log files, so that `less <dir>/*.log` shows this run and not the last one.
+// Concurrent runs on one machine should set DAPR_INTEGRATION_LOGS_DIR to keep
+// out of each other's way.
+//
+// Both matter under `go test -count=N`, which runs the suite N times in one
+// process. Without this, run two reports run one's failures as its own.
 //
 // Only files this package wrote are removed. DAPR_INTEGRATION_LOGS_DIR may point
 // anywhere, so emptying the directory wholesale is not something to do.
-func ResetLogDir() error {
+func Reset() error {
+	failuresLock.Lock()
+	failures = nil
+	failuresLock.Unlock()
+
 	dir := LogDir()
 	if err := os.MkdirAll(dir, 0o750); err != nil {
 		return err

--- a/tests/integration/framework/iowriter/report.go
+++ b/tests/integration/framework/iowriter/report.go
@@ -106,32 +106,45 @@ const inProcessLog = "in-process.log"
 // caveat, since there is a single logger behind log.Printf.
 //
 // Set DAPR_INTEGRATION_INPROCESS_LOGS to leave everything on stderr.
-func RedirectInProcessLogs() (string, error) {
+//
+// The returned function restores the previous destinations and closes the file.
+// Callers must run it: Windows refuses to delete a file which is still open, so
+// leaving the handle around breaks the cleanup of any directory holding it.
+func RedirectInProcessLogs() (string, func(), error) {
 	if kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_INPROCESS_LOGS")) {
-		return "", nil
+		return "", func() {}, nil
 	}
 
 	if err := os.MkdirAll(LogDir(), 0o750); err != nil {
-		return "", err
+		return "", nil, err
 	}
 
 	path := filepath.Join(LogDir(), inProcessLog)
 
-	// Deliberately left open: it is wanted for the lifetime of the process, and
-	// the process is a test binary that is about to exit anyway.
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o600)
 	if err != nil {
-		return "", err
+		return "", nil, err
 	}
+
+	prev := log.Writer()
 	log.SetOutput(f)
 
 	opts := logger.DefaultOptions()
 	opts.OutputFile = path
 	if err := logger.ApplyOptionsToLoggers(&opts); err != nil {
-		return "", err
+		log.SetOutput(prev)
+		f.Close()
+		return "", nil, err
 	}
 
-	return path, nil
+	return path, func() {
+		log.SetOutput(prev)
+		// Handing the dapr loggers a default options with no output file points
+		// them back at stdout, and closes the file kit opened for them.
+		restore := logger.DefaultOptions()
+		_ = logger.ApplyOptionsToLoggers(&restore)
+		f.Close()
+	}, nil
 }
 
 // inline reports whether reports go to the test output rather than to a file.

--- a/tests/integration/framework/os/unshare.go
+++ b/tests/integration/framework/os/unshare.go
@@ -25,6 +25,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 )
 
 // InUnshareNamespace reports whether the current process is running inside an
@@ -95,11 +97,31 @@ func ReexecInUserNamespace(t *testing.T, ctx context.Context) bool {
 		"-test.v",
 		"-focus", "^"+regexp.QuoteMeta(focus)+"$",
 	)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+
+	// The child is a whole second test binary. Captured like any other process,
+	// its output is reported with this test's rather than printed straight to
+	// the terminal, where it collides with the parent run's own output.
+	iow := iowriter.New(t, "unshare")
+	cmd.Stdout = iow
+	cmd.Stderr = iow
+
+	cmd.Env = append(os.Environ(),
+		// The parent owns the terminal; a second progress line would fight it.
+		"DAPR_INTEGRATION_PROGRESS=false",
+		// Fold the child's own report into the output captured above, so there
+		// is one place to read rather than a file the parent never mentions.
+		"DAPR_INTEGRATION_LOGS_INLINE=true",
+		// Without its own directory the child's start of run reset would delete
+		// the reports of every other test in the parent run.
+		"DAPR_INTEGRATION_LOGS_DIR="+t.TempDir(),
+	)
+
+	err = cmd.Run()
+	iow.Close()
+	if err != nil {
 		t.Fatalf("re-exec under unshare failed: %v", err)
 	}
+
 	return true
 }
 

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -41,6 +41,7 @@ type Exec struct {
 
 	args       []string
 	binPath    string
+	logName    string
 	runErrorFn func(*testing.T, error)
 	exitCode   int
 	envs       map[string]string
@@ -119,12 +120,13 @@ func (e *Exec) ReplaceArg(t *testing.T, flag, value string) {
 func (e *Exec) Run(t *testing.T, ctx context.Context) {
 	t.Helper()
 
-	t.Logf("Running %q with args: %s %s", filepath.Base(e.binPath), e.binPath, strings.Join(e.args, " "))
-
 	//nolint:gosec
 	e.cmd = oexec.CommandContext(ctx, e.binPath, e.args...)
 
 	iow := iowriter.New(t, filepath.Base(e.binPath))
+	e.logName = iow.Name()
+	iowriter.Eventf(t, "exec %s: %s %s", e.logName, e.binPath, strings.Join(e.args, " "))
+
 	for _, pipe := range []struct {
 		cmdPipeFn func() (io.ReadCloser, error)
 		procPipe  io.WriteCloser
@@ -201,10 +203,36 @@ func (e *Exec) SignalHUP(t *testing.T) {
 func (e *Exec) checkExit(t *testing.T) {
 	t.Helper()
 
-	t.Logf("waiting for %q process to exit", filepath.Base(e.binPath))
+	iowriter.Eventf(t, "waiting for %s to exit", e.name())
 
-	e.runErrorFn(t, e.cmd.Wait())
+	err := e.cmd.Wait()
+
+	// A test which has already failed tears its processes down mid flight, so
+	// how they exited says nothing about the code under test. Record it instead
+	// of asserting on it, otherwise every fast failure is buried under a stack
+	// of cascading exit code errors.
+	if t.Failed() {
+		if err == nil {
+			iowriter.Eventf(t, "%s exited cleanly during teardown of a failed test", e.name())
+		} else {
+			iowriter.Eventf(t, "%s exited during teardown of a failed test: %v", e.name(), err)
+		}
+		return
+	}
+
+	e.runErrorFn(t, err)
 	assert.NotNil(t, e.cmd.ProcessState, "process state should not be nil")
-	assert.Equalf(t, e.exitCode, e.cmd.ProcessState.ExitCode(), "expected exit code to be %d", e.exitCode)
-	t.Logf("%q process exited", filepath.Base(e.binPath))
+	if e.cmd.ProcessState != nil {
+		iowriter.Eventf(t, "%s exited (code %d, want %d)", e.name(), e.cmd.ProcessState.ExitCode(), e.exitCode)
+		assert.Equalf(t, e.exitCode, e.cmd.ProcessState.ExitCode(), "expected exit code to be %d", e.exitCode)
+	}
+}
+
+// name is the label this process' output is reported under, falling back to
+// the binary name before Run has assigned one.
+func (e *Exec) name() string {
+	if e.logName != "" {
+		return e.logName
+	}
+	return filepath.Base(e.binPath)
 }

--- a/tests/integration/framework/process/exec/exec.go
+++ b/tests/integration/framework/process/exec/exec.go
@@ -127,17 +127,21 @@ func (e *Exec) Run(t *testing.T, ctx context.Context) {
 	e.logName = iow.Name()
 	iowriter.Eventf(t, "exec %s: %s %s", e.logName, e.binPath, strings.Join(e.args, " "))
 
+	// Both streams report under the one name, but each needs its own line
+	// buffer: sharing one lets either stream's EOF flush a partial line the
+	// other is still writing.
 	for _, pipe := range []struct {
 		cmdPipeFn func() (io.ReadCloser, error)
 		procPipe  io.WriteCloser
+		out       iowriter.WriteCloser
 	}{
-		{cmdPipeFn: e.cmd.StdoutPipe, procPipe: e.stdoutpipe},
-		{cmdPipeFn: e.cmd.StderrPipe, procPipe: e.stderrpipe},
+		{cmdPipeFn: e.cmd.StdoutPipe, procPipe: e.stdoutpipe, out: iow},
+		{cmdPipeFn: e.cmd.StderrPipe, procPipe: e.stderrpipe, out: iow.Stream()},
 	} {
 		cmdPipe, err := pipe.cmdPipeFn()
 		require.NoError(t, err)
 
-		pipe := tee.WriteCloser(iow, pipe.procPipe)
+		pipe := tee.WriteCloser(pipe.out, pipe.procPipe)
 
 		e.wg.Go(func() {
 			io.Copy(pipe, cmdPipe)

--- a/tests/integration/framework/process/exec/kill/kill.go
+++ b/tests/integration/framework/process/exec/kill/kill.go
@@ -15,9 +15,12 @@ package kill
 
 import (
 	"os/exec"
+	"path/filepath"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 )
 
 func Interrupt(t *testing.T, cmd *exec.Cmd) {
@@ -27,7 +30,7 @@ func Interrupt(t *testing.T, cmd *exec.Cmd) {
 		return
 	}
 
-	t.Logf("interrupting %s process", cmd.Path)
+	iowriter.Eventf(t, "interrupting %s", filepath.Base(cmd.Path))
 
 	interrupt(t, cmd)
 }
@@ -39,7 +42,7 @@ func Kill(t *testing.T, cmd *exec.Cmd) {
 		return
 	}
 
-	t.Logf("killing %s process", cmd.Path)
+	iowriter.Eventf(t, "killing %s", filepath.Base(cmd.Path))
 
 	kill(t, cmd)
 }
@@ -50,7 +53,7 @@ func SignalHUP(t *testing.T, cmd *exec.Cmd) {
 	require.NotNil(t, cmd, "cmd must not be nil when sending SIGHUP")
 	require.Nil(t, cmd.ProcessState, "process must still be running when sending SIGHUP")
 
-	t.Logf("signaling HUP to %s process", cmd.Path)
+	iowriter.Eventf(t, "signaling HUP to %s", filepath.Base(cmd.Path))
 
 	signalHUP(t, cmd)
 }

--- a/tests/integration/framework/process/grpc/app/app.go
+++ b/tests/integration/framework/process/grpc/app/app.go
@@ -26,6 +26,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
 	testpb "github.com/dapr/dapr/tests/integration/framework/process/grpc/app/proto"
 )
@@ -127,7 +128,7 @@ func (a *App) runActorCallbackStream(t *testing.T) {
 		}
 		conn, err := grpc.NewClient(addr, grpc.WithTransportCredentials(insecure.NewCredentials()))
 		if err != nil {
-			t.Logf("procgrpcapp: failed to dial daprd at %s: %v", addr, err)
+			iowriter.Eventf(t, "procgrpcapp: failed to dial daprd at %s: %v", addr, err)
 			select {
 			case <-a.streamCtx.Done():
 				return
@@ -186,7 +187,7 @@ func (a *App) pumpActorCallbackStream(t *testing.T, conn *grpc.ClientConn) {
 		return
 	}
 	if resp.GetInitialResponse() == nil {
-		t.Logf("procgrpcapp: expected initial response, got %T", resp.GetResponseType())
+		iowriter.Eventf(t, "procgrpcapp: expected initial response, got %T", resp.GetResponseType())
 		return
 	}
 

--- a/tests/integration/framework/process/kubernetes/kubernetes.go
+++ b/tests/integration/framework/process/kubernetes/kubernetes.go
@@ -34,6 +34,7 @@ import (
 	"sigs.k8s.io/yaml"
 
 	"github.com/dapr/dapr/pkg/sentry/server/ca/bundle"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes/informer"
 	cryptopem "github.com/dapr/kit/crypto/pem"
@@ -229,7 +230,7 @@ func parseCRDs(t *testing.T) map[string][]byte {
 
 	dir, ok := os.LookupEnv(EnvVarCRDDirectory)
 	if !ok {
-		t.Logf("environment variable %s not set, using default CRD location %s", EnvVarCRDDirectory, defaultPath)
+		iowriter.Eventf(t, "environment variable %s not set, using default CRD location %s", EnvVarCRDDirectory, defaultPath)
 		dir = defaultPath
 	}
 

--- a/tests/integration/framework/process/ports/ports.go
+++ b/tests/integration/framework/process/ports/ports.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 )
 
 var (
@@ -80,7 +82,7 @@ func Reserve(t *testing.T, count int) *Ports {
 
 	resvPLen -= count
 	if count > resvPLen || resvPLen < 20 {
-		t.Logf("reserving %d more ports", blockSize)
+		iowriter.Eventf(t, "reserving %d more ports", blockSize)
 		for i := 0; i < blockSize; i++ {
 			last++
 			if last+i >= portsCeil {

--- a/tests/integration/framework/process/scheduler/etcd/etcd.go
+++ b/tests/integration/framework/process/scheduler/etcd/etcd.go
@@ -26,6 +26,8 @@ import (
 	clientv3 "go.etcd.io/etcd/client/v3"
 	"go.etcd.io/etcd/server/v3/embed"
 
+	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 	"github.com/dapr/dapr/tests/integration/framework/process/ports"
 )
 
@@ -114,7 +116,7 @@ func (e *Etcd) Run(t *testing.T, ctx context.Context) {
 			}
 		}, time.Second*20, time.Millisecond*10)
 
-		t.Logf("Running etcd with config: %+v", etcd.Config())
+		iowriter.Eventf(t, "running etcd with config: %+v", etcd.Config())
 
 		e.etcds = append(e.etcds, etcd)
 	}
@@ -150,10 +152,10 @@ func (e *Etcd) setupUserPass(t *testing.T, ctx context.Context) {
 		return
 	}
 
-	client, err := clientv3.New(clientv3.Config{
+	client, err := clientv3.New(fclient.WithEtcdLogger(t, clientv3.Config{
 		Endpoints:   e.endpoints,
 		DialTimeout: 5 * time.Second,
-	})
+	}))
 	require.NoError(t, err)
 	defer client.Close()
 

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -425,10 +425,10 @@ func (s *Scheduler) MetricsWithLabels(t *testing.T, ctx context.Context) *metric
 func (s *Scheduler) ETCDClient(t *testing.T, ctx context.Context) *clientv3.Client {
 	t.Helper()
 
-	client, err := clientv3.New(clientv3.Config{
+	client, err := clientv3.New(client.WithEtcdLogger(t, clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:" + strconv.Itoa(s.EtcdClientPort())},
 		DialTimeout: 40 * time.Second,
-	})
+	}))
 	require.NoError(t, err)
 
 	t.Cleanup(func() {

--- a/tests/integration/framework/process/sentry/sentry.go
+++ b/tests/integration/framework/process/sentry/sentry.go
@@ -39,6 +39,7 @@ import (
 	"github.com/dapr/dapr/pkg/sentry/server/ca/bundle"
 	"github.com/dapr/dapr/tests/integration/framework/binary"
 	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/ports"
@@ -360,7 +361,7 @@ func (s *Sentry) DialGRPC(t *testing.T, ctx context.Context, sentryID string) *g
 			}
 
 			// Log the error but don't fail the test if connection is already closed
-			t.Logf("Warning: gRPC connection close error (may be already closed): %v", err)
+			iowriter.Eventf(t, "gRPC connection close error (may be already closed): %v", err)
 		}
 	})
 

--- a/tests/integration/framework/process/sqlite/sqlite.go
+++ b/tests/integration/framework/process/sqlite/sqlite.go
@@ -35,6 +35,7 @@ import (
 
 	commonapi "github.com/dapr/dapr/pkg/apis/common"
 	componentsv1alpha1 "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
 )
 
 // Option is a function that configures the process.
@@ -85,7 +86,7 @@ func New(t *testing.T, fopts ...Option) *SQLite {
 }
 
 func (s *SQLite) Run(t *testing.T, ctx context.Context) {
-	t.Logf("Storing SQLite database at %s", s.dbPath)
+	iowriter.Eventf(t, "storing SQLite database at %s", s.dbPath)
 
 	s.runOnce.Do(func() {
 		for _, migration := range s.migrations {

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -289,13 +289,13 @@ func (w *Workflow) RegistryN(index int) *task.TaskRegistry {
 
 func (w *Workflow) WorkflowClient(t *testing.T, ctx context.Context) *workflow.Client {
 	t.Helper()
-	return workflow.NewClient(w.Dapr().GRPCConn(t, ctx))
+	return workflow.NewClientWithLogger(w.Dapr().GRPCConn(t, ctx), logger.New(t))
 }
 
 func (w *Workflow) WorkflowClientN(t *testing.T, ctx context.Context, index int) *workflow.Client {
 	t.Helper()
 	require.Less(t, index, len(w.daprds), "index out of range")
-	return workflow.NewClient(w.DaprN(index).GRPCConn(t, ctx))
+	return workflow.NewClientWithLogger(w.DaprN(index).GRPCConn(t, ctx), logger.New(t))
 }
 
 func (w *Workflow) BackendClient(t *testing.T, ctx context.Context) *client.TaskHubGrpcClient {

--- a/tests/integration/framework/progress/progress.go
+++ b/tests/integration/framework/progress/progress.go
@@ -1,0 +1,237 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package progress draws a live progress line for an integration test run.
+//
+// It writes to the controlling terminal rather than to stdout. `go test`
+// captures the test binary's stdout and stderr, and without -v throws away
+// everything a passing test wrote, so a progress line sent there would never be
+// seen. Writing to /dev/tty side steps that: the line appears on screen as the
+// run proceeds, stays out of the output when it is piped to a file, and does
+// not need the run to be verbose.
+package progress
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	kitstrings "github.com/dapr/kit/strings"
+)
+
+// tick is how often the line is redrawn when no test has finished, so that a
+// slow test still looks like progress rather than a hang.
+const tick = time.Second / 4
+
+const defaultWidth = 80
+
+var spinner = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
+
+// Reporter renders the progress of a run. The zero value, and any Reporter
+// created when there is no terminal to draw on, is a no-op.
+type Reporter struct {
+	out    io.Writer
+	closer io.Closer
+	total  int
+	start  time.Time
+	width  int
+
+	lock    sync.Mutex
+	done    int
+	failed  int
+	last    string
+	frame   int
+	lastLen int
+
+	stop chan struct{}
+	wg   sync.WaitGroup
+}
+
+// New returns a Reporter drawing on the controlling terminal, or a no-op
+// Reporter when there is not one to draw on.
+func New(total int) *Reporter {
+	if !enabled() || total == 0 {
+		return new(Reporter)
+	}
+
+	tty, err := os.OpenFile("/dev/tty", os.O_WRONLY, 0)
+	if err != nil {
+		return new(Reporter)
+	}
+
+	r := newReporter(tty, total)
+	r.closer = tty
+	r.run()
+
+	return r
+}
+
+// enabled reports whether a progress line should be drawn. A verbose run
+// already prints a line per test, so a progress line would be redundant and
+// would interleave with it. CI has no terminal worth drawing on, and Windows
+// has no /dev/tty.
+func enabled() bool {
+	if v, ok := os.LookupEnv("DAPR_INTEGRATION_PROGRESS"); ok {
+		return kitstrings.IsTruthy(v)
+	}
+	return runtime.GOOS != "windows" &&
+		os.Getenv("GITHUB_ACTIONS") != "true" &&
+		!testing.Verbose()
+}
+
+func newReporter(out io.Writer, total int) *Reporter {
+	return &Reporter{
+		out:   out,
+		total: total,
+		start: time.Now(),
+		width: width(),
+		stop:  make(chan struct{}),
+	}
+}
+
+func width() int {
+	cols, err := strconv.Atoi(os.Getenv("COLUMNS"))
+	if err != nil || cols < 40 {
+		return defaultWidth
+	}
+	return cols
+}
+
+// run redraws the line on a timer so the elapsed time and spinner keep moving
+// between test completions.
+func (r *Reporter) run() {
+	r.wg.Go(func() {
+		ticker := time.NewTicker(tick)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-r.stop:
+				return
+			case <-ticker.C:
+				r.lock.Lock()
+				r.frame++
+				r.draw()
+				r.lock.Unlock()
+			}
+		}
+	})
+}
+
+// Done records that a test case finished. A failure is also written out as a
+// line of its own, so that failures accumulate on screen during a long run
+// rather than only appearing at the end.
+func (r *Reporter) Done(name string, failed bool) {
+	if r.out == nil {
+		return
+	}
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.done++
+	r.last = name
+	if failed {
+		r.failed++
+		r.erase()
+		fmt.Fprintf(r.out, "  FAIL  %s\n", name)
+	}
+
+	r.draw()
+}
+
+// Finish removes the progress line, leaving the terminal as it found it.
+func (r *Reporter) Finish() {
+	if r.out == nil {
+		return
+	}
+
+	close(r.stop)
+	r.wg.Wait()
+
+	r.lock.Lock()
+	defer r.lock.Unlock()
+
+	r.erase()
+	if r.closer != nil {
+		r.closer.Close()
+	}
+	r.out = nil
+}
+
+// erase clears the current line. Expects the lock to be held.
+func (r *Reporter) erase() {
+	if r.lastLen == 0 {
+		return
+	}
+	fmt.Fprintf(r.out, "\r%s\r", strings.Repeat(" ", r.lastLen))
+	r.lastLen = 0
+}
+
+// draw rewrites the progress line in place. Expects the lock to be held.
+func (r *Reporter) draw() {
+	line := r.line()
+	fmt.Fprintf(r.out, "\r%s", line)
+
+	// Blank whatever the previous, longer line left behind.
+	if pad := r.lastLen - len([]rune(line)); pad > 0 {
+		fmt.Fprintf(r.out, "%s\r%s", strings.Repeat(" ", pad), line)
+	}
+
+	r.lastLen = len([]rune(line))
+}
+
+func (r *Reporter) line() string {
+	head := fmt.Sprintf(" %s %d/%d  ok %d",
+		spinner[r.frame%len(spinner)], r.done, r.total, r.done-r.failed,
+	)
+	if r.failed > 0 {
+		head += fmt.Sprintf("  fail %d", r.failed)
+	}
+	head += "  " + elapsed(time.Since(r.start)) + "  "
+
+	// The test name gets whatever room is left, so the line never wraps and
+	// leaves an orphaned half line behind it.
+	room := r.width - len([]rune(head)) - 1
+	if room < 1 {
+		return head
+	}
+
+	return head + truncate(r.last, room)
+}
+
+func elapsed(d time.Duration) string {
+	d = d.Truncate(time.Second)
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	return fmt.Sprintf("%dm%02ds", int(d.Minutes()), int(d.Seconds())%60)
+}
+
+// truncate keeps the tail of a test name, which is the part that distinguishes
+// it from its siblings.
+func truncate(s string, max int) string {
+	runes := []rune(s)
+	if len(runes) <= max {
+		return s
+	}
+	if max <= 1 {
+		return string(runes[len(runes)-max:])
+	}
+	return "…" + string(runes[len(runes)-max+1:])
+}

--- a/tests/integration/framework/progress/progress_test.go
+++ b/tests/integration/framework/progress/progress_test.go
@@ -1,0 +1,155 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package progress
+
+import (
+	"bytes"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+// lines splits terminal output on the carriage returns the reporter uses to
+// rewrite in place, so that each redraw can be inspected on its own.
+func lines(s string) []string {
+	var out []string
+	for l := range strings.SplitSeq(s, "\r") {
+		if strings.TrimSpace(l) != "" {
+			out = append(out, strings.TrimRight(l, " "))
+		}
+	}
+	return out
+}
+
+func TestReporter(t *testing.T) {
+	t.Run("should be a no-op when there is no terminal", func(t *testing.T) {
+		var r Reporter
+		r.Done("a/b", false)
+		r.Finish()
+	})
+
+	t.Run("should count completions", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 3)
+
+		r.Done("ports/daprd", false)
+		r.Done("ports/sentry", false)
+
+		got := lines(buf.String())
+		assert.Contains(t, got[len(got)-1], "2/3")
+		assert.Contains(t, got[len(got)-1], "ok 2")
+		assert.Contains(t, got[len(got)-1], "ports/sentry")
+	})
+
+	t.Run("should show the name of the most recent test", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 2)
+
+		r.Done("actors/reminders/period", false)
+		assert.Contains(t, buf.String(), "actors/reminders/period")
+	})
+
+	t.Run("should report a failure on its own line and keep a count", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 2)
+
+		r.Done("ports/daprd", true)
+		r.Done("ports/sentry", false)
+
+		assert.Contains(t, buf.String(), "FAIL  ports/daprd\n")
+
+		got := lines(buf.String())
+		assert.Contains(t, got[len(got)-1], "fail 1")
+		assert.Contains(t, got[len(got)-1], "ok 1")
+	})
+
+	t.Run("should not mention failures when there are none", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 1)
+
+		r.Done("ports/daprd", false)
+		assert.NotContains(t, buf.String(), "fail")
+	})
+
+	t.Run("should erase the line on finish", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 1)
+		r.Done("ports/daprd", false)
+		r.Finish()
+
+		assert.True(t, strings.HasSuffix(buf.String(), "\r"), "line should be blanked")
+		assert.Nil(t, r.out, "further calls should be no-ops")
+
+		r.Done("ports/sentry", false)
+	})
+
+	t.Run("should keep the line within the terminal width", func(t *testing.T) {
+		t.Setenv("COLUMNS", "60")
+
+		var buf bytes.Buffer
+		r := newReporter(&buf, 1)
+		r.Done(strings.Repeat("very/long/name/", 20), false)
+
+		for _, l := range lines(buf.String()) {
+			assert.LessOrEqual(t, len([]rune(l)), 60, l)
+		}
+	})
+
+	t.Run("should survive concurrent completions", func(t *testing.T) {
+		var buf bytes.Buffer
+		r := newReporter(&buf, 100)
+		r.run()
+
+		var wg sync.WaitGroup
+		wg.Add(100)
+		for i := range 100 {
+			go func() {
+				defer wg.Done()
+				r.Done("case", i%10 == 0)
+			}()
+		}
+		wg.Wait()
+		r.Finish()
+
+		assert.Equal(t, 100, r.done)
+		assert.Equal(t, 10, r.failed)
+	})
+}
+
+func TestElapsed(t *testing.T) {
+	tests := map[time.Duration]string{
+		0:                                     "0s",
+		1500 * time.Millisecond:               "1s",
+		59 * time.Second:                      "59s",
+		time.Minute:                           "1m00s",
+		3*time.Minute + 25*time.Second:        "3m25s",
+		62*time.Minute + 500*time.Millisecond: "62m00s",
+	}
+
+	for in, exp := range tests {
+		assert.Equal(t, exp, elapsed(in), in.String())
+	}
+}
+
+func TestTruncate(t *testing.T) {
+	assert.Equal(t, "abc", truncate("abc", 5))
+	assert.Equal(t, "abc", truncate("abc", 3), "exact fit is untouched")
+	assert.Equal(t, "…c", truncate("abc", 2))
+	assert.Equal(t, "c", truncate("abc", 1))
+	// The tail is what distinguishes sibling test names.
+	assert.Equal(t, "…reminders/period", truncate("actors/reminders/period", 17))
+}

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -50,7 +50,7 @@ func RunIntegrationTests(t *testing.T) {
 	require.NoError(t, err, "Invalid parameter focus")
 	t.Logf("running test suite with focus: %s", *focusF)
 
-	require.NoError(t, iowriter.ResetLogDir(), "could not prepare the log directory")
+	require.NoError(t, iowriter.Reset(), "could not prepare the log directory")
 
 	_, err = iowriter.RedirectInProcessLogs()
 	require.NoError(t, err, "could not redirect in-process logs")

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -52,8 +52,9 @@ func RunIntegrationTests(t *testing.T) {
 
 	require.NoError(t, iowriter.Reset(), "could not prepare the log directory")
 
-	_, err = iowriter.RedirectInProcessLogs()
+	_, restoreLogs, err := iowriter.RedirectInProcessLogs()
 	require.NoError(t, err, "could not redirect in-process logs")
+	t.Cleanup(restoreLogs)
 
 	var binFailed bool
 	t.Run("build binaries", func(t *testing.T) {

--- a/tests/integration/integration.go
+++ b/tests/integration/integration.go
@@ -15,8 +15,10 @@ package integration
 
 import (
 	"context"
+	"errors"
 	"flag"
 	"fmt"
+	"path/filepath"
 	"reflect"
 	"regexp"
 	"strings"
@@ -27,8 +29,14 @@ import (
 
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/binary"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
+	"github.com/dapr/dapr/tests/integration/framework/progress"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
+
+// caseTimeout is the wall clock budget for a single test case, covering both
+// process startup and the case body.
+const caseTimeout = 45 * time.Second
 
 var (
 	focusF       = flag.String("focus", ".*", "Focus on specific test cases. Accepts regex.")
@@ -41,6 +49,11 @@ func RunIntegrationTests(t *testing.T) {
 	focus, err := regexp.Compile(*focusF)
 	require.NoError(t, err, "Invalid parameter focus")
 	t.Logf("running test suite with focus: %s", *focusF)
+
+	require.NoError(t, iowriter.ResetLogDir(), "could not prepare the log directory")
+
+	_, err = iowriter.RedirectInProcessLogs()
+	require.NoError(t, err, "could not redirect in-process logs")
 
 	var binFailed bool
 	t.Run("build binaries", func(t *testing.T) {
@@ -62,6 +75,11 @@ func RunIntegrationTests(t *testing.T) {
 		focusedTests = append(focusedTests, tcase)
 	}
 
+	// Drawn on the terminal rather than through t.Log, so that a run shows it is
+	// making progress without the test output having to be verbose.
+	prog := progress.New(len(focusedTests))
+	t.Cleanup(prog.Finish)
+
 	startTime := time.Now()
 	t.Cleanup(func() {
 		executionMessage := fmt.Sprintf("Total integration test execution time for %d test cases: %s", len(focusedTests), time.Since(startTime).Truncate(time.Millisecond*100))
@@ -71,6 +89,8 @@ func RunIntegrationTests(t *testing.T) {
 		}
 		t.Log(executionMessage)
 		t.Log(strings.Repeat("-", len(executionMessage)))
+
+		logFailures(t, len(focusedTests))
 	})
 
 	for _, tcase := range focusedTests {
@@ -81,22 +101,63 @@ func RunIntegrationTests(t *testing.T) {
 				t.Parallel()
 			}
 
+			// Registered before anything else so that it runs last, once the
+			// processes have been cleaned up and the result is final.
+			t.Cleanup(func() { prog.Done(tcase.Name(), t.Failed()) })
+
 			options := tcase.Setup(t)
 
-			t.Log("setting up test case")
+			iowriter.Eventf(t, "setting up test case")
 
 			// TODO: @joshvanl: update framework to use `t.Context()` which is
 			// correctly respected on cleanup.
 
-			ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+			ctx, cancel := context.WithTimeout(context.Background(), caseTimeout)
 			t.Cleanup(cancel)
+
+			// A blown deadline explains every downstream failure it causes, so
+			// call it out at the top of the report rather than leaving the
+			// reader to infer it.
+			t.Cleanup(func() {
+				if errors.Is(ctx.Err(), context.DeadlineExceeded) {
+					iowriter.Notef(t, "test case exceeded its %s deadline", caseTimeout)
+				}
+			})
 
 			framework.Run(t, ctx, options...)
 
-			t.Run("run", func(t *testing.T) {
-				t.Log("running test case")
-				tcase.Run(t, ctx)
-			})
+			iowriter.Eventf(t, "running test case")
+			tcase.Run(t, ctx)
 		})
+	}
+}
+
+// logFailures lists the failed test cases and where to read their logs. It runs
+// last, so that the one thing worth acting on is the last thing on screen no
+// matter which output format the run used.
+func logFailures(t *testing.T, total int) {
+	failures := iowriter.Failures()
+	if len(failures) == 0 {
+		return
+	}
+
+	width := 0
+	for _, f := range failures {
+		width = max(width, len(f.Test))
+	}
+
+	t.Logf("%d of %d test cases failed:", len(failures), total)
+	for _, f := range failures {
+		// Logs are inlined rather than written to a file on CI, where there is
+		// nowhere useful to point at.
+		if f.Path == "" {
+			t.Logf("  %s", f.Test)
+			continue
+		}
+		t.Logf("  %-*s  %s", width, f.Test, f.Path)
+	}
+
+	if failures[0].Path != "" {
+		t.Logf("Read all of them with: less %s", filepath.Join(iowriter.LogDir(), "*.log"))
 	}
 }

--- a/tests/integration/suite/daprd/mcpserver/call_tool.go
+++ b/tests/integration/suite/daprd/mcpserver/call_tool.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -111,7 +111,7 @@ func (s *callTool) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("CallTool returns tool result with correct content", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/mcpserver/call_tool_sse.go
+++ b/tests/integration/suite/daprd/mcpserver/call_tool_sse.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -108,7 +108,7 @@ func (s *callToolSSE) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("CallTool via SSE transport returns tool result", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/mcpserver/header_injection.go
+++ b/tests/integration/suite/daprd/mcpserver/header_injection.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -114,7 +114,7 @@ func (s *headerInjection) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("static header X-API-Key is injected into MCP requests", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/mcpserver/healthz_outbound.go
+++ b/tests/integration/suite/daprd/mcpserver/healthz_outbound.go
@@ -27,12 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -146,7 +146,7 @@ func (s *healthzOutboundGate) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	t.Run("ListTools workflow is schedulable once /healthz/outbound is Ready", func(t *testing.T) {
-		taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+		taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 		instanceID := httpapi.Start(t, ctx, httpClient, s.daprd.HTTPPort(),
 			mcpnames.MCPListToolsWorkflowName("slow"), map[string]any{})
 

--- a/tests/integration/suite/daprd/mcpserver/list_tools_http.go
+++ b/tests/integration/suite/daprd/mcpserver/list_tools_http.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -116,7 +116,7 @@ func (s *listToolsHTTP) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("ListTools via streamable_http returns expected tools", func(t *testing.T) {
 		instanceID := httpapi.Start(t, ctx, s.httpClient, s.daprd.HTTPPort(),

--- a/tests/integration/suite/daprd/mcpserver/list_tools_sse.go
+++ b/tests/integration/suite/daprd/mcpserver/list_tools_sse.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -104,7 +104,7 @@ func (s *listToolsSSE) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("ListTools via SSE transport returns expected tools", func(t *testing.T) {
 		instanceID := httpapi.Start(t, ctx, s.httpClient, s.daprd.HTTPPort(),

--- a/tests/integration/suite/daprd/mcpserver/middleware_after_call_tool.go
+++ b/tests/integration/suite/daprd/mcpserver/middleware_after_call_tool.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -134,7 +134,7 @@ func (s *middlewareAfterCallTool) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 	r := task.NewTaskRegistry()
 
 	// after_hook_fail: returns an error → workflow should FAIL.

--- a/tests/integration/suite/daprd/mcpserver/middleware_before_call_tool.go
+++ b/tests/integration/suite/daprd/mcpserver/middleware_before_call_tool.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -138,7 +138,7 @@ func (s *middlewareBeforeCallTool) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	r := task.NewTaskRegistry()
 

--- a/tests/integration/suite/daprd/mcpserver/middleware_chained.go
+++ b/tests/integration/suite/daprd/mcpserver/middleware_chained.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -143,7 +143,7 @@ func (s *middlewareChained) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 	r := task.NewTaskRegistry()
 
 	// beforeCallTool chain hooks:

--- a/tests/integration/suite/daprd/mcpserver/middleware_list_tools_hooks.go
+++ b/tests/integration/suite/daprd/mcpserver/middleware_list_tools_hooks.go
@@ -27,13 +27,13 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -132,7 +132,7 @@ func (s *middlewareListToolsHooks) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 	r := task.NewTaskRegistry()
 
 	r.AddWorkflowN("deny_list_workflow", func(ctx *task.WorkflowContext) (any, error) {

--- a/tests/integration/suite/daprd/mcpserver/multiple_servers.go
+++ b/tests/integration/suite/daprd/mcpserver/multiple_servers.go
@@ -25,12 +25,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -133,7 +133,7 @@ func (s *multipleServers) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("CallTool on weather server returns weather", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/mcpserver/oauth2_auth.go
+++ b/tests/integration/suite/daprd/mcpserver/oauth2_auth.go
@@ -29,12 +29,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -154,7 +154,7 @@ func (s *oauth2Auth) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("OAuth2 bearer token is injected into MCP requests", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/mcpserver/registration_retry.go
+++ b/tests/integration/suite/daprd/mcpserver/registration_retry.go
@@ -26,12 +26,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -129,7 +129,7 @@ func (r *registrationRetry) Run(t *testing.T, ctx context.Context) {
 	// workflow proves it.
 	t.Run("its tools are usable", func(t *testing.T) {
 		httpClient := fclient.HTTP(t)
-		taskhubClient := dtclient.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+		taskhubClient := dtclient.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 
 		instanceID := httpapi.Start(t, ctx, httpClient, r.daprd.HTTPPort(),
 			mcpnames.MCPListToolsWorkflowName("flaky"), map[string]any{})

--- a/tests/integration/suite/daprd/mcpserver/restart_mid_call.go
+++ b/tests/integration/suite/daprd/mcpserver/restart_mid_call.go
@@ -27,12 +27,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
@@ -161,7 +161,7 @@ func (s *restartMidCall) Run(t *testing.T, ctx context.Context) {
 		s.daprd.WaitUntilRunning(t, ctx)
 
 		// Reconnect the task-hub client to the restarted daprd instance.
-		taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+		taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 		// Wait for the orchestration to complete. The scheduler's actor
 		// reminder re-delivers the pending activity to the new daprd, which

--- a/tests/integration/suite/daprd/mcpserver/spiffe_auth.go
+++ b/tests/integration/suite/daprd/mcpserver/spiffe_auth.go
@@ -32,12 +32,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 
 	mcpnames "github.com/dapr/dapr/pkg/runtime/wfengine/inprocess/mcp/v1/names"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
@@ -150,7 +150,7 @@ func (s *spiffeAuth) Run(t *testing.T, ctx context.Context) {
 	s.daprd.WaitUntilRunning(t, ctx)
 
 	s.httpClient = fclient.HTTP(t)
-	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := dtclient.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("SPIFFE JWT is injected with correct SPIFFE ID and signed by Sentry", func(t *testing.T) {
 		input := map[string]any{

--- a/tests/integration/suite/daprd/metrics/workflow.go
+++ b/tests/integration/suite/daprd/metrics/workflow.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -97,7 +97,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 	r.AddWorkflowN("waiter", func(ctx *task.WorkflowContext) (any, error) {
 		return nil, ctx.WaitForSingleEvent("never", time.Hour).Await(nil)
 	})
-	taskhubClient := client.NewTaskHubGrpcClient(w.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	taskhubClient := client.NewTaskHubGrpcClient(w.daprd.GRPCConn(t, ctx), logger.New(t))
 	taskhubClient.StartWorkItemListener(ctx, r)
 
 	t.Run("successful workflow execution", func(t *testing.T) {

--- a/tests/integration/suite/daprd/metrics/workflow/custombuckets.go
+++ b/tests/integration/suite/daprd/metrics/workflow/custombuckets.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/metrics/util"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -85,7 +85,7 @@ func (b *customBuckets) Run(t *testing.T, ctx context.Context) {
 		}
 		return nil, nil
 	})
-	taskHubClient := client.NewTaskHubGrpcClient(b.w.Dapr().GRPCConn(t, ctx), backend.DefaultLogger())
+	taskHubClient := client.NewTaskHubGrpcClient(b.w.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, taskHubClient.StartWorkItemListener(ctx, r))
 
 	t.Run("custom latency buckets", func(t *testing.T) {

--- a/tests/integration/suite/daprd/metrics/workflow/defaultbuckets.go
+++ b/tests/integration/suite/daprd/metrics/workflow/defaultbuckets.go
@@ -22,12 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/metrics/util"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -72,7 +72,7 @@ func (b *defaultBuckets) Run(t *testing.T, ctx context.Context) {
 		}
 		return nil, nil
 	})
-	taskHubClient := client.NewTaskHubGrpcClient(b.w.Dapr().GRPCConn(t, ctx), backend.DefaultLogger())
+	taskHubClient := client.NewTaskHubGrpcClient(b.w.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, taskHubClient.StartWorkItemListener(ctx, r))
 
 	t.Run("default latency buckets", func(t *testing.T) {

--- a/tests/integration/suite/daprd/placement/cluster/workflow.go
+++ b/tests/integration/suite/daprd/placement/cluster/workflow.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement/cluster"
@@ -80,7 +81,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 	table := leader.PlacementTables(t, ctx)
 	versionBefore := table.Tables["default"].Version
 
-	client1 := dworkflow.NewClient(w.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(w.daprd1.GRPCConn(t, ctx), logger.New(t))
 	cctx1, cancel1 := context.WithCancel(ctx)
 	t.Cleanup(cancel1)
 	require.NoError(t, client1.StartWorker(cctx1, dworkflow.NewRegistry()))
@@ -110,7 +111,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 
 	versionAfterWf1 := table.Tables["default"].Version
 
-	client2 := dworkflow.NewClient(w.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(w.daprd2.GRPCConn(t, ctx), logger.New(t))
 	cctx2, cancel2 := context.WithCancel(ctx)
 	t.Cleanup(cancel2)
 	require.NoError(t, client2.StartWorker(cctx2, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/disstimeout/workflow.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/workflow.go
@@ -27,6 +27,7 @@ import (
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -71,7 +72,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 		assert.Len(c, table.Tables["default"].Hosts, 1)
 	}, time.Second*15, time.Millisecond*100)
 
-	wfClient := dworkflow.NewClient(w.actors.Daprd().GRPCConn(t, ctx))
+	wfClient := dworkflow.NewClientWithLogger(w.actors.Daprd().GRPCConn(t, ctx), logger.New(t))
 	wfCtx, wfCancel := context.WithCancel(ctx)
 	t.Cleanup(wfCancel)
 	require.NoError(t, wfClient.StartWorker(wfCtx, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
+++ b/tests/integration/suite/daprd/placement/disstimeout/workflowexec.go
@@ -29,13 +29,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	dtclient "github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -97,7 +97,7 @@ func (w *workflowexec) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := dtclient.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := dtclient.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	r := task.NewTaskRegistry()
 	r.AddWorkflowN("TimeoutWorkflow", func(ctx *task.WorkflowContext) (any, error) {

--- a/tests/integration/suite/daprd/placement/multiple/actors.go
+++ b/tests/integration/suite/daprd/placement/multiple/actors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -96,7 +97,7 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 		version1 = tables.Tables["default"].Version
 	}, time.Second*10, time.Millisecond*10)
 
-	client := dworkflow.NewClient(a.actors[0].Daprd().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(a.actors[0].Daprd().GRPCConn(t, ctx), logger.New(t))
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/multiple/workflow.go
+++ b/tests/integration/suite/daprd/placement/multiple/workflow.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -96,7 +97,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 
 	assert.Equal(t, sortedHosts(expTable), sortedHosts(w.actors1.Placement().PlacementTables(t, ctx)))
 
-	client1 := dworkflow.NewClient(w.actors1.Daprd().GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(w.actors1.Daprd().GRPCConn(t, ctx), logger.New(t))
 	cctx1, cancel1 := context.WithCancel(ctx)
 	t.Cleanup(cancel1)
 	require.NoError(t, client1.StartWorker(cctx1, dworkflow.NewRegistry()))
@@ -111,7 +112,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(c, sortedHosts(expTable), sortedHosts(w.actors1.Placement().PlacementTables(t, ctx)))
 	}, time.Second*10, time.Millisecond*10)
 
-	client2 := dworkflow.NewClient(w.actors2.Daprd().GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(w.actors2.Daprd().GRPCConn(t, ctx), logger.New(t))
 	cctx2, cancel2 := context.WithCancel(ctx)
 	t.Cleanup(cancel2)
 	require.NoError(t, client2.StartWorker(cctx2, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/notypes/workflow.go
+++ b/tests/integration/suite/daprd/placement/notypes/workflow.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -65,7 +66,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 	initVersion := table.Tables["default"].Version
 
 	// Start a workflow client which will register workflow actor types.
-	client := dworkflow.NewClient(w.actors.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(w.actors.GRPCConn(t, ctx), logger.New(t))
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/single/actors.go
+++ b/tests/integration/suite/daprd/placement/single/actors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -68,7 +69,7 @@ func (a *actors) Run(t *testing.T, ctx context.Context) {
 
 	assert.Equal(t, expTable, a.actors.Placement().PlacementTables(t, ctx))
 
-	client := dworkflow.NewClient(a.actors.Daprd().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(a.actors.Daprd().GRPCConn(t, ctx), logger.New(t))
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/placement/single/workflow.go
+++ b/tests/integration/suite/daprd/placement/single/workflow.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	dactors "github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -68,7 +69,7 @@ func (w *workflow) Run(t *testing.T, ctx context.Context) {
 
 	assert.Equal(t, expTable, w.actors.Placement().PlacementTables(t, ctx))
 
-	client := dworkflow.NewClient(w.actors.Daprd().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(w.actors.Daprd().GRPCConn(t, ctx), logger.New(t))
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 	require.NoError(t, client.StartWorker(cctx, dworkflow.NewRegistry()))

--- a/tests/integration/suite/daprd/workflow/attestation/activity.go
+++ b/tests/integration/suite/daprd/workflow/attestation/activity.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -94,7 +95,7 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 		return in + "!", nil
 	})
 
-	client := dworkflow.NewClient(a.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(a.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-activity")

--- a/tests/integration/suite/daprd/workflow/attestation/childworkflow.go
+++ b/tests/integration/suite/daprd/workflow/attestation/childworkflow.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -94,7 +95,7 @@ func (c *childworkflow) Run(t *testing.T, ctx context.Context) {
 		return in + "-pong", nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-parent")

--- a/tests/integration/suite/daprd/workflow/attestation/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/attestation/continueasnew.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -97,7 +98,7 @@ func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-can", dworkflow.WithInput(1))

--- a/tests/integration/suite/daprd/workflow/attestation/dedup.go
+++ b/tests/integration/suite/daprd/workflow/attestation/dedup.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -91,7 +92,7 @@ func (d *dedup) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(d.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(d.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-dedup")

--- a/tests/integration/suite/daprd/workflow/attestation/failedactivity.go
+++ b/tests/integration/suite/daprd/workflow/attestation/failedactivity.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (f *failedactivity) Run(t *testing.T, ctx context.Context) {
 		return nil, errors.New("activity blew up on purpose")
 	})
 
-	client := dworkflow.NewClient(f.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(f.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-fail-activity-wf")

--- a/tests/integration/suite/daprd/workflow/attestation/failedchild.go
+++ b/tests/integration/suite/daprd/workflow/attestation/failedchild.go
@@ -23,6 +23,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (f *failedchild) Run(t *testing.T, ctx context.Context) {
 		return nil, errors.New("child blew up on purpose")
 	})
 
-	client := dworkflow.NewClient(f.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(f.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-fail-parent")

--- a/tests/integration/suite/daprd/workflow/attestation/multiapp.go
+++ b/tests/integration/suite/daprd/workflow/attestation/multiapp.go
@@ -25,6 +25,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -117,10 +118,10 @@ func (m *multiapp) Run(t *testing.T, ctx context.Context) {
 		return "from-child-app", nil
 	})
 
-	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, regParent))
 
-	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(m.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, regChild))
 
 	id, err := client1.ScheduleWorkflow(ctx, "attest-xapp-parent")

--- a/tests/integration/suite/daprd/workflow/attestation/purge.go
+++ b/tests/integration/suite/daprd/workflow/attestation/purge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -87,7 +88,7 @@ func (p *purge) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(p.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(p.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "attest-purge")

--- a/tests/integration/suite/daprd/workflow/basic/child.go
+++ b/tests/integration/suite/daprd/workflow/basic/child.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -91,7 +91,7 @@ func (c *child) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	c.grpcClient = runtimev1pb.NewDaprClient(conn)
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	t.Run("child workflow", func(t *testing.T) {
 		r := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/workflow/basic/purge.go
+++ b/tests/integration/suite/daprd/workflow/basic/purge.go
@@ -30,13 +30,13 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -93,7 +93,7 @@ func (p *purge) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	p.grpcClient = runtimev1pb.NewDaprClient(conn)
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	t.Run("purge", func(t *testing.T) {
 		r := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/workflow/basic/single.go
+++ b/tests/integration/suite/daprd/workflow/basic/single.go
@@ -28,13 +28,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -91,7 +91,7 @@ func (s *single) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	s.grpcClient = runtimev1pb.NewDaprClient(conn)
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	t.Run("basic", func(t *testing.T) {
 		r := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/workflow/basic/specialchars.go
+++ b/tests/integration/suite/daprd/workflow/basic/specialchars.go
@@ -25,11 +25,11 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -102,7 +102,7 @@ func (s *specialchars) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
 	require.NoError(t, backendClient.StartWorkItemListener(taskhubCtx, r))

--- a/tests/integration/suite/daprd/workflow/basic/terminate.go
+++ b/tests/integration/suite/daprd/workflow/basic/terminate.go
@@ -32,13 +32,13 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 
 	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fclient "github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
@@ -98,7 +98,7 @@ func (tt *terminate) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { require.NoError(t, conn.Close()) })
 	tt.grpcClient = runtimev1pb.NewDaprClient(conn)
 
-	backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 	t.Run("terminate", func(t *testing.T) {
 		delayTime := 30 * time.Second

--- a/tests/integration/suite/daprd/workflow/crossapp/activity/appdown.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/activity/appdown.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -131,8 +131,8 @@ func (a *appdown) Run(t *testing.T, ctx context.Context) {
 	a.daprd2.Run(t, daprd2Ctx)
 	a.daprd2.WaitUntilRunning(t, daprd2Ctx)
 
-	client1 := client.NewTaskHubGrpcClient(a.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	client2 := client.NewTaskHubGrpcClient(a.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(a.daprd1.GRPCConn(t, ctx), logger.New(t))
+	client2 := client.NewTaskHubGrpcClient(a.daprd2.GRPCConn(t, ctx), logger.New(t))
 
 	// Start listeners for each app
 	err := client1.StartWorkItemListener(t.Context(), a.registry1)

--- a/tests/integration/suite/daprd/workflow/crossapp/activity/restart.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/activity/restart.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -32,7 +33,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -143,8 +143,8 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(t.Context(), r.registry1))
 
 	cctx, ccancel := context.WithCancel(t.Context())
@@ -177,7 +177,7 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 		daprd3.Cleanup(t)
 	})
 
-	client2Restart := client.NewTaskHubGrpcClient(daprd3.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2Restart := client.NewTaskHubGrpcClient(daprd3.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2Restart.StartWorkItemListener(ctx, r.registry2))
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, int32(2), r.inActivity.Load())

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/inboxpreserved.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/inboxpreserved.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -30,7 +31,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -113,7 +113,7 @@ func (p *inboxpreserved) Run(t *testing.T, ctx context.Context) {
 	p.place.WaitUntilRunning(t, ctx)
 	p.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(p.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(p.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, p.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "ParentWorkflow",
@@ -145,7 +145,7 @@ func (p *inboxpreserved) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { p.daprd2.Cleanup(t) })
 	p.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(p.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(p.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, p.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/localthenremote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/localthenremote.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -125,7 +125,7 @@ func (l *localthenremote) Run(t *testing.T, ctx context.Context) {
 	l.place.WaitUntilRunning(t, ctx)
 	l.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(l.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(l.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, l.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "ParentWorkflow", api.WithInput("hello"))
@@ -139,7 +139,7 @@ func (l *localthenremote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { l.daprd2.Cleanup(t) })
 	l.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(l.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(l.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, l.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/multiremote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/multiremote.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -134,10 +134,10 @@ func (m *multiremote) Run(t *testing.T, ctx context.Context) {
 	m.daprd1.WaitUntilRunning(t, ctx)
 	m.daprd2.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(m.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, m.registry1))
 
-	client2 := client.NewTaskHubGrpcClient(m.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(m.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, m.registry2))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "ParentWorkflow", api.WithInput("hello"))
@@ -151,7 +151,7 @@ func (m *multiremote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { m.daprd3.Cleanup(t) })
 	m.daprd3.WaitUntilRunning(t, ctx)
 
-	client3 := client.NewTaskHubGrpcClient(m.daprd3.GRPCConn(t, ctx), backend.DefaultLogger())
+	client3 := client.NewTaskHubGrpcClient(m.daprd3.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client3.StartWorkItemListener(ctx, m.registry3))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remote.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -105,7 +105,7 @@ func (r *remote) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "ParentWorkflow", api.WithInput("hello"))
@@ -119,7 +119,7 @@ func (r *remote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remotethenlocal.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remotethenlocal.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -125,7 +125,7 @@ func (r *remotethenlocal) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "ParentWorkflow", api.WithInput("hello"))
@@ -139,7 +139,7 @@ func (r *remotethenlocal) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remotewithtimer.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/childwf/remotewithtimer.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -111,7 +111,7 @@ func (r *remotewithtimer) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "TimerThenChildWorkflow", api.WithInput("hello"))
@@ -125,7 +125,7 @@ func (r *remotewithtimer) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/inboxpreserved.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/inboxpreserved.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -30,7 +31,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -117,7 +117,7 @@ func (p *inboxpreserved) Run(t *testing.T, ctx context.Context) {
 	p.place.WaitUntilRunning(t, ctx)
 	p.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(p.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(p.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, p.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "InboxPreservedWorkflow",
@@ -157,7 +157,7 @@ func (p *inboxpreserved) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { p.daprd2.Cleanup(t) })
 	p.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(p.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(p.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, p.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/localthenremote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/localthenremote.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -129,7 +129,7 @@ func (l *localthenremote) Run(t *testing.T, ctx context.Context) {
 	l.place.WaitUntilRunning(t, ctx)
 	l.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(l.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(l.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, l.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "LocalThenRemoteWorkflow", api.WithInput("hello"))
@@ -143,7 +143,7 @@ func (l *localthenremote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { l.daprd2.Cleanup(t) })
 	l.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(l.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(l.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, l.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/multiremote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/multiremote.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -137,10 +137,10 @@ func (m *multiremote) Run(t *testing.T, ctx context.Context) {
 	m.daprd1.WaitUntilRunning(t, ctx)
 	m.daprd2.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(m.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, m.registry1))
 
-	client2 := client.NewTaskHubGrpcClient(m.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(m.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, m.registry2))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "MultiRemoteWorkflow", api.WithInput("hello"))
@@ -154,7 +154,7 @@ func (m *multiremote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { m.daprd3.Cleanup(t) })
 	m.daprd3.WaitUntilRunning(t, ctx)
 
-	client3 := client.NewTaskHubGrpcClient(m.daprd3.GRPCConn(t, ctx), backend.DefaultLogger())
+	client3 := client.NewTaskHubGrpcClient(m.daprd3.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client3.StartWorkItemListener(ctx, m.registry3))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/remote.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/remote.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -105,7 +105,7 @@ func (r *remote) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "RemoteFirstWorkflow", api.WithInput("hello"))
@@ -119,7 +119,7 @@ func (r *remote) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/remotethenlocal.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/remotethenlocal.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -125,7 +125,7 @@ func (r *remotethenlocal) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "RemoteThenLocalWorkflow", api.WithInput("hello"))
@@ -139,7 +139,7 @@ func (r *remotethenlocal) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/pending/remotewithtimer.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/pending/remotewithtimer.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -111,7 +111,7 @@ func (r *remotewithtimer) Run(t *testing.T, ctx context.Context) {
 	r.place.WaitUntilRunning(t, ctx)
 	r.daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r.registry1))
 
 	id, err := client1.ScheduleNewWorkflow(ctx, "TimerThenRemoteWorkflow", api.WithInput("hello"))
@@ -125,7 +125,7 @@ func (r *remotewithtimer) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { r.daprd2.Cleanup(t) })
 	r.daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, r.registry2))
 
 	metadata, err = client1.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))

--- a/tests/integration/suite/daprd/workflow/crossapp/resultreminder/orphan.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/resultreminder/orphan.go
@@ -25,11 +25,11 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -99,9 +99,9 @@ func (o *orphan) Run(t *testing.T, ctx context.Context) {
 		return "done", nil
 	}))
 
-	clientA := client.NewTaskHubGrpcClient(daprdA.GRPCConn(t, ctx), backend.DefaultLogger())
+	clientA := client.NewTaskHubGrpcClient(daprdA.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, clientA.StartWorkItemListener(ctx, regA))
-	clientB := client.NewTaskHubGrpcClient(daprdB.GRPCConn(t, ctx), backend.DefaultLogger())
+	clientB := client.NewTaskHubGrpcClient(daprdB.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, clientB.StartWorkItemListener(ctx, regB))
 
 	_, err := daprdA.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -140,7 +140,7 @@ func (o *orphan) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { daprdA2.Cleanup(t) })
 	daprdA2.WaitUntilRunning(t, ctx)
 
-	clientA2 := client.NewTaskHubGrpcClient(daprdA2.GRPCConn(t, ctx), backend.DefaultLogger())
+	clientA2 := client.NewTaskHubGrpcClient(daprdA2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, clientA2.StartWorkItemListener(ctx, regA))
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/tests/integration/suite/daprd/workflow/crossapp/resultreminder/reconnect.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/resultreminder/reconnect.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
@@ -70,8 +71,8 @@ func (r *reconnect) Run(t *testing.T, ctx context.Context) {
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	client1 := dworkflow.NewClient(r.workflow.DaprN(0).GRPCConn(t, cctx))
-	client2 := dworkflow.NewClient(r.workflow.DaprN(1).GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(r.workflow.DaprN(0).GRPCConn(t, cctx), logger.New(t))
+	client2 := dworkflow.NewClientWithLogger(r.workflow.DaprN(1).GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(cctx, reg1))
 	require.NoError(t, client2.StartWorker(ctx, reg2))
 
@@ -93,7 +94,7 @@ func (r *reconnect) Run(t *testing.T, ctx context.Context) {
 		assert.Truef(c, strings.HasPrefix(list[0], exp), "reminder key should have correct prefid, expected prefix: %s, actual key: %s", exp, list[0])
 	}, time.Second*10, time.Millisecond*10)
 
-	client1 = dworkflow.NewClient(r.workflow.DaprN(0).GRPCConn(t, ctx))
+	client1 = dworkflow.NewClientWithLogger(r.workflow.DaprN(0).GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg1))
 
 	meta, err := client1.WaitForWorkflowCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/crossapp/resultreminder/restart.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/resultreminder/restart.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
@@ -70,8 +71,8 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 	cctx, cancel := context.WithCancel(ctx)
 	t.Cleanup(cancel)
 
-	client1 := dworkflow.NewClient(r.workflow.DaprN(0).GRPCConn(t, cctx))
-	client2 := dworkflow.NewClient(r.workflow.DaprN(1).GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(r.workflow.DaprN(0).GRPCConn(t, cctx), logger.New(t))
+	client2 := dworkflow.NewClientWithLogger(r.workflow.DaprN(1).GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(cctx, reg1))
 	require.NoError(t, client2.StartWorker(ctx, reg2))
 
@@ -103,7 +104,7 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 
 	r.workflow.DaprN(0).Restart(t, ctx)
 
-	client1 = dworkflow.NewClient(r.workflow.DaprN(0).GRPCConn(t, ctx))
+	client1 = dworkflow.NewClientWithLogger(r.workflow.DaprN(0).GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg1))
 
 	meta, err := client1.WaitForWorkflowCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/appdown.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/appdown.go
@@ -23,13 +23,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -135,8 +135,8 @@ func (a *appdown) Run(t *testing.T, ctx context.Context) {
 	a.daprd2.Run(t, daprd2Ctx)
 	a.daprd2.WaitUntilRunning(t, daprd2Ctx)
 
-	client1 := client.NewTaskHubGrpcClient(a.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	client2 := client.NewTaskHubGrpcClient(a.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(a.daprd1.GRPCConn(t, ctx), logger.New(t))
+	client2 := client.NewTaskHubGrpcClient(a.daprd2.GRPCConn(t, ctx), logger.New(t))
 
 	// Start listeners for each app
 	err := client1.StartWorkItemListener(t.Context(), a.registry1)

--- a/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/restart.go
+++ b/tests/integration/suite/daprd/workflow/crossapp/suborchestrator/restart.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -32,7 +33,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -147,8 +147,8 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 	r.daprd2.WaitUntilRunning(t, ctx)
 
 	// Start workflow listeners for each app
-	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(r.daprd1.GRPCConn(t, ctx), logger.New(t))
+	client2 := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(t.Context(), r.registry1))
 	cctx, ccancel := context.WithCancel(t.Context())
 	t.Cleanup(ccancel)
@@ -192,7 +192,7 @@ func (r *restart) Run(t *testing.T, ctx context.Context) {
 	})
 
 	// Restart the listener for app2 & ensure wf completion
-	client2Restart := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2Restart := client.NewTaskHubGrpcClient(r.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2Restart.StartWorkItemListener(ctx, r.registry2))
 	close(r.suborchestratorReady)
 

--- a/tests/integration/suite/daprd/workflow/delstate.go
+++ b/tests/integration/suite/daprd/workflow/delstate.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -79,7 +80,7 @@ func (d *delstate) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	cl := workflow.NewClient(d.daprd1.GRPCConn(t, ctx))
+	cl := workflow.NewClientWithLogger(d.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorker(ctx, reg))
 	_, err := cl.ScheduleWorkflow(ctx, "foo")
 	require.NoError(t, err)
@@ -95,7 +96,7 @@ func (d *delstate) Run(t *testing.T, ctx context.Context) {
 		d.daprd2.Kill(t)
 	})
 
-	cl = workflow.NewClient(d.daprd2.GRPCConn(t, ctx))
+	cl = workflow.NewClientWithLogger(d.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorker(ctx, reg))
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/tests/integration/suite/daprd/workflow/detached/signing.go
+++ b/tests/integration/suite/daprd/workflow/detached/signing.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -99,7 +100,7 @@ func (s *signing) Run(t *testing.T, ctx context.Context) {
 		return "spawned-saw:" + input, nil
 	})
 
-	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(s.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	parentID, err := client.ScheduleWorkflow(ctx, "Caller")

--- a/tests/integration/suite/daprd/workflow/listener/crud.go
+++ b/tests/integration/suite/daprd/workflow/listener/crud.go
@@ -22,12 +22,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -80,10 +80,10 @@ func (c *crud) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client1 := client.NewTaskHubGrpcClient(c.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(c.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r))
 
-	client2 := client.NewTaskHubGrpcClient(c.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(c.daprd2.GRPCConn(t, ctx), logger.New(t))
 
 	_, err := client2.FetchWorkflowMetadata(ctx, "foobar")
 	require.Error(t, err)

--- a/tests/integration/suite/daprd/workflow/listener/multi.go
+++ b/tests/integration/suite/daprd/workflow/listener/multi.go
@@ -25,12 +25,12 @@ import (
 	"google.golang.org/grpc/credentials/insecure"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -92,7 +92,7 @@ func (m *multi) Run(t *testing.T, ctx context.Context) {
 				}
 
 				t.Cleanup(func() { require.NoError(t, conn.Close()) })
-				backendClient := client.NewTaskHubGrpcClient(conn, backend.DefaultLogger())
+				backendClient := client.NewTaskHubGrpcClient(conn, logger.New(t))
 
 				taskhubCtx, cancelTaskhub := context.WithCancel(ctx)
 				defer cancelTaskhub()

--- a/tests/integration/suite/daprd/workflow/listener/single.go
+++ b/tests/integration/suite/daprd/workflow/listener/single.go
@@ -20,12 +20,12 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -75,10 +75,10 @@ func (s *single) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client1 := client.NewTaskHubGrpcClient(s.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(s.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, r))
 
-	client2 := client.NewTaskHubGrpcClient(s.daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(s.daprd2.GRPCConn(t, ctx), logger.New(t))
 
 	id, err := client2.ScheduleNewWorkflow(ctx, "foo")
 	require.NoError(t, err)

--- a/tests/integration/suite/daprd/workflow/loadbalance/churnstrand.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/churnstrand.go
@@ -29,10 +29,10 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fgrpc "github.com/dapr/dapr/tests/integration/framework/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -145,7 +145,7 @@ func (c *churnstrand) Run(t *testing.T, ctx context.Context) {
 		conns := dialAll()
 		lctx, lcancel := context.WithCancel(ctx)
 		cl := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t,
-			conns[0], conns[1], conns[2]), backend.DefaultLogger())
+			conns[0], conns[1], conns[2]), logger.New(t))
 		require.NoError(t, cl.StartWorkItemListener(lctx, newRegistry()))
 		wait := time.Millisecond * 300
 		if cycle%2 == 0 {
@@ -179,7 +179,7 @@ func (c *churnstrand) Run(t *testing.T, ctx context.Context) {
 		}
 	})
 	cl := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t,
-		conns[0], conns[1], conns[2]), backend.DefaultLogger())
+		conns[0], conns[1], conns[2]), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, newRegistry()))
 
 	// Sweep with whatever remains of the suite context, leaving grace for a

--- a/tests/integration/suite/daprd/workflow/loadbalance/handoffstrand.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/handoffstrand.go
@@ -29,10 +29,10 @@ import (
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	fgrpc "github.com/dapr/dapr/tests/integration/framework/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -143,7 +143,7 @@ func (h *handoffstrand) Run(t *testing.T, ctx context.Context) {
 	conns1 := dialAll()
 	lctx, lcancel := context.WithCancel(ctx)
 	cl1 := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t,
-		conns1[0], conns1[1], conns1[2]), backend.DefaultLogger())
+		conns1[0], conns1[1], conns1[2]), logger.New(t))
 	require.NoError(t, cl1.StartWorkItemListener(lctx, newRegistry()))
 	waitForCohort(15)
 
@@ -161,7 +161,7 @@ func (h *handoffstrand) Run(t *testing.T, ctx context.Context) {
 		}
 	})
 	cl2 := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t,
-		conns2[0], conns2[1], conns2[2]), backend.DefaultLogger())
+		conns2[0], conns2[1], conns2[2]), logger.New(t))
 	require.NoError(t, cl2.StartWorkItemListener(ctx, newRegistry()))
 
 	mu.Lock()

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalecompletion.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalecompletion.go
@@ -24,12 +24,12 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -99,7 +99,7 @@ func (s *stalecompletion) Run(t *testing.T, ctx context.Context) {
 		return "ok", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(s.workflow.DaprN(0).GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(s.workflow.DaprN(0).GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	resp, err := s.workflow.DaprN(0).GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/multidapr.go
+++ b/tests/integration/suite/daprd/workflow/multidapr.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -81,7 +81,7 @@ func (m *multidapr) Run(t *testing.T, ctx context.Context) {
 
 	d := m.daprds[0] // use the first Dapr instance to call
 
-	backendClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("schedule_workflow_with_multidaprple_daprd_instances", func(t *testing.T) {
 		r := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/workflow/order.go
+++ b/tests/integration/suite/daprd/workflow/order.go
@@ -22,13 +22,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -71,8 +71,8 @@ func (o *order) Run(t *testing.T, ctx context.Context) {
 	o.daprd1.WaitUntilRunning(t, ctx)
 	o.daprd2.WaitUntilRunning(t, ctx)
 
-	backendClient1 := client.NewTaskHubGrpcClient(o.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	backendClient2 := client.NewTaskHubGrpcClient(o.daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient1 := client.NewTaskHubGrpcClient(o.daprd1.GRPCConn(t, ctx), logger.New(t))
+	backendClient2 := client.NewTaskHubGrpcClient(o.daprd1.GRPCConn(t, ctx), logger.New(t))
 
 	t.Run("schedule_workflow_before_worker_connected", func(t *testing.T) {
 		r := task.NewTaskRegistry()

--- a/tests/integration/suite/daprd/workflow/parallel.go
+++ b/tests/integration/suite/daprd/workflow/parallel.go
@@ -25,13 +25,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -94,7 +94,7 @@ func (p *parallel) Run(t *testing.T, ctx context.Context) {
 			return nil, nil
 		}))
 
-		backendClient := client.NewTaskHubGrpcClient(daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+		backendClient := client.NewTaskHubGrpcClient(daprd.GRPCConn(t, ctx), logger.New(t))
 		require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 		resp, err := daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
 			WorkflowComponent: "dapr",

--- a/tests/integration/suite/daprd/workflow/purge/force/newreplica.go
+++ b/tests/integration/suite/daprd/workflow/purge/force/newreplica.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -76,7 +77,7 @@ func (n *newreplica) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(n.daprd1.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(n.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "purge")
@@ -98,7 +99,7 @@ func (n *newreplica) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 	assert.Positive(t, count)
 
-	client = dworkflow.NewClient(n.daprd2.GRPCConn(t, ctx))
+	client = dworkflow.NewClientWithLogger(n.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.PurgeWorkflowState(ctx, id, dworkflow.WithForcePurge(true)))
 
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/base.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/base.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -66,7 +67,7 @@ func (b *base) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(b.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(b.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	_, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/completed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/completed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -67,7 +68,7 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(e.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/failed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/failed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -67,7 +68,7 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(f.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(f.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/high.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/high.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -66,7 +67,7 @@ func (h *high) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(h.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(h.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/idempotent.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/idempotent.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -77,7 +78,7 @@ func (i *idempotent) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(i.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(i.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/manually.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/manually.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -66,7 +67,7 @@ func (m *manually) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(m.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(m.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/completed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/completed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -77,7 +78,7 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 		return nil, errors.New("this is an error")
 	})
 
-	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(e.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	t.Run("completed", func(t *testing.T) {

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/failed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/failed.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -73,7 +74,7 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(f.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(f.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	t.Run("failed", func(t *testing.T) {

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/terminated.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/terminated.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -76,7 +77,7 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(e.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	t.Run("terminated", func(t *testing.T) {

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
@@ -23,6 +23,7 @@ import (
 
 	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -67,7 +68,7 @@ func (n *notexists) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(n.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(n.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/customstatus.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/customstatus.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/components-contrib/state"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
@@ -107,7 +108,7 @@ func (c *customstatus) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	const instanceID = "customstatus-instance"

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/propagatedhistory.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/optionalkeys/propagatedhistory.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
@@ -102,7 +103,7 @@ func (p *propagatedhistory) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(p.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(p.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	const instanceID = "propagatedhistory-instance"

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/retentionstuck.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/retentionstuck.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -64,7 +65,7 @@ func (r *retentionstuck) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(r.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(r.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	const instanceID = "retentionstuck-claim-eval"

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/retentionstuckstalled.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/retentionstuckstalled.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -84,7 +85,7 @@ func (r *retentionstuckstalled) Run(t *testing.T, ctx context.Context) {
 		return chunk, nil
 	}))
 
-	client := dworkflow.NewClient(r.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(r.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	const instanceID = "retentionstuckstalled-claim-eval"

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/terminated.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/terminated.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -63,7 +64,7 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(e.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/zero.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/zero.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -66,7 +67,7 @@ func (z *zero) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(z.workflow.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(z.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	_, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/purge/retention/kubernetes/kubernetes.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/kubernetes/kubernetes.go
@@ -26,6 +26,7 @@ import (
 	compapi "github.com/dapr/dapr/pkg/apis/components/v1alpha1"
 	configapi "github.com/dapr/dapr/pkg/apis/configuration/v1alpha1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/manifest"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/kubernetes"
@@ -129,7 +130,7 @@ func (b *base) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(b.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(b.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/raise.go
+++ b/tests/integration/suite/daprd/workflow/raise.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -89,7 +89,7 @@ func (r *raise) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
 
 	resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/basic.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -90,7 +90,7 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := a.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/longrun.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/longrun.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -31,7 +32,6 @@ import (
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -85,7 +85,7 @@ func (a *longrun) Run(t *testing.T, ctx context.Context) {
 		return "slow-done", nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := a.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/mixed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/mixed.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -31,7 +32,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -108,7 +108,7 @@ func (a *mixed) Run(t *testing.T, ctx context.Context) {
 	daprd1.Run(t, ctx)
 	daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, registry1))
 
 	resp, err := daprd1.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -143,7 +143,7 @@ func (a *mixed) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, registry2))
 
 	wctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/restart.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/restart.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -31,7 +32,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -105,7 +105,7 @@ func (a *restart) Run(t *testing.T, ctx context.Context) {
 	daprd1.Run(t, ctx)
 	daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, registry1))
 
 	resp, err := daprd1.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -142,7 +142,7 @@ func (a *restart) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, registry2))
 
 	wctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/streamloss.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/streamloss.go
@@ -26,6 +26,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -33,7 +34,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -115,7 +115,7 @@ func (a *streamloss) Run(t *testing.T, ctx context.Context) {
 
 	lctx, lcancel := context.WithCancel(ctx)
 	t.Cleanup(lcancel)
-	client1 := client.NewTaskHubGrpcClient(conn1, backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(conn1, logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(lctx, newRegistry(func(task.ActivityContext) (any, error) {
 		select {
 		case started <- struct{}{}:
@@ -153,7 +153,7 @@ func (a *streamloss) Run(t *testing.T, ctx context.Context) {
 
 	conn2 := dial()
 	t.Cleanup(func() { _ = conn2.Close() })
-	client2 := client.NewTaskHubGrpcClient(conn2, backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(conn2, logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, newRegistry(func(task.ActivityContext) (any, error) {
 		return "recovered", nil
 	})))

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2rescue.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2rescue.go
@@ -25,6 +25,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -32,7 +33,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -93,7 +93,7 @@ func (a *activityv2rescue) Run(t *testing.T, ctx context.Context) {
 		return "rescued", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(a.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	resp, err := a.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/deletereminder.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -92,7 +92,7 @@ func (d *deletereminder) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(d.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(d.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := d.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/canchild.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/canchild.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -29,7 +30,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -110,7 +110,7 @@ func (c *canchild) Run(t *testing.T, ctx context.Context) {
 		return childResult, nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(c.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	id, err := cl.ScheduleNewWorkflow(ctx, "loop",

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/captive.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/captive.go
@@ -23,6 +23,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -30,7 +31,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -91,7 +91,7 @@ func (f *captive) Run(t *testing.T, ctx context.Context) {
 		return "ok", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	resp, err := f.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/payloadfanin.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/payloadfanin.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -29,7 +30,6 @@ import (
 	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api/protos"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -105,7 +105,7 @@ func (p *payloadfanin) Run(t *testing.T, ctx context.Context) {
 		return chunk, nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(p.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(p.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	id, err := cl.ScheduleNewWorkflow(ctx, "fanin")

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/restart.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/restart.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -31,7 +32,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -105,7 +105,7 @@ func (f *restart) Run(t *testing.T, ctx context.Context) {
 	daprd1.Run(t, ctx)
 	daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, registry1))
 
 	resp, err := daprd1.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -139,7 +139,7 @@ func (f *restart) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, registry2))
 
 	wctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/senderlapse.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/senderlapse.go
@@ -23,6 +23,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -30,7 +31,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -90,7 +90,7 @@ func (f *senderlapse) Run(t *testing.T, ctx context.Context) {
 		return "ok", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	resp, err := f.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/v2.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/v2.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -90,7 +90,7 @@ func (f *v2) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(f.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := f.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/localwake/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/localwake/basic.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -91,7 +91,7 @@ func (l *basic) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(l.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(l.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := l.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -163,7 +163,7 @@ func (l *localwakeoff) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(l.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(l.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := l.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/pendingstartretry.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/pendingstartretry.go
@@ -23,13 +23,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -74,7 +74,7 @@ func (p *pendingstartretry) Run(t *testing.T, ctx context.Context) {
 		return "Hello, " + input + "!", nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(p.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(p.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	const instanceID = "pending-start-retry"

--- a/tests/integration/suite/daprd/workflow/scheduler/raise.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/raise.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -31,7 +32,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -88,7 +88,7 @@ func (r *raise) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
 
 	resp, err := gclient.StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/reapresume.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/reapresume.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -31,7 +32,6 @@ import (
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -85,7 +85,7 @@ func (r *reapresume) Run(t *testing.T, ctx context.Context) {
 		return "resumed-" + out, nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
 
 	resp, err := r.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/redispatchlost.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/redispatchlost.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -31,7 +32,6 @@ import (
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -104,7 +104,7 @@ func (r *redispatchlost) Run(t *testing.T, ctx context.Context) {
 		return "ok", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
 
 	resp, err := r.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/residencychurn.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/residencychurn.go
@@ -25,13 +25,13 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -91,7 +91,7 @@ func (r *residencychurn) Run(t *testing.T, ctx context.Context) {
 		return in + "-done", nil
 	}))
 
-	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, cl.StartWorkItemListener(ctx, reg))
 
 	const total = 60

--- a/tests/integration/suite/daprd/workflow/scheduler/startelide.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/startelide.go
@@ -23,6 +23,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
@@ -30,7 +31,6 @@ import (
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -96,7 +96,7 @@ func (s *startelide) Run(t *testing.T, ctx context.Context) {
 		return "spun", nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
 
 	triggered := func() int {

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/basic.go
@@ -24,13 +24,13 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -86,7 +86,7 @@ func (w *basic) Run(t *testing.T, ctx context.Context) {
 		return fmt.Sprintf("Hello, %s!", inp), nil
 	}))
 
-	backendClient := client.NewTaskHubGrpcClient(w.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	backendClient := client.NewTaskHubGrpcClient(w.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, r))
 
 	resp, err := w.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
@@ -24,6 +24,7 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -31,7 +32,6 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
@@ -102,7 +102,7 @@ func (w *restart) Run(t *testing.T, ctx context.Context) {
 	daprd1.Run(t, ctx)
 	daprd1.WaitUntilRunning(t, ctx)
 
-	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
+	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorkItemListener(ctx, registry1))
 
 	resp, err := daprd1.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
@@ -131,7 +131,7 @@ func (w *restart) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), backend.DefaultLogger())
+	client2 := client.NewTaskHubGrpcClient(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorkItemListener(ctx, registry))
 
 	wctx, cancel := context.WithTimeout(ctx, time.Minute)

--- a/tests/integration/suite/daprd/workflow/signing/activity.go
+++ b/tests/integration/suite/daprd/workflow/signing/activity.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(a.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(a.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-activity")

--- a/tests/integration/suite/daprd/workflow/signing/basic.go
+++ b/tests/integration/suite/daprd/workflow/signing/basic.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -82,7 +83,7 @@ func (b *basic) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(b.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(b.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-basic")

--- a/tests/integration/suite/daprd/workflow/signing/certexpiry.go
+++ b/tests/integration/suite/daprd/workflow/signing/certexpiry.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -110,7 +111,7 @@ func (c *certexpiry) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-certexpiry")

--- a/tests/integration/suite/daprd/workflow/signing/certrotation.go
+++ b/tests/integration/suite/daprd/workflow/signing/certrotation.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (c *certrotation) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-certrot")
@@ -104,7 +105,7 @@ func (c *certrotation) Run(t *testing.T, ctx context.Context) {
 	c.daprd.Restart(t, ctx)
 	c.daprd.WaitUntilRunning(t, ctx)
 
-	client = dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client = dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	require.NoError(t, client.RaiseEvent(ctx, id, "continue"))

--- a/tests/integration/suite/daprd/workflow/signing/childinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/childinjection.go
@@ -27,6 +27,7 @@ import (
 
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -106,7 +107,7 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 		return "child-done", nil
 	})
 
-	client := dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(i.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-child-inject-parent")
@@ -154,7 +155,7 @@ func (i *childInjection) Run(tt *testing.T, ctx context.Context) {
 	i.daprd.Restart(tt, ctx)
 	i.daprd.WaitUntilRunning(tt, ctx)
 
-	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	client = dworkflow.NewClientWithLogger(i.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	// Inbox injection is treated as state store tampering: the next operation

--- a/tests/integration/suite/daprd/workflow/signing/childworkflow.go
+++ b/tests/integration/suite/daprd/workflow/signing/childworkflow.go
@@ -20,6 +20,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -95,7 +96,7 @@ func (c *childworkflow) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-parent")

--- a/tests/integration/suite/daprd/workflow/signing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/signing/continueasnew.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -92,7 +93,7 @@ func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-can", dworkflow.WithInput(1))

--- a/tests/integration/suite/daprd/workflow/signing/disabled.go
+++ b/tests/integration/suite/daprd/workflow/signing/disabled.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -83,7 +84,7 @@ func (d *disabled) Run(tt *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(d.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(d.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-disabled")

--- a/tests/integration/suite/daprd/workflow/signing/enablesigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/enablesigning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -85,7 +86,7 @@ func (e *enablesigning) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client1 := dworkflow.NewClient(e.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(e.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg))
 
 	id, err := client1.ScheduleWorkflow(ctx, "sign-enable")
@@ -117,7 +118,7 @@ spec:
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := dworkflow.NewClient(daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, reg))
 
 	// The workflow should fail to load because the unsigned history

--- a/tests/integration/suite/daprd/workflow/signing/externalevent.go
+++ b/tests/integration/suite/daprd/workflow/signing/externalevent.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -86,7 +87,7 @@ func (e *externalevent) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(e.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(e.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-event")

--- a/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
+++ b/tests/integration/suite/daprd/workflow/signing/inboxinjection.go
@@ -27,6 +27,7 @@ import (
 
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -106,7 +107,7 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(i.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-inbox-inject")
@@ -153,7 +154,7 @@ func (i *inboxInjection) Run(tt *testing.T, ctx context.Context) {
 	i.daprd.Restart(tt, ctx)
 	i.daprd.WaitUntilRunning(tt, ctx)
 
-	client = dworkflow.NewClient(i.daprd.GRPCConn(tt, ctx))
+	client = dworkflow.NewClientWithLogger(i.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	// Inbox injection is treated as state store tampering: the next operation

--- a/tests/integration/suite/daprd/workflow/signing/largepayload.go
+++ b/tests/integration/suite/daprd/workflow/signing/largepayload.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -91,7 +92,7 @@ func (l *largepayload) Run(tt *testing.T, ctx context.Context) {
 		return strings.Repeat("x", 100000), nil
 	})
 
-	client := dworkflow.NewClient(l.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(l.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-large")

--- a/tests/integration/suite/daprd/workflow/signing/multiactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiactivity.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -96,7 +97,7 @@ func (m *multiactivity) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(m.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(m.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-multi")

--- a/tests/integration/suite/daprd/workflow/signing/multiapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiapp.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -115,10 +116,10 @@ func (m *multiapp) Run(t *testing.T, ctx context.Context) {
 	})
 
 	// Both instances register the same workflow and activity.
-	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg))
 
-	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(m.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, reg))
 
 	// Schedule on the orchestrator instance.

--- a/tests/integration/suite/daprd/workflow/signing/multiappchild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multiappchild.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -118,10 +119,10 @@ func (m *multiappchild) Run(t *testing.T, ctx context.Context) {
 
 	// daprd1 runs the orchestrator; daprd2 hosts the activity. The parent
 	// explicitly routes the activity call to daprd2 via WithActivityAppID.
-	client1 := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, regParent))
 
-	client2 := dworkflow.NewClient(m.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(m.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, regChild))
 
 	// Schedule on the parent (orchestrator) instance.

--- a/tests/integration/suite/daprd/workflow/signing/multireplica.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplica.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -117,7 +118,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(m.daprd1.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(m.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-replica")
@@ -147,7 +148,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 		t.Cleanup(func() { newDaprd.Cleanup(t) })
 		newDaprd.WaitUntilRunning(t, ctx)
 
-		newClient := dworkflow.NewClient(newDaprd.GRPCConn(t, ctx))
+		newClient := dworkflow.NewClientWithLogger(newDaprd.GRPCConn(t, ctx), logger.New(t))
 		require.NoError(t, newClient.StartWorker(ctx, reg))
 
 		require.NoError(t, newClient.RaiseEvent(ctx, id, fmt.Sprintf("event-%d", i)))
@@ -163,7 +164,7 @@ func (m *multireplica) Run(t *testing.T, ctx context.Context) {
 	}
 
 	// Wait for completion.
-	lastClient := dworkflow.NewClient(currentDaprd.GRPCConn(t, ctx))
+	lastClient := dworkflow.NewClientWithLogger(currentDaprd.GRPCConn(t, ctx), logger.New(t))
 	meta, err = lastClient.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 	assert.Equal(t, dworkflow.StatusCompleted, meta.RuntimeStatus)

--- a/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
+++ b/tests/integration/suite/daprd/workflow/signing/multireplicachild.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
@@ -117,12 +118,12 @@ func (m *multireplicachild) Run(t *testing.T, ctx context.Context) {
 
 	// Start workers on ALL replicas.
 	for i := range 3 {
-		client := dworkflow.NewClient(m.daprds[i].GRPCConn(t, ctx))
+		client := dworkflow.NewClientWithLogger(m.daprds[i].GRPCConn(t, ctx), logger.New(t))
 		require.NoError(t, client.StartWorker(ctx, reg))
 	}
 
 	// Schedule from replica 0.
-	client := dworkflow.NewClient(m.daprds[0].GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(m.daprds[0].GRPCConn(t, ctx), logger.New(t))
 	id, err := client.ScheduleWorkflow(ctx, "sign-repchild-parent")
 	require.NoError(t, err)
 

--- a/tests/integration/suite/daprd/workflow/signing/nosigning.go
+++ b/tests/integration/suite/daprd/workflow/signing/nosigning.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -68,7 +69,7 @@ func (n *nosigning) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(n.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(n.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-no-mtls")

--- a/tests/integration/suite/daprd/workflow/signing/purge.go
+++ b/tests/integration/suite/daprd/workflow/signing/purge.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -83,7 +84,7 @@ func (p *purge) Run(tt *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(p.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(p.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-purge")

--- a/tests/integration/suite/daprd/workflow/signing/restart.go
+++ b/tests/integration/suite/daprd/workflow/signing/restart.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -83,7 +84,7 @@ func (r *restart) Run(tt *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(r.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(r.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-restart")
@@ -99,7 +100,7 @@ func (r *restart) Run(tt *testing.T, ctx context.Context) {
 	r.daprd.Restart(tt, ctx)
 	r.daprd.WaitUntilRunning(tt, ctx)
 
-	client = dworkflow.NewClient(r.daprd.GRPCConn(tt, ctx))
+	client = dworkflow.NewClientWithLogger(r.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	// Verify the signature chain is still valid after restart.

--- a/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
+++ b/tests/integration/suite/daprd/workflow/signing/signaturestripped.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -118,7 +119,7 @@ func (s *signatureStripped) scheduleAndComplete(t *testing.T, ctx context.Contex
 	reg.AddWorkflowN("sign-stripped", func(ctx *dworkflow.WorkflowContext) (any, error) {
 		return "", nil
 	})
-	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(s.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-stripped")
@@ -135,7 +136,7 @@ func (s *signatureStripped) assertLoadFails(t *testing.T, ctx context.Context, i
 	s.daprd.Restart(t, ctx)
 	s.daprd.WaitUntilRunning(t, ctx)
 
-	client := dworkflow.NewClient(s.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(s.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, dworkflow.NewRegistry()))
 
 	_, err := client.FetchWorkflowMetadata(ctx, id)

--- a/tests/integration/suite/daprd/workflow/signing/signinggap.go
+++ b/tests/integration/suite/daprd/workflow/signing/signinggap.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -93,7 +94,7 @@ func (s *signinggap) Run(t *testing.T, ctx context.Context) {
 
 	appID := s.daprd1.AppID()
 
-	client1 := dworkflow.NewClient(s.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(s.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg))
 
 	id, err := client1.ScheduleWorkflow(ctx, "sign-gap")
@@ -133,7 +134,7 @@ spec:
 	t.Cleanup(func() { daprd2.Cleanup(t) })
 	daprd2.WaitUntilRunning(t, ctx)
 
-	client2 := dworkflow.NewClient(daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, reg))
 
 	// Raising an event on a signed workflow from a non-signing host should fail.

--- a/tests/integration/suite/daprd/workflow/signing/tampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/tampered.go
@@ -22,6 +22,7 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(tp.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(tp.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-tamper")
@@ -116,7 +117,7 @@ func (tp *tampered) Run(tt *testing.T, ctx context.Context) {
 	tp.daprd.Restart(tt, ctx)
 	tp.daprd.WaitUntilRunning(tt, ctx)
 
-	client = dworkflow.NewClient(tp.daprd.GRPCConn(tt, ctx))
+	client = dworkflow.NewClientWithLogger(tp.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	_, err = client.FetchWorkflowMetadata(ctx, id)

--- a/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
+++ b/tests/integration/suite/daprd/workflow/signing/tamperedrunning.go
@@ -24,6 +24,7 @@ import (
 
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -93,7 +94,7 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 		return payload, nil
 	})
 
-	client := dworkflow.NewClient(tr.daprd.GRPCConn(tt, ctx))
+	client := dworkflow.NewClientWithLogger(tr.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-tamper-running")
@@ -120,7 +121,7 @@ func (tr *tamperedrunning) Run(tt *testing.T, ctx context.Context) {
 	tr.daprd.Restart(tt, ctx)
 	tr.daprd.WaitUntilRunning(tt, ctx)
 
-	client = dworkflow.NewClient(tr.daprd.GRPCConn(tt, ctx))
+	client = dworkflow.NewClientWithLogger(tr.daprd.GRPCConn(tt, ctx), logger.New(tt))
 	require.NoError(tt, client.StartWorker(ctx, reg))
 
 	// Trigger the orchestrator actor by raising the event the workflow is

--- a/tests/integration/suite/daprd/workflow/signing/terminate.go
+++ b/tests/integration/suite/daprd/workflow/signing/terminate.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -88,7 +89,7 @@ func (tr *terminate) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(tr.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(tr.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-term")

--- a/tests/integration/suite/daprd/workflow/signing/threeapp.go
+++ b/tests/integration/suite/daprd/workflow/signing/threeapp.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -138,13 +139,13 @@ func (a *threeapp) Run(t *testing.T, ctx context.Context) {
 
 	// All three instances register the same workflow and activities so that
 	// placement can route activities across the cluster.
-	client1 := dworkflow.NewClient(a.daprd1.GRPCConn(t, ctx))
+	client1 := dworkflow.NewClientWithLogger(a.daprd1.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client1.StartWorker(ctx, reg))
 
-	client2 := dworkflow.NewClient(a.daprd2.GRPCConn(t, ctx))
+	client2 := dworkflow.NewClientWithLogger(a.daprd2.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client2.StartWorker(ctx, reg))
 
-	client3 := dworkflow.NewClient(a.daprd3.GRPCConn(t, ctx))
+	client3 := dworkflow.NewClientWithLogger(a.daprd3.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client3.StartWorker(ctx, reg))
 
 	// Schedule on the orchestrator instance (app A).

--- a/tests/integration/suite/daprd/workflow/signing/timer.go
+++ b/tests/integration/suite/daprd/workflow/signing/timer.go
@@ -21,6 +21,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
@@ -86,7 +87,7 @@ func (m *timer) Run(t *testing.T, ctx context.Context) {
 		return "", nil
 	})
 
-	client := dworkflow.NewClient(m.daprd.GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(m.daprd.GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "sign-timer")

--- a/tests/integration/suite/daprd/workflow/tracing/base.go
+++ b/tests/integration/suite/daprd/workflow/tracing/base.go
@@ -25,6 +25,7 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/otel"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -74,7 +75,7 @@ func (b *base) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(b.wf.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(b.wf.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "foo", dworkflow.WithInstanceID("helloworld"))

--- a/tests/integration/suite/daprd/workflow/tracing/childwf.go
+++ b/tests/integration/suite/daprd/workflow/tracing/childwf.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/otel"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -75,7 +76,7 @@ func (c *childwf) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.wf.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.wf.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	cctx, span := tracer.Start(ctx, "schedule-my-workflow")

--- a/tests/integration/suite/daprd/workflow/tracing/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/tracing/continueasnew.go
@@ -24,6 +24,7 @@ import (
 	v1 "go.opentelemetry.io/proto/otlp/trace/v1"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/otel"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -70,7 +71,7 @@ func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(c.wf.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(c.wf.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	id, err := client.ScheduleWorkflow(ctx, "can",

--- a/tests/integration/suite/daprd/workflow/tracing/remote.go
+++ b/tests/integration/suite/daprd/workflow/tracing/remote.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/otel"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
@@ -91,11 +92,11 @@ func (r *remote) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(r.wf.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(r.wf.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	for i := 1; i < r.n; i++ {
-		cl := dworkflow.NewClient(r.wf.DaprN(i).GRPCConn(t, ctx))
+		cl := dworkflow.NewClientWithLogger(r.wf.DaprN(i).GRPCConn(t, ctx), logger.New(t))
 		require.NoError(t, cl.StartWorker(ctx, reg))
 	}
 

--- a/tests/integration/suite/daprd/workflow/tracing/root.go
+++ b/tests/integration/suite/daprd/workflow/tracing/root.go
@@ -22,6 +22,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
 	"github.com/dapr/dapr/tests/integration/framework/process/otel"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
@@ -71,7 +72,7 @@ func (r *root) Run(t *testing.T, ctx context.Context) {
 		return nil, nil
 	})
 
-	client := dworkflow.NewClient(r.wf.Dapr().GRPCConn(t, ctx))
+	client := dworkflow.NewClientWithLogger(r.wf.Dapr().GRPCConn(t, ctx), logger.New(t))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	cctx, span := tracer.Start(ctx, "schedule-my-workflow")


### PR DESCRIPTION
A full suite run printed 25,444 lines. 8,073 of those were `go test -v` framing, roughly 17,000 were process logs dumped straight into the terminal, and the rest were libraries logging to stderr behind the framework's back. The failures were somewhere in the middle, and finding the logs explaining one meant scrolling past the logs of the 1,346 tests that passed.

Process logs now go to one file per failed test under /tmp/dapr_integration_logs. The terminal gets the assertion and a pointer:

```
    daprd.go:60: Error: Not equal: expected 1234, actual 1027
    logs: /tmp/dapr_integration_logs/ports.daprd.log
```

and the end of the run lists every failure with its log path. Inside a file, framework events come first, then one block per process, every line stamped with how long after the test started it was written. Dapr log lines are parsed down to level, scope and message instead of repeating a full logfmt prefix on each one, which takes a typical line from about 180 columns to 70. Anything that does not parse, panics, stack traces, etcd output, is passed through untouched. Where a test runs several of the same process they are indexed, so two sidecars read as daprd and daprd-1.

Dropping the process logs left nothing on screen during a run, so the framework now draws a progress line:

```
    512/1347  ok 510  fail 2  1m04s  actors/reminders/period
```

It is written to /dev/tty rather than stdout, because `go test` captures the binary's output and discards it entirely for a passing package. That also means `go test > out.txt` still gets clean output while progress stays on screen. Failures print above the line as they happen. It turns itself off with no terminal, on CI, and under -v, where `go test` is already printing a line per test.

Three separate channels were bypassing the framework and writing to stderr, where the output belongs to no test and cannot be suppressed:

  - dapr's own logger, from packages such as pkg/security running in-process, 217 lines a run;
  - the durabletask client, iting to the process's stderr, 1,742 lines a run. Its logger is captured at package init so it cannothe injection of logger.New(t) at every call site, which is most of this diff;
  - the standard library logest apps and, less obviously, by net/http for TLS handshake errors when a server has no ErrorLog of its o

The first and last are rediress.log beside
the per-test reports. The etcd client gets a logger for the same reason. The disk tests re-exec the tch was piping a
whole second test run to the terminal; that child is now captured like any other process, and given its start of
run reset was deleting every other test's report.

Also fixes a data race in actors/deactivation/move, where an HTTP handler wrote a variable thee fails every
test running in parallel when the detector fires, so this alone accounted for 18 failures in

# Description

<!--
Please explain the changes you've made.
-->

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
