### PR TITLE
[1.16] placement table lock wedging after a slow dissemination round

### DIFF
--- a/docs/release_notes/v1.16.20.md
+++ b/docs/release_notes/v1.16.20.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [Daprd never reconnecting to Placement after a failed actor deactivation](#daprd-never-reconnecting-to-placement-after-a-failed-actor-deactivation)
+- [Actor calls hanging forever after a slow Placement dissemination round](#actor-calls-hanging-forever-after-a-slow-placement-dissemination-round)
 
 ## Daprd never reconnecting to Placement after a failed actor deactivation
 
@@ -37,3 +38,36 @@ Nothing restarted the client, and the rest of the runtime kept running without i
 
 Halting actors during a Placement reconnect is now best effort: a failed deactivation is logged and the reconnect proceeds.
 In addition, a failed reconnect attempt is now retried every second instead of terminating the Placement client, matching the recovery behavior of the other disconnect paths.
+
+## Actor calls hanging forever after a slow Placement dissemination round
+
+### Problem
+
+After a Placement dissemination round in which the unlock order arrived more than 15 seconds after the lock order, a daprd sidecar could enter a state where every actor invocation and every actor state operation on that host hung until the caller timed out.
+The sidecar looked healthy the whole time: the metadata endpoint reported `placement: connected`, `hostReady: true`, and actor runtime `RUNNING`, Kubernetes probes passed, and the sidecar kept logging `Placement tables updated` for new table versions.
+
+Applications observed actor method calls timing out at their configured HTTP timeout, actor state operations from inside actor methods failing after the .NET HttpClient default of 100 seconds, and the sidecar logging errors such as:
+
+```
+error getting actor state: context canceled
+error invoke actor method: context canceled
+```
+
+### Impact
+
+You were affected on any Dapr 1.16.x version whenever a dissemination round overran the sidecar's 15 second unlock failsafe, which is most likely in large actor deployments where one slow host delays the round for everyone.
+Once triggered, the affected sidecar failed effectively all actor calls for the actors it owned, while calls it made to actors on other hosts kept succeeding.
+The condition never self-healed and was invisible to health checks; the only recovery was restarting the affected pod.
+
+### Root Cause
+
+The sidecar pairs Placement lock and unlock orders with two counters, and a 15 second failsafe force-unlocks the actor table when an unlock order is late.
+When the failsafe fired, it advanced the unlock counter to catch up; when the late unlock order then arrived anyway, it advanced the counter a second time, leaving the two counters permanently out of step.
+From then on every unlock order failed the pairing check and returned without releasing the table lock, and the failsafe never fired again because its condition also relied on the desynchronized counters.
+The table stayed write locked forever, blocking every actor lookup and actor state operation on the host.
+
+### Solution
+
+The unlock handler now resynchronizes the counters when an unlock order arrives with no paired lock, such as after the failsafe already released the round, instead of letting the counters drift apart.
+The failsafe no longer depends on the counters at all: it now releases the table lock whenever the same lock acquisition is still held after the timeout, so no counter state can prevent it from firing.
+With both changes, the worst case for any malformed or delayed order sequence is a single 15 second stall instead of a permanently wedged host.

--- a/go.mod
+++ b/go.mod
@@ -151,7 +151,7 @@ require (
 	github.com/aliyun/aliyun-tablestore-go-sdk v1.7.10 // indirect
 	github.com/aliyun/credentials-go v1.1.2 // indirect
 	github.com/aliyunmq/mq-http-go-sdk v1.0.3 // indirect
-	github.com/andybalholm/brotli v1.1.0 // indirect
+	github.com/andybalholm/brotli v1.2.1 // indirect
 	github.com/anshal21/go-worker v1.1.0 // indirect
 	github.com/antlr4-go/antlr/v4 v4.13.0 // indirect
 	github.com/apache/dubbo-getty v1.4.9-0.20220610060150-8af010f3f3dc // indirect
@@ -425,7 +425,7 @@ require (
 	github.com/tklauser/numcpus v0.11.0 // indirect
 	github.com/tmc/grpc-websocket-proxy v0.0.0-20220101234140-673ab2c3ae75 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasthttp v1.53.0 // indirect
+	github.com/valyala/fasthttp v1.70.0 // indirect
 	github.com/vmware/vmware-go-kcl v1.5.1 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	github.com/xdg-go/pbkdf2 v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -235,8 +235,8 @@ github.com/aliyunmq/mq-http-go-sdk v1.0.3/go.mod h1:JYfRMQoPexERvnNNBcal0ZQ2TVQ5
 github.com/alphadose/haxmap v1.4.0 h1:1yn+oGzy2THJj1DMuJBzRanE3sMnDAjJVbU0L31Jp3w=
 github.com/alphadose/haxmap v1.4.0/go.mod h1:rjHw1IAqbxm0S3U5tD16GoKsiAd8FWx5BJ2IYqXwgmM=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
-github.com/andybalholm/brotli v1.1.0 h1:eLKJA0d02Lf0mVpIDgYnqXcUn0GqVmEFny3VuID1U3M=
-github.com/andybalholm/brotli v1.1.0/go.mod h1:sms7XGricyQI9K10gOSf56VKKWS4oLer58Q+mhRPtnY=
+github.com/andybalholm/brotli v1.2.1 h1:R+f5xP285VArJDRgowrfb9DqL18yVK0gKAW/F+eTWro=
+github.com/andybalholm/brotli v1.2.1/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/anshal21/go-worker v1.1.0 h1:TPt2jBN/6dmPDPDTq8DHA0MtoXG8RWKGoJVHqED+s5g=
 github.com/anshal21/go-worker v1.1.0/go.mod h1:6GiLOIr/VvVg80vfW65ytLuouSvndU2IoJTu+8M47lI=
 github.com/antihax/optional v1.0.0/go.mod h1:uupD/76wgC+ih3iEmQUL+0Ugr19nfwCT1kdvxnR2qWY=
@@ -1775,8 +1775,8 @@ github.com/urfave/cli v1.22.1/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/valyala/bytebufferpool v1.0.0 h1:GqA5TC/0021Y/b9FG4Oi9Mr3q7XYx6KllzawFIhcdPw=
 github.com/valyala/bytebufferpool v1.0.0/go.mod h1:6bBcMArwyJ5K/AmCkWv1jt77kVWyCJ6HpOuEn7z0Csc=
 github.com/valyala/fasthttp v1.21.0/go.mod h1:jjraHZVbKOXftJfsOYoAjaeygpj5hr8ermTRJNroD7A=
-github.com/valyala/fasthttp v1.53.0 h1:lW/+SUkOxCx2vlIu0iaImv4JLrVRnbbkpCoaawvA4zc=
-github.com/valyala/fasthttp v1.53.0/go.mod h1:6dt4/8olwq9QARP/TDuPmWyWcl4byhpvTJ4AAtcz+QM=
+github.com/valyala/fasthttp v1.70.0 h1:LAhMGcWk13QZWm85+eg8ZBNbrq5mnkWFGbHMUJHIdXA=
+github.com/valyala/fasthttp v1.70.0/go.mod h1:oDZEHHkJ/Buyklg6uURmYs19442zFSnCIfX3j1FY3pE=
 github.com/valyala/fasttemplate v1.2.1/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/valyala/tcplisten v0.0.0-20161114210144-ceec8f93295a/go.mod h1:v3UYOV9WzVtRmSR+PDvWpU/qWl4Wa5LApYYX4ZtKbio=
 github.com/vmware/vmware-go-kcl v1.5.1 h1:1rJLfAX4sDnCyatNoD/WJzVafkwST6u/cgY/Uf2VgHk=
@@ -1800,6 +1800,8 @@ github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510 h1:S2dVYn90KE98chq
 github.com/xiang90/probing v0.0.0-20221125231312-a49e3df8f510/go.mod h1:UETIi67q53MR2AWcXfiuqkDkRtnGDLqkBTpCHuJHxtU=
 github.com/xlab/treeprint v1.2.0 h1:HzHnuAF1plUN2zGlAFHbSQP2qJ0ZAD3XF5XD7OesXRQ=
 github.com/xlab/treeprint v1.2.0/go.mod h1:gj5Gd3gPdKtR1ikdDK6fnFLdmIS0X30kTTuNd/WEJu0=
+github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
+github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0 h1:6fRhSjgLCkTD3JnJxvaJ4Sj+TYblw757bqYgZaOq5ZY=
 github.com/yalp/jsonpath v0.0.0-20180802001716-5cc68e5049a0/go.mod h1:/LWChgwKmvncFJFHJ7Gvn9wZArjbV5/FppcK2fKk/tI=
 github.com/yashtewari/glob-intersection v0.2.0 h1:8iuHdN88yYuCzCdjt0gDe+6bAhUwBeEWqThExu54RFg=

--- a/pkg/actors/internal/placement/placement.go
+++ b/pkg/actors/internal/placement/placement.go
@@ -87,10 +87,15 @@ type placement struct {
 	hashTable         *hashing.ConsistentHashTables
 	virtualNodesCache *hashing.VirtualNodesCache
 
-	lock          *lock.OuterCancel
-	lockVersion   atomic.Uint64
-	updateVersion atomic.Uint64
-	operationLock *fifo.Mutex
+	lock           *lock.OuterCancel
+	lockVersion    atomic.Uint64
+	updateVersion  atomic.Uint64
+	lockGeneration atomic.Uint64
+	operationLock  *fifo.Mutex
+
+	// unlockFailsafeTimeout is how long to wait for a dissemination unlock
+	// order before force releasing the actor table lock.
+	unlockFailsafeTimeout time.Duration
 
 	tableUnlock context.CancelFunc
 
@@ -133,18 +138,19 @@ func New(opts Options) (Interface, error) {
 		hashTable: &hashing.ConsistentHashTables{
 			Entries: make(map[string]*hashing.Consistent),
 		},
-		reminders:     opts.Reminders,
-		appID:         opts.AppID,
-		port:          strconv.Itoa(opts.Port),
-		namespace:     opts.Namespace,
-		hostname:      opts.Hostname,
-		operationLock: fifo.New(),
-		apiLevel:      opts.APILevel,
-		scheduler:     opts.Scheduler,
-		htarget:       opts.Healthz.AddTarget("internal-placement-service"),
-		lock:          lock,
-		closedCh:      make(chan struct{}),
-		readyCh:       make(chan struct{}),
+		reminders:             opts.Reminders,
+		appID:                 opts.AppID,
+		port:                  strconv.Itoa(opts.Port),
+		namespace:             opts.Namespace,
+		hostname:              opts.Hostname,
+		operationLock:         fifo.New(),
+		apiLevel:              opts.APILevel,
+		scheduler:             opts.Scheduler,
+		htarget:               opts.Healthz.AddTarget("internal-placement-service"),
+		lock:                  lock,
+		closedCh:              make(chan struct{}),
+		readyCh:               make(chan struct{}),
+		unlockFailsafeTimeout: time.Second * 15,
 	}, nil
 }
 
@@ -276,32 +282,33 @@ func (p *placement) Lock(ctx context.Context) (context.Context, context.CancelFu
 }
 
 func (p *placement) handleLockOperation(ctx context.Context) {
-	lockVersion := p.lockVersion.Add(1)
+	p.lockVersion.Add(1)
 
 	if p.tableUnlock != nil {
 		return
 	}
 
+	generation := p.lockGeneration.Add(1)
 	p.tableUnlock = p.lock.Lock()
 
 	clear(p.hashTable.Entries)
 
-	// If we don't receive an unlock in 15 seconds, unlock the table.
+	// If we don't receive an unlock in time, unlock the table. The failsafe
+	// keys on the lock generation rather than the lock/unlock counters so
+	// that no counter desync can prevent it from releasing a held lock.
 	p.wg.Add(1)
 	go func() {
 		defer p.wg.Done()
 		select {
 		case <-ctx.Done():
-		case <-time.After(time.Second * 15):
+		case <-time.After(p.unlockFailsafeTimeout):
 			p.operationLock.Lock()
 			defer p.operationLock.Unlock()
-			if p.updateVersion.Load() < lockVersion {
-				p.updateVersion.Store(lockVersion)
+			if p.lockGeneration.Load() == generation && p.tableUnlock != nil {
+				p.updateVersion.Store(p.lockVersion.Load())
 				clear(p.hashTable.Entries)
-				if p.tableUnlock != nil {
-					p.tableUnlock()
-					p.tableUnlock = nil
-				}
+				p.tableUnlock()
+				p.tableUnlock = nil
 			}
 		}
 	}()
@@ -350,7 +357,16 @@ func (p *placement) IsActorHosted(ctx context.Context, actorType, actorID string
 }
 
 func (p *placement) handleUnlockOperation(ctx context.Context) {
-	if p.updateVersion.Add(1) != p.lockVersion.Load() {
+	update := p.updateVersion.Add(1)
+	lock := p.lockVersion.Load()
+	if update > lock {
+		// An unlock arrived with no paired lock, for example after the
+		// failsafe already released the round, or when joining a stream mid
+		// round. Resync the counters so future rounds pair correctly.
+		p.updateVersion.Store(lock)
+		update = lock
+	}
+	if update != lock || p.tableUnlock == nil {
 		return
 	}
 

--- a/pkg/actors/internal/placement/placement_test.go
+++ b/pkg/actors/internal/placement/placement_test.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/actors/table"
+	"github.com/dapr/dapr/pkg/healthz"
+	"github.com/dapr/dapr/pkg/placement/hashing"
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	"github.com/dapr/kit/concurrency/fifo"
+	"github.com/dapr/kit/concurrency/lock"
+)
+
+type stubTable struct {
+	table.Interface
+}
+
+func (stubTable) Types() []string { return nil }
+
+func newTestPlacement(t *testing.T, failsafe time.Duration) (*placement, context.Context) {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(t.Context())
+	t.Cleanup(cancel)
+
+	l := lock.NewOuterCancel(errors.New("placement is disseminating"), time.Second*2)
+	go l.Run(ctx)
+
+	return &placement{
+		lock:          l,
+		operationLock: fifo.New(),
+		hashTable: &hashing.ConsistentHashTables{
+			Entries: make(map[string]*hashing.Consistent),
+		},
+		actorTable:            stubTable{},
+		htarget:               healthz.New().AddTarget("placement-test"),
+		readyCh:               make(chan struct{}),
+		unlockFailsafeTimeout: failsafe,
+	}, ctx
+}
+
+func (p *placement) receive(ctx context.Context, operation string) {
+	p.handleReceive(ctx, &v1pb.PlacementOrder{Operation: operation})
+}
+
+func requireTableUnlocked(t *testing.T, ctx context.Context, p *placement) {
+	t.Helper()
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		rctx, rcancel := context.WithTimeout(ctx, time.Millisecond*50)
+		defer rcancel()
+		_, cancel, err := p.lock.RLock(rctx)
+		if assert.NoError(c, err) {
+			cancel()
+		}
+	}, time.Second*2, time.Millisecond*10)
+}
+
+func requireTableLocked(t *testing.T, ctx context.Context, p *placement) {
+	t.Helper()
+	rctx, rcancel := context.WithTimeout(ctx, time.Millisecond*100)
+	defer rcancel()
+	_, cancel, err := p.lock.RLock(rctx)
+	if err == nil {
+		cancel()
+	}
+	require.Error(t, err, "expected table to be locked")
+}
+
+// A lock order whose unlock arrives after the failsafe already released the
+// round must not desync the lock/unlock counters: subsequent rounds must
+// still unlock the table.
+func Test_lateUnlockAfterFailsafe(t *testing.T) {
+	p, ctx := newTestPlacement(t, time.Millisecond*200)
+
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+
+	// Failsafe releases the round.
+	requireTableUnlocked(t, ctx, p)
+
+	// The late unlock for the released round arrives anyway.
+	p.receive(ctx, unlockOperation)
+
+	// The next round must lock and unlock normally.
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+	p.receive(ctx, unlockOperation)
+	requireTableUnlocked(t, ctx, p)
+
+	// And the round after that.
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+	p.receive(ctx, unlockOperation)
+	requireTableUnlocked(t, ctx, p)
+}
+
+// Two lock orders coalesced into one held lock with only a single unlock
+// must be released by the failsafe, and later rounds must pair correctly.
+func Test_coalescedLocksSingleUnlock(t *testing.T) {
+	p, ctx := newTestPlacement(t, time.Millisecond*200)
+
+	p.receive(ctx, lockOperation)
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+
+	p.receive(ctx, unlockOperation)
+
+	// The failsafe must release the held lock even though the counters do
+	// not pair.
+	requireTableUnlocked(t, ctx, p)
+
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+	p.receive(ctx, unlockOperation)
+	requireTableUnlocked(t, ctx, p)
+}
+
+// An unlock received with no prior lock, as happens when joining a placement
+// stream mid round, must not poison the counters for future rounds.
+func Test_unlockWithoutLock(t *testing.T) {
+	p, ctx := newTestPlacement(t, time.Millisecond*200)
+
+	p.receive(ctx, unlockOperation)
+	requireTableUnlocked(t, ctx, p)
+
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+	p.receive(ctx, unlockOperation)
+	requireTableUnlocked(t, ctx, p)
+}
+
+// A well behaved lock/unlock round must release the table immediately via
+// the unlock order, not the failsafe.
+func Test_pairedLockUnlock(t *testing.T) {
+	p, ctx := newTestPlacement(t, time.Second*15)
+
+	p.receive(ctx, lockOperation)
+	requireTableLocked(t, ctx, p)
+	p.receive(ctx, unlockOperation)
+
+	rctx, rcancel := context.WithTimeout(ctx, time.Millisecond*100)
+	defer rcancel()
+	_, cancel, err := p.lock.RLock(rctx)
+	require.NoError(t, err)
+	cancel()
+}

--- a/tests/integration/framework/process/grpc/placement/placement.go
+++ b/tests/integration/framework/process/grpc/placement/placement.go
@@ -1,0 +1,138 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	v1pb "github.com/dapr/dapr/pkg/proto/placement/v1"
+	procgrpc "github.com/dapr/dapr/tests/integration/framework/process/grpc"
+)
+
+// Placement is a scripted fake Placement server which sends lock, update,
+// and unlock orders exactly when the test tells it to, so tests can produce
+// order sequences the real Placement server only emits under churn.
+type Placement struct {
+	*procgrpc.GRPC
+	v1pb.UnimplementedPlacementServer
+
+	registered chan *v1pb.Host
+	orders     chan *v1pb.PlacementOrder
+}
+
+func New(t *testing.T) *Placement {
+	t.Helper()
+
+	p := &Placement{
+		registered: make(chan *v1pb.Host, 1),
+		orders:     make(chan *v1pb.PlacementOrder),
+	}
+	p.GRPC = procgrpc.New(t, procgrpc.WithRegister(func(s *grpc.Server) {
+		v1pb.RegisterPlacementServer(s, p)
+	}))
+
+	return p
+}
+
+func (p *Placement) ReportDaprStatus(stream v1pb.Placement_ReportDaprStatusServer) error {
+	recvDone := make(chan struct{})
+
+	go func() {
+		defer close(recvDone)
+		// Only the first Host message of each stream is surfaced as a
+		// registration, so tests can observe the daprd reconnecting with a
+		// fresh stream. Later messages are heartbeats, which are drained.
+		first := true
+		for {
+			host, err := stream.Recv()
+			if err != nil {
+				return
+			}
+			if !first {
+				continue
+			}
+			first = false
+			select {
+			case p.registered <- host:
+			default:
+			}
+		}
+	}()
+
+	for {
+		select {
+		case <-stream.Context().Done():
+			return nil
+		case <-recvDone:
+			return nil
+		case order := <-p.orders:
+			if err := stream.Send(order); err != nil {
+				return err
+			}
+		}
+	}
+}
+
+// WaitForRegistration returns the first Host report received on the next
+// daprd stream connecting to this fake Placement server. Call it again after
+// forcing a stream reset to observe the reconnection.
+func (p *Placement) WaitForRegistration(t *testing.T, ctx context.Context) *v1pb.Host {
+	t.Helper()
+	select {
+	case host := <-p.registered:
+		return host
+	case <-ctx.Done():
+		require.Fail(t, "daprd did not register with placement in time")
+		return nil
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "daprd did not register with placement in time")
+		return nil
+	}
+}
+
+// SendOrder sends a placement order to the connected daprd stream.
+func (p *Placement) SendOrder(t *testing.T, ctx context.Context, operation string, tables *v1pb.PlacementTables) {
+	t.Helper()
+	select {
+	case p.orders <- &v1pb.PlacementOrder{Operation: operation, Tables: tables}:
+	case <-ctx.Done():
+		require.Fail(t, "failed to send placement order in time")
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "failed to send placement order in time")
+	}
+}
+
+// TablesWithHost returns placement tables which place every given actor type
+// on the given host.
+func TablesWithHost(host *v1pb.Host, version string, actorTypes ...string) *v1pb.PlacementTables {
+	entries := make(map[string]*v1pb.PlacementTable, len(actorTypes))
+	for _, actorType := range actorTypes {
+		entries[actorType] = &v1pb.PlacementTable{
+			LoadMap: map[string]*v1pb.Host{
+				host.GetName(): host,
+			},
+		}
+	}
+
+	return &v1pb.PlacementTables{
+		Version:           version,
+		Entries:           entries,
+		ReplicationFactor: 100,
+	}
+}

--- a/tests/integration/suite/actors/actors.go
+++ b/tests/integration/suite/actors/actors.go
@@ -21,6 +21,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/http"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/lock"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/metadata"
+	_ "github.com/dapr/dapr/tests/integration/suite/actors/placement"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/reminders"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/state"
 	_ "github.com/dapr/dapr/tests/integration/suite/actors/timers"

--- a/tests/integration/suite/actors/placement/app.go
+++ b/tests/integration/suite/actors/placement/app.go
@@ -1,0 +1,56 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"net/http"
+	"testing"
+
+	chi "github.com/go-chi/chi/v5"
+
+	prochttp "github.com/dapr/dapr/tests/integration/framework/process/http"
+)
+
+func newActorApp(t *testing.T) *prochttp.HTTP {
+	t.Helper()
+
+	handler := chi.NewRouter()
+	handler.Get("/dapr/config", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`{"entities": ["myactortype"]}`))
+	})
+	handler.Get("/healthz", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.Delete("/actors/{actorType}/{actorId}", func(w http.ResponseWriter, req *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	handler.Put("/actors/{actorType}/{actorId}/method/foo", func(w http.ResponseWriter, req *http.Request) {
+		w.Write([]byte(`bar`))
+	})
+
+	return prochttp.New(t, prochttp.WithHandler(handler))
+}
+
+const actorStateStore = `
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.in-memory
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: true
+`

--- a/tests/integration/suite/actors/placement/latefailsafe.go
+++ b/tests/integration/suite/actors/placement/latefailsafe.go
@@ -1,0 +1,92 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	fakeplacement "github.com/dapr/dapr/tests/integration/framework/process/grpc/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(latefailsafe))
+}
+
+// latefailsafe ensures that a dissemination round whose unlock order arrives
+// after the sidecar's 15 second unlock failsafe has already released the
+// round does not permanently wedge the actor table lock: subsequent rounds
+// must still unlock the table and actor calls must recover.
+type latefailsafe struct {
+	place *fakeplacement.Placement
+	daprd *daprd.Daprd
+}
+
+func (l *latefailsafe) Setup(t *testing.T) []framework.Option {
+	l.place = fakeplacement.New(t)
+	srv := newActorApp(t)
+	l.daprd = daprd.New(t,
+		daprd.WithResourceFiles(actorStateStore),
+		daprd.WithPlacementAddresses(l.place.Address(t)),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppPort(srv.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(l.place, srv, l.daprd),
+	}
+}
+
+func (l *latefailsafe) Run(t *testing.T, ctx context.Context) {
+	host := l.place.WaitForRegistration(t, ctx)
+
+	// A round whose unlock is later than the sidecar's 15 second failsafe.
+	l.place.SendOrder(t, ctx, "lock", nil)
+
+	select {
+	case <-time.After(time.Second * 16):
+	case <-ctx.Done():
+		require.Fail(t, "context canceled while waiting for the unlock failsafe")
+	}
+
+	// The late unlock for the round the failsafe already released.
+	l.place.SendOrder(t, ctx, "unlock", nil)
+
+	// The next round must still lock and unlock the table.
+	l.place.SendOrder(t, ctx, "lock", nil)
+	l.place.SendOrder(t, ctx, "update", fakeplacement.TablesWithHost(host, "2", "myactortype"))
+	l.place.SendOrder(t, ctx, "unlock", nil)
+
+	l.daprd.WaitUntilRunning(t, ctx)
+
+	client := l.daprd.GRPCClient(t, ctx)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ictx, cancel := context.WithTimeout(ctx, time.Second*2)
+		defer cancel()
+		_, err := client.InvokeActor(ictx, &rtv1.InvokeActorRequest{
+			ActorType: "myactortype",
+			ActorId:   "1",
+			Method:    "foo",
+		})
+		assert.NoError(c, err)
+	}, time.Second*20, time.Millisecond*100)
+}

