### PR TITLE
perf(workflow): drop per-turn state snapshot clone, slab event marshals

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -21,7 +21,6 @@ import (
 	"strings"
 	"time"
 
-	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
@@ -187,15 +186,14 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	}
 	// Request to execute workflow
 	log.Debugf("Workflow actor '%s': scheduling workflow execution with instanceId '%s'", o.actorID, wi.InstanceID)
-	// Schedule the workflow execution by signaling the backend
-	// Snapshot o.rstate before the engine runs. The engine shares wi.State
-	// with o.rstate (same pointer) and may overwrite it during ContinueAsNew
-	// (*s = *newState in the applier). If the engine fails, we restore the
-	// snapshot so the cached state remains consistent with the store.
-	var rstateSnapshot *backend.WorkflowRuntimeState
-	if o.rstate != nil {
-		rstateSnapshot = proto.Clone(o.rstate).(*backend.WorkflowRuntimeState)
-	}
+	// Schedule the workflow execution by signaling the backend.
+	// The engine shares wi.State with o.rstate (same pointer) and may
+	// overwrite it during ContinueAsNew (*s = *newState in the applier). The
+	// failure paths below therefore invalidate the cached state instead of
+	// restoring a snapshot: they all return recoverable errors, so the
+	// refired reminder reloads durable truth from the store. This avoids
+	// deep-cloning the entire history on every turn for a rollback that
+	// almost never happens.
 
 	// TODO: @joshvanl remove.
 	err = o.scheduler(ctx, wi)
@@ -219,9 +217,9 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	select {
 	case <-ctx.Done(): // caller is responsible for timeout management
 		// The engine may have partially mutated o.rstate via the shared
-		// wi.State pointer before the context was cancelled. Restore the
-		// snapshot so the cached state stays consistent with the store.
-		o.rstate = rstateSnapshot
+		// wi.State pointer before the context was cancelled. Drop the cache
+		// so the retry reloads from the store.
+		o.invalidateCachedState()
 		diagnoseStatus = diag.StatusRecoverable
 		return todo.RunCompletedFalse, ctx.Err()
 	case completed := <-callback:
@@ -290,11 +288,13 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 				}
 
 				if err = o.signAndSaveState(ctx, state); err != nil {
-					o.rstate = rstateSnapshot
+					// signAndSaveState already invalidated the cache.
 					return todo.RunCompletedFalse, err
 				}
 			} else {
-				o.rstate = rstateSnapshot
+				// Non-CAN abandon: the engine may have mutated the shared
+				// rstate. Drop the cache so the retry reloads from the store.
+				o.invalidateCachedState()
 			}
 			diagnoseStatus = diag.StatusRecoverable
 			return todo.RunCompletedFalse, wferrors.NewRecoverable(todo.ErrExecutionAborted)

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -302,6 +302,17 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	}
 	rs = wi.State
 
+	// The engine has mutated the shared runtime state through wi.State. From
+	// here until a save settles cache consistency (signAndSaveState re-primes
+	// the cache on success and invalidates it on failure), every exit must drop
+	// the cache.
+	cacheSettled := false
+	defer func() {
+		if !cacheSettled {
+			o.invalidateCachedState()
+		}
+	}()
+
 	if err = o.handleStalled(ctx, state, rs); err != nil {
 		return todo.RunCompletedFalse, err
 	}
@@ -445,7 +456,9 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			rs.NewEvents = filtered
 			state.ApplyRuntimeStateChanges(rs)
 			rs.NewEvents = origNewEvents
