### PR TITLE
perf(diagnostics): cache tag maps for hot-path metric records

### DIFF
--- a/pkg/diagnostics/grpc_monitoring.go
+++ b/pkg/diagnostics/grpc_monitoring.go
@@ -61,6 +61,15 @@ type grpcMetrics struct {
 	enabled bool
 
 	meter stats.Recorder
+
+	// Cached recorders for the server interceptor hot path (built in Init):
+	// direct meter.Record through prebuilt tag maps instead of the
+	// RecordWithOptions allocation chain. Method and status sets are
+	// bounded, so the caches are too.
+	serverCompletedRpcsC *diagUtils.CachedInt64Counter
+	serverReceivedBytesC *diagUtils.CachedInt64Recorder
+	serverSentBytesC     *diagUtils.CachedInt64Recorder
+	serverLatencyC       *diagUtils.CachedFloat64Recorder
 }
 
 func newGRPCMetrics() *grpcMetrics {
@@ -117,6 +126,11 @@ func (g *grpcMetrics) Init(meter view.Meter, appID string, latencyDistribution *
 	g.enabled = true
 	g.meter = meter
 
+	g.serverCompletedRpcsC = diagUtils.NewCachedInt64Counter(meter, g.serverCompletedRpcs, appIDKey, appID)
+	g.serverReceivedBytesC = diagUtils.NewCachedInt64Recorder(meter, g.serverReceivedBytes, appIDKey, appID)
+	g.serverSentBytesC = diagUtils.NewCachedInt64Recorder(meter, g.serverSentBytes, appIDKey, appID)
+	g.serverLatencyC = diagUtils.NewCachedFloat64Recorder(meter, g.serverLatency, appIDKey, appID)
+
 	return meter.Register(
 		diagUtils.NewMeasureView(g.serverReceivedBytes, []tag.Key{appIDKey, KeyServerMethod}, defaultSizeDistribution),
 		diagUtils.NewMeasureView(g.serverSentBytes, []tag.Key{appIDKey, KeyServerMethod}, defaultSizeDistribution),
@@ -141,22 +155,10 @@ func (g *grpcMetrics) ServerRequestSent(ctx context.Context, method, status stri
 	}
 
 	elapsed := float64(time.Since(start) / time.Millisecond)
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverCompletedRpcs.Name(), appIDKey, g.appID, KeyServerMethod, method, KeyServerStatus, status)...),
-		stats.WithMeasurements(g.serverCompletedRpcs.M(1)))
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverReceivedBytes.Name(), appIDKey, g.appID, KeyServerMethod, method)...),
-		stats.WithMeasurements(g.serverReceivedBytes.M(reqContentSize)))
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverSentBytes.Name(), appIDKey, g.appID, KeyServerMethod, method)...),
-		stats.WithMeasurements(g.serverSentBytes.M(resContentSize)))
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverLatency.Name(), appIDKey, g.appID, KeyServerMethod, method, KeyServerStatus, status)...),
-		stats.WithMeasurements(g.serverLatency.M(elapsed)))
+	g.serverCompletedRpcsC.Record2(KeyServerMethod, method, KeyServerStatus, status)
+	g.serverReceivedBytesC.Record1(KeyServerMethod, method, reqContentSize)
+	g.serverSentBytesC.Record1(KeyServerMethod, method, resContentSize)
+	g.serverLatencyC.Record2(KeyServerMethod, method, KeyServerStatus, status, elapsed)
 }
 
 func (g *grpcMetrics) StreamServerRequestSent(ctx context.Context, method, status string, start time.Time) {
@@ -165,14 +167,8 @@ func (g *grpcMetrics) StreamServerRequestSent(ctx context.Context, method, statu
 	}
 
 	elapsed := float64(time.Since(start) / time.Millisecond)
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverCompletedRpcs.Name(), appIDKey, g.appID, KeyServerMethod, method, KeyServerStatus, status)...),
-		stats.WithMeasurements(g.serverCompletedRpcs.M(1)))
-	stats.RecordWithOptions(ctx,
-		stats.WithRecorder(g.meter),
-		stats.WithTags(diagUtils.WithTags(g.serverLatency.Name(), appIDKey, g.appID, KeyServerMethod, method, KeyServerStatus, status)...),
-		stats.WithMeasurements(g.serverLatency.M(elapsed)))
+	g.serverCompletedRpcsC.Record2(KeyServerMethod, method, KeyServerStatus, status)
+	g.serverLatencyC.Record2(KeyServerMethod, method, KeyServerStatus, status, elapsed)
 }
 
 func (g *grpcMetrics) StreamClientRequestSent(ctx context.Context, method, status string, start time.Time) {

--- a/pkg/diagnostics/metrics.go
+++ b/pkg/diagnostics/metrics.go
@@ -58,6 +58,10 @@ var payloadRatioDistribution = view.Distribution(0.1, 0.25, 0.5, 0.75, 0.9, 0.95
 func InitMetrics(meter view.Meter, appID, namespace string, metricSpec config.MetricSpec) error {
 	meter.Start()
 
+	if err := utils.CreateRulesMap(metricSpec.Rules); err != nil {
+		return err
+	}
+
 	latencyDistribution := metricSpec.GetLatencyDistribution(log)
 	// Workflow latency views default to the shared latencyDistribution unless
 	// spec.metrics.workflow.latencyDistributionBuckets provides an override.
@@ -99,5 +103,5 @@ func InitMetrics(meter view.Meter, appID, namespace string, metricSpec config.Me
 
 	// Set reporting period of views on the explicit meter
 	meter.SetReportingPeriod(DefaultReportingPeriod)
-	return utils.CreateRulesMap(metricSpec.Rules)
+	return nil
 }

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -19,6 +19,7 @@ import (
 	"regexp"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -83,18 +84,29 @@ func WithTags(name string, opts ...any) []tag.Mutator {
 			continue
 		}
 
-		if len(metricsRules) > 0 {
-			pairs := metricsRules[strings.ReplaceAll(name, "_", "/")+key.Name()]
-
-			for _, p := range pairs {
-				value = p.regex.ReplaceAllString(value, p.replace)
-			}
-		}
-
-		tagMutators = append(tagMutators, tag.Upsert(key, value))
+		tagMutators = append(tagMutators, tag.Upsert(key, NormalizeTagValue(name, key, value)))
 	}
 	return tagMutators
 }
+
+// NormalizeTagValue applies the configured metric rules (regex label
+// rewrites) for the measure and tag key to value, exactly as the per-record
+// WithTags path does.
+func NormalizeTagValue(name string, key tag.Key, value string) string {
+	if len(metricsRules) == 0 {
+		return value
+	}
+	for _, p := range metricsRules[strings.ReplaceAll(name, "_", "/")+key.Name()] {
+		value = p.regex.ReplaceAllString(value, p.replace)
+	}
+	return value
+}
+
+// rulesGeneration counts CreateRulesMap installations. Cached tag maps are
+// keyed and built from rule-normalized values, so any cache built under an
+// older rules generation must be discarded: production installs rules once
+// at startup, so in practice this trips at most once per cache.
+var rulesGeneration atomic.Uint64
 
 // CachedTagMaps caches fully-built *tag.Map values keyed by their varying
 // tag values, so hot-path metric records can call stats.Recorder.Record
@@ -103,31 +115,67 @@ func WithTags(name string, opts ...any) []tag.Mutator {
 // ~18-20 allocations per record down to zero for cached counters.
 //
 // Base tags (typically app_id and namespace, constant for the process) are
-// applied once at construction; metricsRules are resolved at map-build time,
-// matching WithTags semantics. Maps are built lazily, once per distinct
-// value tuple, and cached forever: intended for low-cardinality
-// discriminators (statuses, kinds, bounded method sets). The cardinality of
-// the cache mirrors the cardinality the metric views already accumulate.
+// applied once per rules generation. Cache keys are the RULE-NORMALIZED
+// values, so the cache's cardinality mirrors the exported view's even when
+// a cardinality rule collapses many raw values into one label, and a rules
+// installation after construction rebuilds the base tags and drops stale
+// entries. Intended for low-cardinality exported discriminators (statuses,
+// kinds, bounded method sets).
 type CachedTagMaps struct {
 	measureName string
-	baseCtx     context.Context
-	maps        sync.Map // value-tuple key -> *tag.Map
+	base        []any
+
+	mu      sync.Mutex
+	gen     atomic.Uint64
+	baseCtx atomic.Value // context.Context
+	maps    sync.Map     // normalized value-tuple key -> *tag.Map
 }
 
 // NewCachedTagMaps builds the cache with constant base tag pairs
 // (key1, value1, key2, value2, ...).
 func NewCachedTagMaps(measureName string, base ...any) *CachedTagMaps {
-	ctx, _ := tag.New(context.Background(), WithTags(measureName, base...)...)
-	return &CachedTagMaps{measureName: measureName, baseCtx: ctx}
+	c := &CachedTagMaps{measureName: measureName, base: base}
+	c.rebuild(rulesGeneration.Load())
+	return c
+}
+
+func (c *CachedTagMaps) rebuild(gen uint64) {
+	ctx, _ := tag.New(context.Background(), WithTags(c.measureName, c.base...)...)
+	c.baseCtx.Store(ctx)
+	c.maps.Range(func(k, _ any) bool {
+		c.maps.Delete(k)
+		return true
+	})
+	c.gen.Store(gen)
+}
+
+// baseContext returns the base-tag context for the current rules
+// generation, rebuilding the cache if rules were installed after this
+// cache was constructed.
+func (c *CachedTagMaps) baseContext() context.Context {
+	g := rulesGeneration.Load()
+	if c.gen.Load() != g {
+		c.mu.Lock()
+		if c.gen.Load() != g {
+			c.rebuild(g)
+		}
+		c.mu.Unlock()
+	}
+	return c.baseCtx.Load().(context.Context)
 }
 
 // Get1 returns the cached tag map for one varying tag. Zero allocations on
 // the cached path.
 func (c *CachedTagMaps) Get1(k tag.Key, v string) *tag.Map {
+	base := c.baseContext()
+	v = NormalizeTagValue(c.measureName, k, v)
 	if m, ok := c.maps.Load(v); ok {
 		return m.(*tag.Map)
 	}
-	ctx, _ := tag.New(c.baseCtx, WithTags(c.measureName, k, v)...)
+	ctx := base
+	if v != "" {
+		ctx, _ = tag.New(base, tag.Upsert(k, v))
+	}
 	m := tag.FromContext(ctx)
 	c.maps.Store(v, m)
 	return m
@@ -137,11 +185,21 @@ func (c *CachedTagMaps) Get1(k tag.Key, v string) *tag.Map {
 // concatenation allocates one small string per call; use nested caches if
 // even that matters.
 func (c *CachedTagMaps) Get2(k1 tag.Key, v1 string, k2 tag.Key, v2 string) *tag.Map {
+	base := c.baseContext()
+	v1 = NormalizeTagValue(c.measureName, k1, v1)
+	v2 = NormalizeTagValue(c.measureName, k2, v2)
 	key := v1 + "\x00" + v2
 	if m, ok := c.maps.Load(key); ok {
 		return m.(*tag.Map)
 	}
-	ctx, _ := tag.New(c.baseCtx, WithTags(c.measureName, k1, v1, k2, v2)...)
+	muts := make([]tag.Mutator, 0, 2)
+	if v1 != "" {
+		muts = append(muts, tag.Upsert(k1, v1))
+	}
+	if v2 != "" {
+		muts = append(muts, tag.Upsert(k2, v2))
+	}
+	ctx, _ := tag.New(base, muts...)
 	m := tag.FromContext(ctx)
 	c.maps.Store(key, m)
 	return m
@@ -150,7 +208,7 @@ func (c *CachedTagMaps) Get2(k1 tag.Key, v1 string, k2 tag.Key, v2 string) *tag.
 // Base returns the tag map holding only the constant base tags, for
 // measures with no varying discriminator.
 func (c *CachedTagMaps) Base() *tag.Map {
-	return tag.FromContext(c.baseCtx)
+	return tag.FromContext(c.baseContext())
 }
 
 // CachedInt64Counter records a constant-increment counter through cached
@@ -257,6 +315,7 @@ func AddNewTagKey(views []*view.View, key *tag.Key) []*view.View {
 
 // CreateRulesMap generates a fast lookup map for metrics regex.
 func CreateRulesMap(rules []config.MetricsRule) error {
+	defer rulesGeneration.Add(1)
 	newMetricsRules := make(map[string][]regexPair, len(rules))
 
 	for _, r := range rules {

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -14,9 +14,11 @@ limitations under the License.
 package utils
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"strings"
+	"sync"
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
@@ -92,6 +94,156 @@ func WithTags(name string, opts ...any) []tag.Mutator {
 		tagMutators = append(tagMutators, tag.Upsert(key, value))
 	}
 	return tagMutators
+}
+
+// CachedTagMaps caches fully-built *tag.Map values keyed by their varying
+// tag values, so hot-path metric records can call stats.Recorder.Record
+// directly instead of paying the RecordWithOptions chain (mutator closures,
+// option closures, a fresh tag map and value context) on every record:
+// ~18-20 allocations per record down to zero for cached counters.
+//
+// Base tags (typically app_id and namespace, constant for the process) are
+// applied once at construction; metricsRules are resolved at map-build time,
+// matching WithTags semantics. Maps are built lazily, once per distinct
+// value tuple, and cached forever: intended for low-cardinality
+// discriminators (statuses, kinds, bounded method sets). The cardinality of
+// the cache mirrors the cardinality the metric views already accumulate.
+type CachedTagMaps struct {
+	measureName string
+	baseCtx     context.Context
+	maps        sync.Map // value-tuple key -> *tag.Map
+}
+
+// NewCachedTagMaps builds the cache with constant base tag pairs
+// (key1, value1, key2, value2, ...).
+func NewCachedTagMaps(measureName string, base ...any) *CachedTagMaps {
+	ctx, _ := tag.New(context.Background(), WithTags(measureName, base...)...)
+	return &CachedTagMaps{measureName: measureName, baseCtx: ctx}
+}
+
+// Get1 returns the cached tag map for one varying tag. Zero allocations on
+// the cached path.
+func (c *CachedTagMaps) Get1(k tag.Key, v string) *tag.Map {
+	if m, ok := c.maps.Load(v); ok {
+		return m.(*tag.Map)
+	}
+	ctx, _ := tag.New(c.baseCtx, WithTags(c.measureName, k, v)...)
+	m := tag.FromContext(ctx)
+	c.maps.Store(v, m)
+	return m
+}
+
+// Get2 returns the cached tag map for two varying tags. The composite key
+// concatenation allocates one small string per call; use nested caches if
+// even that matters.
+func (c *CachedTagMaps) Get2(k1 tag.Key, v1 string, k2 tag.Key, v2 string) *tag.Map {
+	key := v1 + "\x00" + v2
+	if m, ok := c.maps.Load(key); ok {
+		return m.(*tag.Map)
+	}
+	ctx, _ := tag.New(c.baseCtx, WithTags(c.measureName, k1, v1, k2, v2)...)
+	m := tag.FromContext(ctx)
+	c.maps.Store(key, m)
+	return m
+}
+
+// Base returns the tag map holding only the constant base tags, for
+// measures with no varying discriminator.
+func (c *CachedTagMaps) Base() *tag.Map {
+	return tag.FromContext(c.baseCtx)
+}
+
+// CachedInt64Counter records a constant-increment counter through cached
+// tag maps: zero allocations on the cached path.
+type CachedInt64Counter struct {
+	meter stats.Recorder
+	maps  *CachedTagMaps
+	m1    []stats.Measurement
+	m0    []stats.Measurement
+}
+
+// NewCachedInt64Counter builds the counter recorder; base holds the
+// constant tag pairs.
+func NewCachedInt64Counter(meter stats.Recorder, measure *stats.Int64Measure, base ...any) *CachedInt64Counter {
+	return &CachedInt64Counter{
+		meter: meter,
+		maps:  NewCachedTagMaps(measure.Name(), base...),
+		m1:    []stats.Measurement{measure.M(1)},
+		m0:    []stats.Measurement{measure.M(0)},
+	}
+}
+
+// Record1 records +1 with one varying tag.
+func (c *CachedInt64Counter) Record1(k tag.Key, v string) {
+	c.meter.Record(c.maps.Get1(k, v), c.m1, nil)
+}
+
+// Record2 records +1 with two varying tags.
+func (c *CachedInt64Counter) Record2(k1 tag.Key, v1 string, k2 tag.Key, v2 string) {
+	c.meter.Record(c.maps.Get2(k1, v1, k2, v2), c.m1, nil)
+}
+
+// Zero1 records 0 with one varying tag, pre-registering the series so it is
+// exported at value 0 before its first increment. Only meaningful for views
+// with a Sum aggregation: under Count every record, including a zero, counts.
+func (c *CachedInt64Counter) Zero1(k tag.Key, v string) {
+	c.meter.Record(c.maps.Get1(k, v), c.m0, nil)
+}
+
+// CachedInt64Recorder records variable int64 measurements (byte sizes)
+// through cached tag maps: one small slice allocation per record.
+type CachedInt64Recorder struct {
+	meter   stats.Recorder
+	maps    *CachedTagMaps
+	measure *stats.Int64Measure
+}
+
+// NewCachedInt64Recorder builds the recorder; base holds the constant tag
+// pairs.
+func NewCachedInt64Recorder(meter stats.Recorder, measure *stats.Int64Measure, base ...any) *CachedInt64Recorder {
+	return &CachedInt64Recorder{
+		meter:   meter,
+		maps:    NewCachedTagMaps(measure.Name(), base...),
+		measure: measure,
+	}
+}
+
+// Record1 records with one varying tag.
+func (c *CachedInt64Recorder) Record1(k tag.Key, tv string, v int64) {
+	c.meter.Record(c.maps.Get1(k, tv), []stats.Measurement{c.measure.M(v)}, nil)
+}
+
+// CachedFloat64Recorder records float64 measurements (histograms, gauges)
+// through cached tag maps: one small slice allocation per record.
+type CachedFloat64Recorder struct {
+	meter   stats.Recorder
+	maps    *CachedTagMaps
+	measure *stats.Float64Measure
+}
+
+// NewCachedFloat64Recorder builds the recorder; base holds the constant tag
+// pairs.
+func NewCachedFloat64Recorder(meter stats.Recorder, measure *stats.Float64Measure, base ...any) *CachedFloat64Recorder {
+	return &CachedFloat64Recorder{
+		meter:   meter,
+		maps:    NewCachedTagMaps(measure.Name(), base...),
+		measure: measure,
+	}
+}
+
+// Record0 records with only the base tags.
+func (c *CachedFloat64Recorder) Record0(v float64) {
+	c.meter.Record(c.maps.Base(), []stats.Measurement{c.measure.M(v)}, nil)
+}
+
+// Record1 records with one varying tag.
+func (c *CachedFloat64Recorder) Record1(k tag.Key, tv string, v float64) {
+	c.meter.Record(c.maps.Get1(k, tv), []stats.Measurement{c.measure.M(v)}, nil)
+}
+
+// Record2 records with two varying tags.
+func (c *CachedFloat64Recorder) Record2(k1 tag.Key, v1 string, k2 tag.Key, v2 string, v float64) {
+	c.meter.Record(c.maps.Get2(k1, v1, k2, v2), []stats.Measurement{c.measure.M(v)}, nil)
 }
 
 // AddNewTagKey adds new tag keys to existing view.

--- a/pkg/diagnostics/utils/metrics_utils.go
+++ b/pkg/diagnostics/utils/metrics_utils.go
@@ -315,7 +315,6 @@ func AddNewTagKey(views []*view.View, key *tag.Key) []*view.View {
 
 // CreateRulesMap generates a fast lookup map for metrics regex.
 func CreateRulesMap(rules []config.MetricsRule) error {
-	defer rulesGeneration.Add(1)
 	newMetricsRules := make(map[string][]regexPair, len(rules))
 
 	for _, r := range rules {
@@ -344,5 +343,6 @@ func CreateRulesMap(rules []config.MetricsRule) error {
 	}
 
 	metricsRules = newMetricsRules
+	rulesGeneration.Add(1)
 	return nil
 }

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -14,6 +14,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -101,4 +102,59 @@ func TestCreateRulesMap(t *testing.T) {
 		assert.Equal(t, "TEST", metricsRules["testlabel"][0].replace)
 		assert.NotNil(t, metricsRules["testlabel"][0].regex)
 	})
+}
+
+func TestCachedTagMaps_NormalizedKeysCollapse(t *testing.T) {
+	// A cardinality rule collapsing every workflow name into one label must
+	// collapse the cache the same way: keys are normalized values, so cache
+	// cardinality mirrors the exported view, not the raw input space.
+	require.NoError(t, CreateRulesMap([]config.MetricsRule{{
+		Name: "wf_count",
+		Labels: []config.MetricLabel{{
+			Name:  "workflow",
+			Regex: map[string]string{"other": "wf-.+"},
+		}},
+	}}))
+	t.Cleanup(func() { require.NoError(t, CreateRulesMap(nil)) })
+
+	wfKey := tag.MustNewKey("workflow")
+	c := NewCachedTagMaps("wf_count", tag.MustNewKey("app_id"), "app")
+	for i := range 100 {
+		m := c.Get1(wfKey, fmt.Sprintf("wf-%d", i))
+		v, ok := m.Value(wfKey)
+		require.True(t, ok)
+		assert.Equal(t, "other", v)
+	}
+	entries := 0
+	c.maps.Range(func(_, _ any) bool { entries++; return true })
+	assert.Equal(t, 1, entries, "cache must be keyed by normalized values")
+}
+
+func TestCachedTagMaps_RulesInstalledAfterConstruction(t *testing.T) {
+	// Production InitMetrics installs rules before any cached recorder is
+	// built, but the cache must also self-heal if rules land later: base
+	// tags and cached entries are rebuilt under the new rules generation.
+	require.NoError(t, CreateRulesMap(nil))
+	t.Cleanup(func() { require.NoError(t, CreateRulesMap(nil)) })
+
+	appKey := tag.MustNewKey("app_id")
+	stKey := tag.MustNewKey("status")
+	c := NewCachedTagMaps("wf_count", appKey, "app-1234")
+	m := c.Get1(stKey, "success")
+	v, ok := m.Value(appKey)
+	require.True(t, ok)
+	require.Equal(t, "app-1234", v)
+
+	require.NoError(t, CreateRulesMap([]config.MetricsRule{{
+		Name: "wf_count",
+		Labels: []config.MetricLabel{{
+			Name:  "app_id",
+			Regex: map[string]string{"app": "app-.+"},
+		}},
+	}}))
+
+	m = c.Get1(stKey, "success")
+	v, ok = m.Value(appKey)
+	require.True(t, ok)
+	assert.Equal(t, "app", v, "base tags must be re-normalized under the new rules")
 }

--- a/pkg/diagnostics/utils/metrics_utils_test.go
+++ b/pkg/diagnostics/utils/metrics_utils_test.go
@@ -64,6 +64,7 @@ func TestWithTags(t *testing.T) {
 
 func TestCreateRulesMap(t *testing.T) {
 	t.Run("invalid rule", func(t *testing.T) {
+		genBefore := rulesGeneration.Load()
 		err := CreateRulesMap([]config.MetricsRule{
 			{
 				Name: "test",
@@ -78,9 +79,12 @@ func TestCreateRulesMap(t *testing.T) {
 			},
 		})
 		require.Error(t, err)
+		assert.Equal(t, genBefore, rulesGeneration.Load(),
+			"a failed install must not bump the rules generation")
 	})
 
 	t.Run("valid rule", func(t *testing.T) {
+		genBefore := rulesGeneration.Load()
 		err := CreateRulesMap([]config.MetricsRule{
 			{
 				Name: "test",
@@ -96,6 +100,8 @@ func TestCreateRulesMap(t *testing.T) {
 		})
 
 		require.NoError(t, err)
+		assert.Equal(t, genBefore+1, rulesGeneration.Load(),
+			"a successful install must bump the rules generation")
 		assert.NotNil(t, metricsRules)
 		assert.Len(t, metricsRules, 1)
 		assert.Len(t, metricsRules["testlabel"], 1)

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -132,10 +132,24 @@ type workflowMetrics struct {
 	// routes; sustained wait_watch indicates broken co-location (e.g.
 	// placement churn or legacy-format reminders).
 	completionRouteCount *stats.Int64Measure
-	appID                string
-	enabled              bool
-	namespace            string
-	meter                stats.Recorder
+	// Cached recorders for hot-path records (built in Init): direct
+	// meter.Record through prebuilt tag maps instead of the
+	// RecordWithOptions allocation chain. One recorder per measure so
+	// per-measure metric rules resolve exactly as before.
+	workflowOperationCountC   *diagUtils.CachedInt64Counter
+	workflowOperationLatencyC *diagUtils.CachedFloat64Recorder
+	workflowExecutionCountC   *diagUtils.CachedInt64Counter
+	workflowExecutionLatencyC *diagUtils.CachedFloat64Recorder
+	schedulingLatencyC        *diagUtils.CachedFloat64Recorder
+	activityExecutionCountC   *diagUtils.CachedInt64Counter
+	activityExecutionLatencyC *diagUtils.CachedFloat64Recorder
+	activityOperationCountC   *diagUtils.CachedInt64Counter
+	activityOperationLatencyC *diagUtils.CachedFloat64Recorder
+
+	appID     string
+	enabled   bool
+	namespace string
+	meter     stats.Recorder
 }
 
 func newWorkflowMetrics() *workflowMetrics {
@@ -218,7 +232,18 @@ func (w *workflowMetrics) Init(meter view.Meter, appID, namespace string, latenc
 	w.namespace = namespace
 	w.meter = meter
 
-	return meter.Register(
+	base := []any{appIDKey, appID, namespaceKey, namespace}
+	w.workflowOperationCountC = diagUtils.NewCachedInt64Counter(meter, w.workflowOperationCount, base...)
+	w.workflowOperationLatencyC = diagUtils.NewCachedFloat64Recorder(meter, w.workflowOperationLatency, base...)
+	w.workflowExecutionCountC = diagUtils.NewCachedInt64Counter(meter, w.workflowExecutionCount, base...)
+	w.workflowExecutionLatencyC = diagUtils.NewCachedFloat64Recorder(meter, w.workflowExecutionLatency, base...)
+	w.schedulingLatencyC = diagUtils.NewCachedFloat64Recorder(meter, w.workflowSchedulingLatency, base...)
+	w.activityExecutionCountC = diagUtils.NewCachedInt64Counter(meter, w.activityExecutionCount, base...)
+	w.activityExecutionLatencyC = diagUtils.NewCachedFloat64Recorder(meter, w.activityExecutionLatency, base...)
+	w.activityOperationCountC = diagUtils.NewCachedInt64Counter(meter, w.activityOperationCount, base...)
+	w.activityOperationLatencyC = diagUtils.NewCachedFloat64Recorder(meter, w.activityOperationLatency, base...)
+
+	err := meter.Register(
 		diagUtils.NewMeasureView(w.workflowOperationCount, []tag.Key{appIDKey, namespaceKey, operationKey, statusKey}, view.Count()),
 		diagUtils.NewMeasureView(w.workflowOperationLatency, []tag.Key{appIDKey, namespaceKey, operationKey, statusKey}, latencyDistribution),
 		diagUtils.NewMeasureView(w.workflowExecutionCount, []tag.Key{appIDKey, namespaceKey, workflowNameKey, statusKey}, view.Count()),
@@ -235,6 +260,11 @@ func (w *workflowMetrics) Init(meter view.Meter, appID, namespace string, latenc
 		diagUtils.NewMeasureView(w.workflowPayloadSizeRatio, []tag.Key{appIDKey, namespaceKey, workflowNameKey}, payloadRatioDistribution),
 		diagUtils.NewMeasureView(w.activityPayloadSizeRatio, []tag.Key{appIDKey, namespaceKey, workflowNameKey, activityNameKey}, payloadRatioDistribution),
 		diagUtils.NewMeasureView(w.completionRouteCount, []tag.Key{appIDKey, namespaceKey, taskTypeKey, completionRouteKey}, view.Count()))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // WorkflowOperationEvent records total number of Successful/Failed workflow Operations requests. It also records latency for those requests.
@@ -243,10 +273,10 @@ func (w *workflowMetrics) WorkflowOperationEvent(ctx context.Context, operation,
 		return
 	}
 
-	stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.workflowOperationCount.Name(), appIDKey, w.appID, namespaceKey, w.namespace, operationKey, operation, statusKey, status)...), stats.WithMeasurements(w.workflowOperationCount.M(1)))
+	w.workflowOperationCountC.Record2(operationKey, operation, statusKey, status)
 
 	if elapsed > 0 {
-		stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.workflowOperationLatency.Name(), appIDKey, w.appID, namespaceKey, w.namespace, operationKey, operation, statusKey, status)...), stats.WithMeasurements(w.workflowOperationLatency.M(elapsed)))
+		w.workflowOperationLatencyC.Record2(operationKey, operation, statusKey, status, elapsed)
 	}
 }
 
@@ -257,7 +287,7 @@ func (w *workflowMetrics) WorkflowExecutionEvent(ctx context.Context, workflowNa
 		return
 	}
 
-	stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.workflowExecutionCount.Name(), appIDKey, w.appID, namespaceKey, w.namespace, workflowNameKey, workflowName, statusKey, status)...), stats.WithMeasurements(w.workflowExecutionCount.M(1)))
+	w.workflowExecutionCountC.Record2(workflowNameKey, workflowName, statusKey, status)
 }
 
 func (w *workflowMetrics) WorkflowExecutionLatency(ctx context.Context, workflowName, status string, elapsed float64) {
@@ -266,7 +296,7 @@ func (w *workflowMetrics) WorkflowExecutionLatency(ctx context.Context, workflow
 	}
 
 	if elapsed > 0 {
-		stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.workflowExecutionLatency.Name(), appIDKey, w.appID, namespaceKey, w.namespace, workflowNameKey, workflowName, statusKey, status)...), stats.WithMeasurements(w.workflowExecutionLatency.M(elapsed)))
+		w.workflowExecutionLatencyC.Record2(workflowNameKey, workflowName, statusKey, status, elapsed)
 	}
 }
 
@@ -276,7 +306,7 @@ func (w *workflowMetrics) WorkflowSchedulingLatency(ctx context.Context, workflo
 	}
 
 	if elapsed > 0 {
-		stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.workflowSchedulingLatency.Name(), appIDKey, w.appID, namespaceKey, w.namespace, workflowNameKey, workflowName)...), stats.WithMeasurements(w.workflowSchedulingLatency.M(elapsed)))
+		w.schedulingLatencyC.Record1(workflowNameKey, workflowName, elapsed)
 	}
 }
 
@@ -286,10 +316,10 @@ func (w *workflowMetrics) ActivityExecutionEvent(ctx context.Context, activityNa
 		return
 	}
 
-	stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.activityExecutionCount.Name(), appIDKey, w.appID, namespaceKey, w.namespace, activityNameKey, activityName, statusKey, status)...), stats.WithMeasurements(w.activityExecutionCount.M(1)))
+	w.activityExecutionCountC.Record2(activityNameKey, activityName, statusKey, status)
 
 	if elapsed > 0 {
-		stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.activityExecutionLatency.Name(), appIDKey, w.appID, namespaceKey, w.namespace, activityNameKey, activityName, statusKey, status)...), stats.WithMeasurements(w.activityExecutionLatency.M(elapsed)))
+		w.activityExecutionLatencyC.Record2(activityNameKey, activityName, statusKey, status, elapsed)
 	}
 }
 