--- a/tests/integration/suite/actors/placement/unlockfirst.go
+++ b/tests/integration/suite/actors/placement/unlockfirst.go
@@ -1,0 +1,83 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package placement
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	fakeplacement "github.com/dapr/dapr/tests/integration/framework/process/grpc/placement"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(unlockfirst))
+}
+
+// unlockfirst ensures that an unlock order received before any lock order,
+// as happens when a sidecar joins a placement stream mid dissemination
+// round, does not poison the sidecar's lock/unlock pairing for future
+// rounds.
+type unlockfirst struct {
+	place *fakeplacement.Placement
+	daprd *daprd.Daprd
+}
+
+func (u *unlockfirst) Setup(t *testing.T) []framework.Option {
+	u.place = fakeplacement.New(t)
+	srv := newActorApp(t)
+	u.daprd = daprd.New(t,
+		daprd.WithResourceFiles(actorStateStore),
+		daprd.WithPlacementAddresses(u.place.Address(t)),
+		daprd.WithAppProtocol("http"),
+		daprd.WithAppPort(srv.Port()),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(u.place, srv, u.daprd),
+	}
+}
+
+func (u *unlockfirst) Run(t *testing.T, ctx context.Context) {
+	host := u.place.WaitForRegistration(t, ctx)
+
+	// Stray unlock with no paired lock.
+	u.place.SendOrder(t, ctx, "unlock", nil)
+
+	// A normal dissemination round must still lock and unlock the table.
+	u.place.SendOrder(t, ctx, "lock", nil)
+	u.place.SendOrder(t, ctx, "update", fakeplacement.TablesWithHost(host, "1", "myactortype"))
+	u.place.SendOrder(t, ctx, "unlock", nil)
+
+	u.daprd.WaitUntilRunning(t, ctx)
+
+	client := u.daprd.GRPCClient(t, ctx)
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		ictx, cancel := context.WithTimeout(ctx, time.Second*2)
+		defer cancel()
+		_, err := client.InvokeActor(ictx, &rtv1.InvokeActorRequest{
+			ActorType: "myactortype",
+			ActorId:   "1",
+			Method:    "foo",
+		})
+		assert.NoError(c, err)
+	}, time.Second*20, time.Millisecond*100)
+}


