### PR TITLE
workflow: fix mid-batch terminate

### DIFF
--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -16,7 +16,6 @@ This update contains the following bug fixes:
 - [Fixes orphaned workflow activity-result reminders retrying forever](#fixes-orphaned-workflow-activity-result-reminders-retrying-forever)
 - [Pub/sub delivery to a gRPC app failing with "use of closed network connection"](#pubsub-delivery-to-a-grpc-app-failing-with-use-of-closed-network-connection)
 - [Azure component authentication halting at the SPIFFE credential instead of falling back](#azure-component-authentication-halting-at-the-spiffe-credential-instead-of-falling-back)
-- [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 
 ## Actor state store components cannot be hot reloaded
 
@@ -429,40 +428,3 @@ The SPIFFE credential returned a plain error when the context carried no JWT SVI
 
 The SPIFFE credential now reports itself as unavailable when no JWT SVID source is present, before any token request is made, which is exactly what `ChainedTokenCredential` requires to continue to the next credential in the chain.
 Both the default chain and explicitly ordered `azureAuthMethods` lists now fall through as expected, and behavior when a SPIFFE source is configured is unchanged.
-
-## Workflow terminate silently dropped when delivered in the same batch as other events
-
-### Problem
-
-Terminating a workflow intermittently had no effect: the workflow's status stayed `RUNNING` and it kept executing activities and timers as if the terminate had never been issued.
-Blocking terminate calls (such as `TerminateWorkflowAsync` in the .NET SDK) never returned, because they wait for the instance to reach a terminal status that never came.
-With debug logging enabled, a dropped terminate showed the `ExecutionTerminated` event being delivered and consumed with no effect:
-
-```
-received work item with 2 new event(s): [ExecutionTerminated, TaskCompleted#1]
-workflow execution returned with status 'ORCHESTRATION_STATUS_RUNNING'
-```
-
-A workflow terminated while it was suspended was affected the same way, deterministically: the status stayed `SUSPENDED` and every terminate sent to it was lost.
-
-### Impact
-
-You were affected if you terminated workflows that were actively making progress, regardless of SDK language.
-The window depends on inbox pressure: the terminate is dropped when it arrives in the same work item batch as another event and is not the last event in that batch, so long-running workflows that loop over short activities and timers (endless pollers, monitors, `continue_as_new` loops) were the most exposed, while a workflow idling on a single slow activity or timer almost always received its terminate alone and was unaffected.
-
-A dropped terminate is consumed with its batch and never redelivered, so the instance kept running; a retried terminate raced the same window again.
-A recursive terminate that was dropped also never cascaded, leaving child workflows running as orphans.
-For suspended workflows there was no window: every terminate was lost until the workflow was resumed.
-
-### Root Cause
-
-The workflow engine hands an instance's pending events to the workflow executor as one batch, and relied entirely on the SDK executor to turn an `ExecutionTerminated` event into a termination outcome.
-SDK executors registered the termination when they processed the event but kept feeding the remaining events of the batch into the workflow code, which resumed past its own termination and produced a competing outcome: scheduling more work, completing normally, or restarting via `continue_as_new`.
-A `continue_as_new` outcome always discarded the termination; other outcomes raced it nondeterministically.
-A terminate delivered while the workflow was suspended produced no outcome at all, because suspension suppressed every action the executor would have returned.
-Since the engine trusted the executor's result and the event was consumed with the batch, the terminate was lost permanently.
-
-### Solution
-
-When a delivered batch contains an `ExecutionTerminated` event and the executor does not complete the workflow, daprd discards the doomed execution's pending work and completes the instance as `TERMINATED`.
-A `continue_as_new` returned alongside a terminate no longer starts a new iteration, and terminating a suspended workflow now terminates it without requiring a resume.

--- a/docs/release_notes/v1.18.3.md
+++ b/docs/release_notes/v1.18.3.md
@@ -16,6 +16,7 @@ This update contains the following bug fixes:
 - [Fixes orphaned workflow activity-result reminders retrying forever](#fixes-orphaned-workflow-activity-result-reminders-retrying-forever)
 - [Pub/sub delivery to a gRPC app failing with "use of closed network connection"](#pubsub-delivery-to-a-grpc-app-failing-with-use-of-closed-network-connection)
 - [Azure component authentication halting at the SPIFFE credential instead of falling back](#azure-component-authentication-halting-at-the-spiffe-credential-instead-of-falling-back)
+- [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 
 ## Actor state store components cannot be hot reloaded
 
@@ -428,3 +429,40 @@ The SPIFFE credential returned a plain error when the context carried no JWT SVI
 
 The SPIFFE credential now reports itself as unavailable when no JWT SVID source is present, before any token request is made, which is exactly what `ChainedTokenCredential` requires to continue to the next credential in the chain.
 Both the default chain and explicitly ordered `azureAuthMethods` lists now fall through as expected, and behavior when a SPIFFE source is configured is unchanged.
+
+## Workflow terminate silently dropped when delivered in the same batch as other events
+
+### Problem
+
+Terminating a workflow intermittently had no effect: the workflow's status stayed `RUNNING` and it kept executing activities and timers as if the terminate had never been issued.
+Blocking terminate calls (such as `TerminateWorkflowAsync` in the .NET SDK) never returned, because they wait for the instance to reach a terminal status that never came.
+With debug logging enabled, a dropped terminate showed the `ExecutionTerminated` event being delivered and consumed with no effect:
+
+```
+received work item with 2 new event(s): [ExecutionTerminated, TaskCompleted#1]
+workflow execution returned with status 'ORCHESTRATION_STATUS_RUNNING'
+```
+
+A workflow terminated while it was suspended was affected the same way, deterministically: the status stayed `SUSPENDED` and every terminate sent to it was lost.
+
+### Impact
+
+You were affected if you terminated workflows that were actively making progress, regardless of SDK language.
+The window depends on inbox pressure: the terminate is dropped when it arrives in the same work item batch as another event and is not the last event in that batch, so long-running workflows that loop over short activities and timers (endless pollers, monitors, `continue_as_new` loops) were the most exposed, while a workflow idling on a single slow activity or timer almost always received its terminate alone and was unaffected.
+
+A dropped terminate is consumed with its batch and never redelivered, so the instance kept running; a retried terminate raced the same window again.
+A recursive terminate that was dropped also never cascaded, leaving child workflows running as orphans.
+For suspended workflows there was no window: every terminate was lost until the workflow was resumed.
+
+### Root Cause
+
+The workflow engine hands an instance's pending events to the workflow executor as one batch, and relied entirely on the SDK executor to turn an `ExecutionTerminated` event into a termination outcome.
+SDK executors registered the termination when they processed the event but kept feeding the remaining events of the batch into the workflow code, which resumed past its own termination and produced a competing outcome: scheduling more work, completing normally, or restarting via `continue_as_new`.
+A `continue_as_new` outcome always discarded the termination; other outcomes raced it nondeterministically.
+A terminate delivered while the workflow was suspended produced no outcome at all, because suspension suppressed every action the executor would have returned.
+Since the engine trusted the executor's result and the event was consumed with the batch, the terminate was lost permanently.
+
+### Solution
+
+When a delivered batch contains an `ExecutionTerminated` event and the executor does not complete the workflow, daprd discards the doomed execution's pending work and completes the instance as `TERMINATED`.
+A `continue_as_new` returned alongside a terminate no longer starts a new iteration, and terminating a suspended workflow now terminates it without requiring a resume.

--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -6,6 +6,7 @@ This update contains the following bug fixes:
 - [Output binding invocations over gRPC forwarding binary trace metadata to components](#output-binding-invocations-over-grpc-forwarding-binary-trace-metadata-to-components)
 - [Force purge failed for every workflow when history signing was enabled](#force-purge-failed-for-every-workflow-when-history-signing-was-enabled)
 - [Workflow wrongly failed as tampered when a stale completion arrived after ContinueAsNew or a transient state store fault](#workflow-wrongly-failed-as-tampered-when-a-stale-completion-arrived-after-continueasnew-or-a-transient-state-store-fault)
+- [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -152,3 +153,40 @@ A completion referencing a task scheduled ID absent from signed history is now d
 The same applies when the ID is present but records a different invocation: task IDs restart after ContinueAsNew, so a straggler completion can land on a reused ID belonging to the new generation's own child or activity; a validly signed completion whose input digest does not match the recorded invocation is dropped as stale instead of tombstoning the workflow.
 This is safe because the event is discarded before it is written: a forged completion with an unknown ID gains an attacker nothing.
 Additionally, before tombstoning on any other verification failure, the runtime now re-verifies the event against freshly loaded durable state, so a stale in-memory cache can no longer condemn a healthy workflow; genuine signature mismatches still tombstone as before.
+
+## Workflow terminate silently dropped when delivered in the same batch as other events
+
+### Problem
+
+Terminating a workflow intermittently had no effect: the workflow's status stayed `RUNNING` and it kept executing activities and timers as if the terminate had never been issued.
+Blocking terminate calls (such as `TerminateWorkflowAsync` in the .NET SDK) never returned, because they wait for the instance to reach a terminal status that never came.
+With debug logging enabled, a dropped terminate showed the `ExecutionTerminated` event being delivered and consumed with no effect:
+
+```
+received work item with 2 new event(s): [ExecutionTerminated, TaskCompleted#1]
+workflow execution returned with status 'ORCHESTRATION_STATUS_RUNNING'
+```
+
+A workflow terminated while it was suspended was affected the same way, deterministically: the status stayed `SUSPENDED` and every terminate sent to it was lost.
+
+### Impact
+
+You were affected if you terminated workflows that were actively making progress, regardless of SDK language.
+The window depends on inbox pressure: the terminate is dropped when it arrives in the same work item batch as another event and is not the last event in that batch, so long-running workflows that loop over short activities and timers (endless pollers, monitors, `continue_as_new` loops) were the most exposed, while a workflow idling on a single slow activity or timer almost always received its terminate alone and was unaffected.
+
+A dropped terminate is consumed with its batch and never redelivered, so the instance kept running; a retried terminate raced the same window again.
+A recursive terminate that was dropped also never cascaded, leaving child workflows running as orphans.
+For suspended workflows there was no window: every terminate was lost until the workflow was resumed.
+
+### Root Cause
+
+The workflow engine hands an instance's pending events to the workflow executor as one batch, and relied entirely on the SDK executor to turn an `ExecutionTerminated` event into a termination outcome.
+SDK executors registered the termination when they processed the event but kept feeding the remaining events of the batch into the workflow code, which resumed past its own termination and produced a competing outcome: scheduling more work, completing normally, or restarting via `continue_as_new`.
+A `continue_as_new` outcome always discarded the termination; other outcomes raced it nondeterministically.
+A terminate delivered while the workflow was suspended produced no outcome at all, because suspension suppressed every action the executor would have returned.
+Since the engine trusted the executor's result and the event was consumed with the batch, the terminate was lost permanently.
+
+### Solution
+
+When a delivered batch contains an `ExecutionTerminated` event and the executor does not complete the workflow, daprd discards the doomed execution's pending work and completes the instance as `TERMINATED`.
+A `continue_as_new` returned alongside a terminate no longer starts a new iteration, and terminating a suspended workflow now terminates it without requiring a resume.

--- a/tests/integration/suite/daprd/workflow/terminate/batched/child.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/child.go
@@ -1,0 +1,122 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(child))
+}
+
+// child verifies that a child workflow terminated mid-batch
+// ([ExecutionTerminated, TaskCompleted], with the child continuing-as-new)
+// still notifies its awaiting parent. If the child's termination is dropped,
+// or the completion is applied without the parent notification, the parent
+// blocks forever.
+type child struct {
+	workflow *workflow.Workflow
+}
+
+func (b *child) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *child) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	const childID = "terminate-child-child"
+
+	var inActivity atomic.Bool
+	holdCh := make(chan struct{})
+
+	r := b.workflow.Registry()
+
+	r.AddWorkflowN("terminate-child-child", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("hold").Await(nil); err != nil {
+			return nil, err
+		}
+		ctx.ContinueAsNew(nil)
+		return nil, nil
+	})
+	r.AddWorkflowN("terminate-child", func(ctx *task.WorkflowContext) (any, error) {
+		out := "child-completed"
+		if err := ctx.CallChildWorkflow("terminate-child-child",
+			task.WithChildWorkflowInstanceID(childID),
+		).Await(nil); err != nil {
+			out = "child-failed"
+		}
+		return out, nil
+	})
+	require.NoError(t, r.AddActivityN("hold", func(ctx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		<-holdCh
+		return nil, nil
+	}))
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-child", api.WithInstanceID("terminate-child"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, inActivity.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, api.InstanceID(childID), fworkflow.IsTaskScheduledFor(0)))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), childID, &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	close(holdCh)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	cmeta, err := cl.WaitForWorkflowCompletion(ctx, api.InstanceID(childID))
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), cmeta.GetRuntimeStatus().String())
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	require.Equal(t, `"child-completed"`, meta.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/completed.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/completed.go
@@ -1,0 +1,109 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(completed))
+}
+
+type completed struct {
+	workflow *workflow.Workflow
+}
+
+func (b *completed) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *completed) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	var inActivity atomic.Bool
+	holdCh := make(chan struct{})
+
+	b.workflow.Registry().AddWorkflowN("terminate-completed", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("hold").Await(nil); err != nil {
+			return nil, err
+		}
+		return "done", nil
+	})
+	require.NoError(t, b.workflow.Registry().AddActivityN("hold", func(ctx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		<-holdCh
+		return nil, nil
+	}))
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-completed", api.WithInstanceID("terminate-completed"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, inActivity.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(0)))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`null`),
+			},
+		},
+	})
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	close(holdCh)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	require.Equal(t, `"done"`, meta.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/continueasnew.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(continueasnew))
+}
+
+// continueasnew verifies that a terminate delivered in the same work
+// item as an activity completion, with the terminate NOT last in the batch
+// ([ExecutionTerminated, TaskCompleted]), terminates an eternal workflow that
+// continues-as-new after each activity. The ContinueAsNew of the resumed
+// workflow must not override or discard the termination.
+type continueasnew struct {
+	workflow *workflow.Workflow
+}
+
+func (b *continueasnew) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *continueasnew) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	var inActivity atomic.Bool
+	holdCh := make(chan struct{})
+
+	b.workflow.Registry().AddWorkflowN("terminate-continueasnew", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("hold").Await(nil); err != nil {
+			return nil, err
+		}
+		ctx.ContinueAsNew(nil)
+		return nil, nil
+	})
+	require.NoError(t, b.workflow.Registry().AddActivityN("hold", func(ctx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		<-holdCh
+		return nil, nil
+	}))
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-continueasnew")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, inActivity.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(0)))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	close(holdCh)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_TERMINATED", meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/raisedevent.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/raisedevent.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(raisedevent))
+}
+
+// raisedevent verifies that a terminate is honoured when the awaited
+// external event arrives after it in the same work item batch:
+// [ExecutionTerminated, EventRaised]. The raised event must not resume the
+// workflow past its termination.
+type raisedevent struct {
+	workflow *workflow.Workflow
+}
+
+func (b *raisedevent) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *raisedevent) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	b.workflow.Registry().AddWorkflowN("terminate-raisedevent", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return "raised-done", nil
+	})
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-raisedevent", api.WithInstanceID("terminate-raisedevent"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(e *protos.HistoryEvent) bool {
+			return e.GetTimerCreated() != nil
+		}))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/recursive.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/recursive.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(recursive))
+}
+
+type recursive struct {
+	workflow *workflow.Workflow
+}
+
+func (b *recursive) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *recursive) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	const childID = "recursive-child"
+
+	var inActivity atomic.Bool
+	holdCh := make(chan struct{})
+
+	r := b.workflow.Registry()
+
+	r.AddWorkflowN("terminate-recursive-child", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("never", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, nil
+	})
+	r.AddWorkflowN("terminate-recursive", func(ctx *task.WorkflowContext) (any, error) {
+		ctx.CallChildWorkflow("terminate-recursive-child",
+			task.WithChildWorkflowInstanceID(childID),
+		)
+		if err := ctx.CallActivity("hold").Await(nil); err != nil {
+			return nil, err
+		}
+		ctx.ContinueAsNew(nil)
+		return nil, nil
+	})
+	require.NoError(t, r.AddActivityN("hold", func(ctx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		<-holdCh
+		return nil, nil
+	}))
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-recursive", api.WithInstanceID("terminate-recursive"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, inActivity.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(e *protos.HistoryEvent) bool {
+			return e.GetChildWorkflowInstanceCreated() != nil
+		}))
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(1)))
+		cmeta, cerr := cl.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
+		if assert.NoError(c, cerr) {
+			assert.Equal(c, api.RUNTIME_STATUS_RUNNING.String(), cmeta.GetRuntimeStatus().String())
+		}
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input:   wrapperspb.String(`"stop"`),
+				Recurse: true,
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	close(holdCh)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		cmeta, cerr := cl.FetchWorkflowMetadata(ctx, api.InstanceID(childID))
+		if !assert.NoError(c, cerr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_TERMINATED.String(), cmeta.GetRuntimeStatus().String())
+	}, time.Second*20, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/taskcompleted.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/taskcompleted.go
@@ -1,0 +1,97 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(taskcompleted))
+}
+
+type taskcompleted struct {
+	workflow *workflow.Workflow
+}
+
+func (b *taskcompleted) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *taskcompleted) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	var inActivity atomic.Bool
+	holdCh := make(chan struct{})
+
+	b.workflow.Registry().AddWorkflowN("terminate-taskcompleted", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("hold").Await(nil); err != nil {
+			return nil, err
+		}
+		return "taskcompleted-done", nil
+	})
+	require.NoError(t, b.workflow.Registry().AddActivityN("hold", func(ctx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		<-holdCh
+		return nil, nil
+	}))
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-taskcompleted")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.True(c, inActivity.Load())
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(0)))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	close(holdCh)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_TERMINATED", meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/batched/timer.go
+++ b/tests/integration/suite/daprd/workflow/terminate/batched/timer.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package batched
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(timer))
+}
+
+type timer struct {
+	workflow *workflow.Workflow
+}
+
+func (b *timer) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *timer) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	b.workflow.Registry().AddWorkflowN("terminate-timer", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.CreateTimer(time.Second * 5).Await(nil); err != nil {
+			return nil, err
+		}
+		return "timer-done", nil
+	})
+
+	cl := b.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-timer", api.WithInstanceID("terminate-timer"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(e *protos.HistoryEvent) bool {
+			return e.GetTimerCreated() != nil
+		}))
+	}, time.Second*20, time.Millisecond*10)
+
+	fworkflow.InjectInboxEvent(t, ctx, b.workflow.DB(), b.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	b.workflow.Dapr().Restart(t, ctx)
+	b.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = b.workflow.BackendClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/enforced.go
+++ b/tests/integration/suite/daprd/workflow/terminate/enforced.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terminate
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+func init() {
+	suite.Register(new(enforced))
+}
+
+// enforced verifies that the runtime itself guarantees a terminate delivered
+// mid-batch, independent of SDK behavior. The worker here speaks the raw task
+// hub protocol and answers every workflow request with a CreateTimer action,
+// ignoring the ExecutionTerminated event in its batch. This mimics the
+// misbehaving SDK that motivated the fix; the SDK-based tests in the batched
+// subpackage cannot cover this path because a correct SDK converts the
+// terminate into a completion action before the runtime's enforcement is
+// needed.
+type enforced struct {
+	workflow *workflow.Workflow
+}
+
+func (e *enforced) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *enforced) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	// A worker that parks every workflow on a timer, forever, no matter what
+	// events it is sent. Reconnects across the daprd restart below.
+	var timerSeq atomic.Int32
+	wctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	go func() {
+		for wctx.Err() == nil {
+			conn, err := grpc.NewClient(e.workflow.Dapr().GRPCAddress(),
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			)
+			if err != nil {
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			sc := protos.NewTaskHubSidecarServiceClient(conn)
+			if _, err = sc.Hello(wctx, new(emptypb.Empty)); err != nil {
+				conn.Close()
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			stream, err := sc.GetWorkItems(wctx, new(protos.GetWorkItemsRequest))
+			if err != nil {
+				conn.Close()
+				time.Sleep(time.Millisecond * 50)
+				continue
+			}
+			for {
+				wi, rerr := stream.Recv()
+				if rerr != nil {
+					break
+				}
+				wr := wi.GetWorkflowRequest()
+				if wr == nil {
+					continue
+				}
+				_, rerr = sc.CompleteWorkflowTask(wctx, &protos.WorkflowResponse{
+					InstanceId: wr.GetInstanceId(),
+					Actions: []*protos.WorkflowAction{{
+						Id: timerSeq.Add(1) - 1,
+						WorkflowActionType: &protos.WorkflowAction_CreateTimer{
+							CreateTimer: &protos.CreateTimerAction{
+								FireAt: timestamppb.New(time.Now().Add(time.Second * 5)),
+							},
+						},
+					}},
+				})
+				if rerr != nil {
+					break
+				}
+			}
+			conn.Close()
+		}
+	}()
+
+	cl := e.workflow.ManagementClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-enforced", api.WithInstanceID("terminate-enforced"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil
+		}))
+	}, time.Second*20, time.Millisecond*10)
+
+	// Persist the terminate directly into the inbox without a wake-up reminder.
+	// When the pending timer fires it appends its TimerFired behind the
+	// terminate and the worker receives [ExecutionTerminated, TimerFired], which
+	// it answers with another timer as if the terminate did not exist.
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionTerminated{
+			ExecutionTerminated: &protos.ExecutionTerminatedEvent{
+				Input: wrapperspb.String(`"stop"`),
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.ManagementClient(t, ctx)
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+	require.Equal(t, `"stop"`, meta.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/terminate/suspended.go
+++ b/tests/integration/suite/daprd/workflow/terminate/suspended.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package terminate
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(suspended))
+}
+
+// suspended verifies that terminating a suspended workflow terminates it. The
+// suspension must neither buffer the terminate nor suppress the termination
+// action the workflow produces for it.
+type suspended struct {
+	workflow *workflow.Workflow
+}
+
+func (s *suspended) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *suspended) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	s.workflow.Registry().AddWorkflowN("terminate-suspended", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("never", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return "suspended-done", nil
+	})
+
+	cl := s.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "terminate-suspended", api.WithInstanceID("terminate-suspended"))
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.NoError(t, cl.SuspendWorkflow(ctx, id, "hold it"))
+	meta, err := cl.FetchWorkflowMetadata(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_SUSPENDED.String(), meta.GetRuntimeStatus().String())
+
+	termCtx, termCancel := context.WithTimeout(ctx, time.Second*20)
+	t.Cleanup(termCancel)
+	require.NoError(t, cl.TerminateWorkflow(termCtx, id))
+
+	meta, err = cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_TERMINATED.String(), meta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -56,6 +56,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/statefulhistory"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/taskexecutionid"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/terminate"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/terminate/batched"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/timer"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/tracing"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/versioning"