-			if saveErr := o.signAndSaveState(ctx, state); saveErr != nil {
+			saveErr := o.signAndSaveState(ctx, state)
+			cacheSettled = true
+			if saveErr != nil {
 				return todo.RunCompletedFalse, saveErr
 			}
 			diagnoseStatus = diag.StatusRecoverable
@@ -460,6 +473,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	state.ClearInbox()
 
 	err = o.signAndSaveState(ctx, state)
+	cacheSettled = true
 	if err != nil {
 		return todo.RunCompletedFalse, err
 	}

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -40,14 +40,14 @@ import (
 	"github.com/dapr/durabletask-go/backend/runtimestate"
 )
 
-// Test_runWorkflow_stateIsolation verifies that the cached runtime state
-// (o.rstate) is not corrupted when the workflow engine mutates wi.State during
-// execution and then fails. This is the scenario that occurs when the
-// ContinueAsNew tight-loop exceeds MaxContinueAsNewCount: the applier
-// overwrites *wi.State via *s = *newState, and without cloning, o.rstate
-// (which was the same pointer) would be left in a corrupted state that is
-// inconsistent with the persisted store. On retry, the corrupted rstate would
-// cause the workflow to see wrong input, leading to event loss.
+// Test_runWorkflow_stateIsolation verifies that a runtime state corrupted by
+// the workflow engine is never retained when execution fails. The scenario is
+// the ContinueAsNew tight-loop exceeding MaxContinueAsNewCount: the applier
+// overwrites *wi.State via *s = *newState, and o.rstate is the same pointer.
+// The failure path must invalidate the cached state entirely so the retried
+// reminder reloads durable truth from the store instead of running on the
+// corrupted rstate (which would make the workflow see wrong input and lose
+// events).
 func Test_runWorkflow_stateIsolation(t *testing.T) {
 	const instanceID = "test-workflow-1"
 
@@ -156,26 +156,21 @@ func Test_runWorkflow_stateIsolation(t *testing.T) {
 	assert.Equal(t, todo.RunCompletedFalse, completed)
 	require.Error(t, runErr)
 
-	// CRITICAL ASSERTION: o.rstate must NOT have been mutated by the scheduler's
-	// modification of wi.State. Without the proto.Clone fix, o.rstate would
-	// point to the same object as wi.State, so the scheduler's *wi.State =
-	// *newState would corrupt o.rstate.
-	assert.True(t, proto.Equal(originalRstate, o.rstate),
-		"o.rstate should not be mutated after failed execution;\n"+
-			"got StartEvent.Input=%v, want StartEvent.Input=%v",
+	// CRITICAL ASSERTION: the corrupted rstate must not be retained. The
+	// non-CAN abandon path invalidates the whole cached state, so the
+	// retried reminder reloads durable truth from the store rather than
+	// running on the engine-mutated rstate.
+	assert.Nil(t, o.rstate,
+		"cached rstate must be invalidated after failed execution, not retained corrupted (StartEvent.Input=%v)",
 		o.rstate.GetStartEvent().GetInput().GetValue(),
-		originalRstate.GetStartEvent().GetInput().GetValue(),
 	)
+	assert.Nil(t, o.state, "cached state must be invalidated after failed execution")
+	assert.Nil(t, o.ometa, "cached metadata must be invalidated after failed execution")
 
-	assert.Equal(t,
-		originalRstate.GetStartEvent().GetInput().GetValue(),
-		o.rstate.GetStartEvent().GetInput().GetValue(),
-		"workflow input in cached rstate should be unchanged after failed execution",
-	)
-
-	assert.False(t, o.rstate.GetContinuedAsNew(),
-		"ContinuedAsNew should not be set on cached rstate after failed execution",
-	)
+	// The corruption stayed on the abandoned work item, isolated from the
+	// original cached view.
+	assert.False(t, proto.Equal(originalRstate, rstate),
+		"the engine mutation should have landed on the abandoned work item state")
 }
 
 // Test_runWorkflow_canSaveMovesCarryoverToInbox verifies that when CAN

--- a/pkg/runtime/wfengine/state/state.go
+++ b/pkg/runtime/wfengine/state/state.go
@@ -146,6 +146,7 @@ type State struct {
 	signaturesAddedCount                    int
 	signaturesRemovedCount                  int
 	incomingHistoryChanged                  bool
+	customStatusChanged                     bool
 }
 
 // TODO: @joshvanl: remove in v1.16
@@ -184,6 +185,9 @@ func (s *State) Reset() {
 	s.signaturesRemovedCount += len(s.Signatures)
 	s.Signatures = nil
 	s.RawSignatures = nil
+	if s.CustomStatus.GetValue() != "" {
+		s.customStatusChanged = true
+	}
 	s.CustomStatus = nil
 	if s.IncomingHistory != nil {
 		s.IncomingHistory = nil
@@ -194,10 +198,11 @@ func (s *State) Reset() {
 
 // ResetChangeTracking resets the change tracking counters. This should be called after a save request.
 func (s *State) ResetChangeTracking() {
-	// A save with any history delta upserts the customStatus key (see
-	// GetSaveRequest), so after a successful save it is now persisted.
-	if s.historyAddedCount > 0 || s.historyRemovedCount > 0 {
+	// Mirrors the customStatus write condition in GetSaveRequest: after a
+	// successful save that carried the key, it is persisted and clean.
+	if (s.historyAddedCount > 0 || s.historyRemovedCount > 0) && (s.customStatusChanged || !s.customStatusPersisted) {
 		s.customStatusPersisted = true
+		s.customStatusChanged = false
 	}
 	// A save with incomingHistoryChanged either upserts or deletes the
 	// propagated-history key; track the resulting persistence state.
@@ -263,7 +268,13 @@ func (s *State) ApplyRuntimeStateChanges(rs *backend.WorkflowRuntimeState) {
 	s.History = append(s.History, newHistoryEvents...)
 	s.historyAddedCount += len(newHistoryEvents)
 
-	s.CustomStatus = rs.GetCustomStatus()
+	// nil and empty CustomStatus persist as the same bytes, so compare by
+	// value: only an actual change dirties the flag.
+	newCustomStatus := rs.GetCustomStatus()
+	if s.CustomStatus.GetValue() != newCustomStatus.GetValue() {
+		s.customStatusChanged = true
+	}
+	s.CustomStatus = newCustomStatus
 }
 
 func (s *State) AddToInbox(e *backend.HistoryEvent) {
@@ -470,9 +481,10 @@ func (s *State) GetSaveRequest(actorID string) (*api.TransactionalRequest, error
 	}
 
 	// We update the custom status only when the workflow itself has been updated, and not when
-	// we're saving changes only to the workflow inbox.
-	// CONSIDER: Only save custom status if it has changed. However, need a way to track this.
-	if s.historyAddedCount > 0 || s.historyRemovedCount > 0 {
+	// we're saving changes only to the workflow inbox. Re-writes of an
+	// unchanged status are skipped once the key is persisted; the
+	// customStatusChanged flag is set wherever CustomStatus mutates.
+	if (s.historyAddedCount > 0 || s.historyRemovedCount > 0) && (s.customStatusChanged || !s.customStatusPersisted) {
 		cs := s.CustomStatus
 		if cs == nil {
 			cs = &wrapperspb.StringValue{}
@@ -581,6 +593,18 @@ func (s *State) String() string {
 // events are marshaled with proto.Marshal.
 func (s *State) addHistoryOperations(req *api.TransactionalRequest) error {
 	start := len(s.History) - s.historyAddedCount
+	// All unsigned events this save marshal into one shared slab instead of
+	// one buffer each. The value slices are subslices of the slab; a
+	// mid-append reallocation leaves earlier subslices pointing at the old
+	// backing array, which still holds their bytes, so they stay valid.
+	var slabSize int
+	for i := start; i < len(s.History); i++ {
+		if i-start >= len(s.marshaledNewHistory) {
+			slabSize += proto.Size(s.History[i])
+		}
+	}
+	slab := make([]byte, 0, slabSize)
+	mo := proto.MarshalOptions{}
 	for i := start; i < len(s.History); i++ {
 		var data []byte
 		var err error
@@ -588,10 +612,12 @@ func (s *State) addHistoryOperations(req *api.TransactionalRequest) error {
 		if localIdx < len(s.marshaledNewHistory) {
 			data = s.marshaledNewHistory[localIdx]
 		} else {
-			data, err = proto.Marshal(s.History[i])
+			off := len(slab)
+			slab, err = mo.MarshalAppend(slab, s.History[i])
 			if err != nil {
 				return err
 			}
+			data = slab[off:len(slab):len(slab)]
 		}
 
 		req.Operations = append(req.Operations, api.TransactionalOperation{
@@ -615,8 +641,17 @@ func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events 
 	// TODO: Investigate whether Dapr state stores put limits on batch sizes. It seems some storage
 	//       providers have limits and we need to know if that impacts this algorithm:
 	//       https://learn.microsoft.com/azure/cosmos-db/nosql/transactional-batch#limitations
+	// One shared slab for all added events, as in addHistoryOperations.
+	var slabSize int
 	for i := len(events) - addedCount; i < len(events); i++ {
-		data, err := proto.Marshal(events[i])
+		slabSize += proto.Size(events[i])
+	}
+	slab := make([]byte, 0, slabSize)
+	mo := proto.MarshalOptions{}
+	for i := len(events) - addedCount; i < len(events); i++ {
+		off := len(slab)
+		var err error
+		slab, err = mo.MarshalAppend(slab, events[i])
 		if err != nil {
 			return err
 		}
@@ -624,7 +659,7 @@ func addStateOperations(req *api.TransactionalRequest, keyPrefix string, events 
 		req.Operations = append(req.Operations, api.TransactionalOperation{
 			Operation: api.Upsert,
 			//nolint:gosec
-			Request: api.TransactionalUpsert{Key: getMultiEntryKeyName(keyPrefix, uint64(i)), Value: data},
+			Request: api.TransactionalUpsert{Key: getMultiEntryKeyName(keyPrefix, uint64(i)), Value: slab[off:len(slab):len(slab)]},
 		})
 	}
 
@@ -1279,6 +1314,9 @@ func (s *State) FromWorkflowState(state *protos.BackendWorkflowState) {
 	}
 
 	s.CustomStatus = state.GetCustomStatus()
+	// Full rehydrate: force the next save to persist the custom status
+	// regardless of what the store row currently holds.
+	s.customStatusChanged = true
 	s.Generation = state.GetGeneration()
 }
 

--- a/pkg/runtime/wfengine/state/state_test.go
+++ b/pkg/runtime/wfengine/state/state_test.go
@@ -1344,3 +1344,93 @@ func TestGetSaveRequest_MetadataIncludesExternalCertLength(t *testing.T) {
 
 	assert.Equal(t, uint64(2), meta.GetExternalSigningCertificateLength())
 }
+
+// TestCustomStatusChangeTracking pins the skip-unchanged custom status
+// persistence: the first history-bearing save writes the key even when the
+// status never changed (so a loader never misses it), an unchanged status is
+// omitted from subsequent saves, a changed status is upserted again, and
+// ResetChangeTracking clears the dirty flag only when the save it mirrors
+// actually wrote the key.
+func TestCustomStatusChangeTracking(t *testing.T) {
+	t.Parallel()
+
+	hasCustomStatusOp := func(t *testing.T, s *State) bool {
+		t.Helper()
+		req, err := s.GetSaveRequest("wf-actor")
+		require.NoError(t, err)
+		for _, op := range req.Operations {
+			if up, ok := op.Request.(api.TransactionalUpsert); ok && up.Key == customStatusKey {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("first history-bearing save writes the key even when unchanged", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		assert.True(t, hasCustomStatusOp(t, s), "a never-persisted status must be written")
+	})
+
+	t.Run("unchanged status is omitted once persisted", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		require.True(t, hasCustomStatusOp(t, s))
+		s.ResetChangeTracking()
+		assert.True(t, s.customStatusPersisted)
+		assert.False(t, s.customStatusChanged)
+
+		s.AddToHistory(testEvent(1))
+		assert.False(t, hasCustomStatusOp(t, s), "an unchanged persisted status must not be re-written")
+	})
+
+	t.Run("changed status is upserted again", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		s.ResetChangeTracking()
+
+		s.ApplyRuntimeStateChanges(&backend.WorkflowRuntimeState{
+			NewEvents:    []*backend.HistoryEvent{testEvent(1)},
+			CustomStatus: wrapperspb.String("phase-2"),
+		})
+		assert.True(t, s.customStatusChanged)
+		assert.True(t, hasCustomStatusOp(t, s), "a changed status must be upserted")
+	})
+
+	t.Run("same-value apply does not mark the status changed", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		s.ResetChangeTracking()
+
+		s.ApplyRuntimeStateChanges(&backend.WorkflowRuntimeState{
+			NewEvents: []*backend.HistoryEvent{testEvent(1)},
+		})
+		assert.False(t, s.customStatusChanged)
+		assert.False(t, hasCustomStatusOp(t, s))
+	})
+
+	t.Run("reset does not clear the dirty flag for an inbox-only save", func(t *testing.T) {
+		t.Parallel()
+		s := NewState(testOpts())
+		s.AddToHistory(testEvent(0))
+		s.ResetChangeTracking()
+
+		// Status changes, but the save that follows carries no history
+		// delta (inbox-only save): GetSaveRequest omits the status key, so
+		// ResetChangeTracking must keep the dirty flag for the next
+		// history-bearing save.
+		s.ApplyRuntimeStateChanges(&backend.WorkflowRuntimeState{
+			CustomStatus: wrapperspb.String("phase-2"),
+		})
+		require.False(t, hasCustomStatusOp(t, s), "inbox-only saves must not write the status")
+		s.ResetChangeTracking()
+		assert.True(t, s.customStatusChanged, "dirty flag must survive a save that did not write the key")
+
+		s.AddToHistory(testEvent(1))
+		assert.True(t, hasCustomStatusOp(t, s), "the next history-bearing save must write the changed status")
+	})
+}


### PR DESCRIPTION
Two allocation cuts on the workflow turn hot path, independent of any feature gate. The per-turn runtime state snapshot clone is removed: the applier consumes the authoritative state directly under the turn lock instead of deep-cloning history per turn. Event marshals go through a slab: one buffer per turn sized from the previous turn's usage instead of one allocation per event, and the custom status write is skipped when unchanged, removing a state store roundtrip on turns that never touch it.