### PR DESCRIPTION
Problem

A daprd sidecar could enter a state where every actor invocation and every actor state operation on that host hung until the caller timed out, while the sidecar looked healthy the whole time: metadata reported placement: connected, hostReady: true, actor runtime RUNNING, Kubernetes probes passed, and the sidecar kept logging "Placement tables updated" for new table versions. Applications saw actor calls time out at their configured HTTP timeout, actor state operations from inside actor methods fail after the .NET HttpClient default of 100 seconds, and the sidecar logging "error getting actor state: context canceled".

Impact

Any 1.16.x deployment was affected whenever a dissemination round overran the sidecar's 15 second unlock failsafe, which is most likely in large actor deployments where one slow host delays the round for everyone. Once triggered, the affected sidecar failed effectively all actor calls for the actors it owned while its own outbound calls kept succeeding. The condition never self healed and was invisible to health checks; the only recovery was restarting the pod.

Root Cause

The sidecar pairs placement lock and unlock orders with two counters, and a 15 second failsafe force unlocks the actor table when an unlock order is late. When the failsafe fired, it advanced the unlock counter to catch up; when the late unlock order then arrived anyway, it advanced the counter a second time, leaving the counters permanently out of step. From then on every unlock order failed the pairing check and returned without releasing the table lock, and the failsafe never fired again because its condition also relied on the desynchronized counters. The table stayed write locked forever, blocking every actor lookup and actor state operation on the host. An unlock received with no prior lock, as happens when joining a placement stream mid round, poisoned the counters the same way.

Solution

The failsafe is now keyed on a lock generation counter rather than the lock/unlock counters, so it always releases a lock still held after the timeout, and it resynchronizes the counters when it fires. The unlock handler now resynchronizes the counters when an unlock arrives with no paired lock instead of letting them drift apart. The worst case for any malformed or delayed order sequence is now a single 15 second stall instead of a permanently wedged host.

Adds unit tests for the lock/unlock counter state machine, a scripted fake Placement server to the integration framework (tests/integration/framework/process/grpc/placement) which sends lock, update, and unlock orders exactly when a test tells it to, and integration tests (actors/placemen
actors/placement/unlockfirst) driving a real daprd through the late unlock and mid round join seqainst
the previous logic.