### PR DESCRIPTION
Terminating a workflow was silently dropped when the ExecutionTerminated event was not the last event in the work item batch it arrived in, e.g. [ExecutionTerminated, TaskCompleted]. The workflow stayed RUNNING forever, blocking terminate callers indefinitely, and a dropped recursive terminate never cascaded to child workflows. Terminating a suspended workflow was likewise lost. Fixed in the durable task engine by dapr/durabletask-go#123; this change adds the dapr-side integration coverage and the v1.18.3 release note.

The new terminate/batched suite builds the exact failing inbox shapes deterministically by injecting the ExecutionTerminated event directly into the persisted inbox with no wake-up reminder, restarting daprd to invalidate the actor cache, and letting the next completion, timer, or raised event trigger a run that drains the whole inbox as one batch:

- taskcompleted: [ExecutionTerminated, TaskCompleted] terminates.
- continueasnew: an eternal continue-as-new poller (the original reproduction) terminates instead of running forever.
- recursive: a recursive terminate delivered mid-batch still cascades to a running child workflow.
- child: a child terminated mid-batch still notifies its awaiting parent, which unblocks and completes.
- raisedevent, timer: [ExecutionTerminated, EventRaised] and [ExecutionTerminated, TimerFired] batches terminate.
- completed: a workflow that completes normally earlier in the batch keeps COMPLETED, pinning the first-completion-wins ordering that was previously a nondeterministic coin flip.