@@ -299,10 +329,10 @@ func (w *workflowMetrics) ActivityOperationEvent(ctx context.Context, activityNa
 		return
 	}
 
-	stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.activityOperationCount.Name(), appIDKey, w.appID, namespaceKey, w.namespace, activityNameKey, activityName, statusKey, status)...), stats.WithMeasurements(w.activityOperationCount.M(1)))
+	w.activityOperationCountC.Record2(activityNameKey, activityName, statusKey, status)
 
 	if elapsed > 0 {
-		stats.RecordWithOptions(ctx, stats.WithRecorder(w.meter), stats.WithTags(diagUtils.WithTags(w.activityOperationLatency.Name(), appIDKey, w.appID, namespaceKey, w.namespace, activityNameKey, activityName, statusKey, status)...), stats.WithMeasurements(w.activityOperationLatency.M(elapsed)))
+		w.activityOperationLatencyC.Record2(activityNameKey, activityName, statusKey, status, elapsed)
 	}
 }
 


### PR DESCRIPTION
Every hot-path metric record went through stats.RecordWithOptions, rebuilding the tag mutators and options struct per call. Cache one prebuilt recorder per measure at Init (direct meter.Record through a prebuilt tag map), so per-measure metric rules resolve exactly as before while the per-record allocation chain disappears. Applies to the workflow and activity operation/execution/latency records and the gRPC interceptor records.