### PR TITLE
perf(workflow): bounded actor residency, janitor hysteresis, scoped activity lock

### DIFF
--- a/pkg/actors/targets/workflow/activity/activity.go
+++ b/pkg/actors/targets/workflow/activity/activity.go
@@ -48,14 +48,6 @@ func (a *activity) InvokeMethod(ctx context.Context, req *internalsv1pb.Internal
 
 // InvokeReminder implements actors.InternalActor and executes the activity logic.
 func (a *activity) InvokeReminder(ctx context.Context, reminder *actorapi.Reminder) error {
-	if !reminder.SkipLock {
-		unlock, err := a.lock.ContextLock(ctx)
-		if err != nil {
-			return err
-		}
-		defer unlock()
-	}
-
 	if err := a.handleReminder(ctx, reminder); err != nil {
 		return err
 	}

--- a/pkg/actors/targets/workflow/activity/drive.go
+++ b/pkg/actors/targets/workflow/activity/drive.go
@@ -48,8 +48,9 @@ const (
 // MUST fall back to creating the durable reminder.
 //
 // The drive is detached: the arming Execute invocation holds the activity
-// actor lock the execution needs, and the execution can run for an arbitrary
-// length of time while the orchestrator's dispatch must unblock immediately.
+// actor lock the execution's claim needs, and the execution can run for an
+// arbitrary length of time while the orchestrator's dispatch must unblock
+// immediately.
 // It is scoped to the factory drive context, drained in HaltAll. Delivering
 // the execution through router.CallReminder re-enters the normal
 // InvokeReminder path, so locking, inflight dedup, error classification and
@@ -131,8 +132,9 @@ func (f *factory) driveActivity(driveCtx context.Context, actorID string, invoca
 
 	// SkipRetries: this drive owns its recovery (bounded local retries, then
 	// escalation to the durable reminder), so the router's blind 1s-backoff
-	// retries would only delay it. SkipLock stays false: the execution must
-	// hold the activity actor lock like any reminder fire.
+	// retries would only delay it. SkipLock stays false: the execution claim
+	// takes the activity actor lock like any locked reminder fire, and the
+	// lock is released before the app roundtrip (see claim in execute.go).
 	reminder := &actorapi.Reminder{
 		Name:        activityReminderName,
 		ActorType:   f.actorType,

--- a/pkg/actors/targets/workflow/activity/drive_test.go
+++ b/pkg/actors/targets/workflow/activity/drive_test.go
@@ -152,7 +152,7 @@ func Test_localDrive_successNoReminder(t *testing.T) {
 	assert.Equal(t, activityReminderName, call.Name)
 	assert.Equal(t, "wf::3", call.ActorID)
 	assert.True(t, call.SkipRetries, "the drive owns its recovery; the router's blind retries must be skipped")
-	assert.False(t, call.SkipLock, "the execution must hold the activity actor lock")
+	assert.False(t, call.SkipLock, "the execution claim must take the activity actor lock")
 	assert.NotNil(t, call.Data, "the invocation must ride on the synthetic reminder")
 
 	assert.Empty(t, h.sched.snapshotCreates(), "a successful drive must not create any reminder")

--- a/pkg/actors/targets/workflow/activity/execute.go
+++ b/pkg/actors/targets/workflow/activity/execute.go
@@ -144,6 +144,11 @@ func (a *activity) claim(ctx context.Context, key, workflowID string, taskID int
 		// parked followers into their retry chains, and a completion of the
 		// evicted execution arriving late is dropped by the orchestrator's
 		// duplicate-completion dedup.
+		if !call.TryEvict() {
+			// The owner entered resolve between the staleness read and here:
+			// the execution is publishing its result and must not be evicted.
+			return call, owner, nil
+		}
 		call.Finish(errStaleClaimEvicted)
 		a.inflight.Release(key, call)
 		log.Warnf("Activity actor '%s': evicted a stale in-flight claim (no engine-held work item after %s); re-executing", a.actorID, call.Age())

--- a/pkg/actors/targets/workflow/activity/execute.go
+++ b/pkg/actors/targets/workflow/activity/execute.go
@@ -34,7 +34,7 @@ import (
 var errStaleClaimEvicted = wferrors.NewRecoverable(errors.New(
 	"in-flight activity claim evicted as stale (its work item is no longer held by the engine); re-executing"))
 
-func (a *activity) executeActivity(ctx context.Context, name string, invocation *protos.ActivityInvocation) error {
+func (a *activity) executeActivity(ctx context.Context, name string, invocation *protos.ActivityInvocation, skipLock bool) error {
 	taskEvent := invocation.GetHistoryEvent()
 	activityName := ""
 	if ts := taskEvent.GetTaskScheduled(); ts != nil {
@@ -62,7 +62,10 @@ func (a *activity) executeActivity(ctx context.Context, name string, invocation 
 
 	key := inflight.Key(a.actorID, taskEvent)
 	for {
-		call, owner := a.claim(key, workflowID, taskEvent.GetEventId())
+		call, owner, err := a.claim(ctx, key, workflowID, taskEvent.GetEventId(), skipLock)
+		if err != nil {
+			return err
+		}
 		if owner {
 			return a.runOwned(ctx, key, call, name, activityName, workflowID, taskEvent, invocation)
 		}
@@ -76,6 +79,16 @@ func (a *activity) executeActivity(ctx context.Context, name string, invocation 
 		// can turn stale AFTER followers arrive (the owner's work item lost
 		// mid-wait), and claim() only evicts at claim time.
 		log.Debugf("Activity actor '%s': following in-flight execution of '%s'", a.actorID, name)
+		if a.staleClaimAfter <= 0 {
+			// No eviction grace configured (test harnesses): park without
+			// the staleness recheck.
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-call.Done():
+				return call.Err()
+			}
+		}
 		stale := false
 		ticker := time.NewTicker(a.staleClaimAfter)
 		for !stale {
@@ -97,12 +110,29 @@ func (a *activity) executeActivity(ctx context.Context, name string, invocation 
 	}
 }
 
-// claim acquires the inflight entry for key, evicting a stale claim first.
-func (a *activity) claim(key, workflowID string, taskID int32) (*inflight.Call, bool) {
+// claim acquires the inflight entry for key, taking the actor lock for the
+// claim only unless the caller asked to skip it.
+// The lock MUST NOT extend past the claim: the segments that follow are the
+// app roundtrip (arbitrary length) and the result delivery into the parent
+// workflow (contends on the parent's turn lock), and holding the per-actor
+// lock across either parks Execute dispatches mesh-wide behind slow parent
+// turns. Neither segment needs the actor's serialization: the inflight entry
+// dedups duplicate arrivals (they join as followers, locked or not), and a
+// crash mid-execution is recovered by the parent janitor re-dispatching the
+// unresolved TaskScheduled event.
+func (a *activity) claim(ctx context.Context, key, workflowID string, taskID int32, skipLock bool) (*inflight.Call, bool, error) {
+	if !skipLock {
+		unlock, err := a.lock.ContextLock(ctx)
+		if err != nil {
+			return nil, false, err
+		}
+		defer unlock()
+	}
+
 	for {
 		call, owner := a.inflight.Acquire(key)
 		if owner || !a.staleClaim(call, workflowID, taskID) {
-			return call, owner
+			return call, owner, nil
 		}
 
 		// The claim belongs to a dead execution: its work item left the
@@ -122,7 +152,11 @@ func (a *activity) claim(key, workflowID string, taskID int32) (*inflight.Call, 
 }
 
 // staleClaim reports whether an inflight claim is provably dead: unsettled,
-// older than the stale grace, and with no engine-held work item for it. A
+// not resolving, older than the stale grace, and with no engine-held work
+// item for it. The resolving phase covers the gap between the engine
+// releasing its held registration (work item completed) and the result
+// publish settling the call: the publish contends on the parent workflow's
+// turn lock and must never read as stale. A
 // live execution of any length keeps its completion registration in the
 // engine, so it is never stale regardless of age (long-running activities
 // are not re-executed). The grace is two janitor periods: it must exceed the
@@ -133,7 +167,7 @@ func (a *activity) claim(key, workflowID string, taskID int32) (*inflight.Call, 
 // degrades to a duplicate execution absorbed by the orchestrator's dedup
 // (at-least-once, the same guarantee the durable reminder path provides).
 func (a *activity) staleClaim(call *inflight.Call, workflowID string, taskID int32) bool {
-	if call.Settled() || call.Age() < a.staleClaimAfter {
+	if call.Settled() || call.Resolving() || call.Age() < a.staleClaimAfter {
 		return false
 	}
 	return a.executionHeld != nil && !a.executionHeld(workflowID, taskID)

--- a/pkg/actors/targets/workflow/activity/execute_test.go
+++ b/pkg/actors/targets/workflow/activity/execute_test.go
@@ -1,0 +1,242 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activity
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+func newExecHarness() (*factory, chan *backend.ActivityWorkItem) {
+	scheduled := make(chan *backend.ActivityWorkItem, 2)
+	f := &factory{
+		appID:             "testapp",
+		actorType:         "dapr.internal.default.testapp.activity",
+		workflowActorType: "dapr.internal.default.testapp.workflow",
+		router:            routerfake.New(),
+		signing:           &signing.Signing{Namespace: "default"},
+		scheduler: func(_ context.Context, wi *backend.ActivityWorkItem) error {
+			scheduled <- wi
+			return nil
+		},
+	}
+	return f, scheduled
+}
+
+func Test_executeActivity_lockFreeDuringExecution(t *testing.T) {
+	t.Parallel()
+	f, scheduled := newExecHarness()
+
+	a := f.GetOrCreate("wf::3").(*activity)
+
+	ownerErr := make(chan error, 1)
+	go func() {
+		ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false)
+	}()
+
+	var wi *backend.ActivityWorkItem
+	select {
+	case wi = <-scheduled:
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for the WorkItem dispatch")
+	}
+
+	// The owner is parked on the SDK callback (the app roundtrip). The actor
+	// lock must be free: Execute dispatches and duplicate reminder fires must
+	// not queue behind the execution.
+	unlock, err := a.lock.ContextLock(t.Context())
+	require.NoError(t, err, "the actor lock must be free while the app executes")
+	unlock()
+
+	// A duplicate locked fire during the unlocked execution joins as a
+	// follower via the inflight entry and must not dispatch a second
+	// WorkItem.
+	followerErr := make(chan error, 1)
+	go func() {
+		followerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false)
+	}()
+
+	wi.Result = &protos.HistoryEvent{
+		EventId: -1,
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 3},
+		},
+	}
+	callback, ok := wi.Properties[todo.CallbackChannelProperty].(chan bool)
+	require.True(t, ok)
+	callback <- true
+
+	select {
+	case err := <-ownerErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for the owner to finish")
+	}
+	select {
+	case err := <-followerErr:
+		require.NoError(t, err)
+	case <-time.After(time.Second * 5):
+		t.Fatal("timed out waiting for the follower to finish")
+	}
+
+	select {
+	case <-scheduled:
+		t.Fatal("the duplicate fire must not dispatch a second WorkItem")
+	default:
+	}
+}
+
+func Test_claim(t *testing.T) {
+	t.Parallel()
+	f, _ := newExecHarness()
+
+	a := f.GetOrCreate("wf::3").(*activity)
+
+	unlock, err := a.lock.ContextLock(t.Context())
+	require.NoError(t, err)
+
+	// A skipLock claim must not touch the actor lock.
+	call, owner, err := a.claim(t.Context(), "k1", "wf", 3, true)
+	require.NoError(t, err)
+	assert.True(t, owner)
+	a.inflight.Release("k1", call)
+
+	// A locked claim parks on the held lock and surfaces ctx cancellation.
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+	_, _, err = a.claim(ctx, "k2", "wf", 3, false)
+	require.ErrorIs(t, err, context.Canceled)
+
+	unlock()
+	call, owner, err = a.claim(t.Context(), "k2", "wf", 3, false)
+	require.NoError(t, err)
+	assert.True(t, owner)
+
+	// A second claim for the same key is a follower on the same call.
+	call2, owner2, err := a.claim(t.Context(), "k2", "wf", 3, false)
+	require.NoError(t, err)
+	assert.False(t, owner2)
+	assert.Same(t, call, call2)
+	a.inflight.Release("k2", call)
+}
+
+// Test_claimStaleEviction covers the janitor-livelock rescue: a claim held by
+// a dead execution (unsettled, past the grace, no engine-held work item) is
+// evicted so the arrival re-executes as a fresh owner, while live, young, or
+// settled claims are followed as before.
+func Test_claimStaleEviction(t *testing.T) {
+	t.Parallel()
+
+	newHarness := func(held func(string, int32) bool, grace time.Duration) *activity {
+		f, _ := newExecHarness()
+		f.executionHeld = held
+		f.staleClaimAfter = grace
+		return f.GetOrCreate("wf::3").(*activity)
+	}
+
+	t.Run("dead claim is evicted and ownership reclaimed", func(t *testing.T) {
+		t.Parallel()
+		a := newHarness(func(string, int32) bool { return false }, time.Millisecond)
+
+		stale, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		require.True(t, owner)
+		time.Sleep(5 * time.Millisecond)
+
+		fresh, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		assert.True(t, owner, "the rescue must become a fresh owner")
+		assert.NotSame(t, stale, fresh)
+
+		// The evicted call is settled with the recoverable eviction error so
+		// parked followers unblock into their retry chains.
+		select {
+		case <-stale.Done():
+		default:
+			t.Fatal("the evicted call must be settled")
+		}
+		require.ErrorIs(t, stale.Err(), errStaleClaimEvicted)
+	})
+
+	t.Run("engine-held claim is never evicted", func(t *testing.T) {
+		t.Parallel()
+		a := newHarness(func(string, int32) bool { return true }, time.Millisecond)
+
+		call, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		require.True(t, owner)
+		time.Sleep(5 * time.Millisecond)
+
+		follower, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		assert.False(t, owner, "a live long-running execution must be followed, not evicted")
+		assert.Same(t, call, follower)
+	})
+
+	t.Run("young claim is never evicted", func(t *testing.T) {
+		t.Parallel()
+		a := newHarness(func(string, int32) bool { return false }, time.Hour)
+
+		call, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		require.True(t, owner)
+
+		follower, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		assert.False(t, owner)
+		assert.Same(t, call, follower)
+	})
+
+	t.Run("settled claim keeps its cached outcome", func(t *testing.T) {
+		t.Parallel()
+		a := newHarness(func(string, int32) bool { return false }, time.Millisecond)
+
+		call, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		require.True(t, owner)
+		call.Finish(nil)
+		time.Sleep(5 * time.Millisecond)
+
+		follower, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		assert.False(t, owner, "a cached outcome must be followed, never evicted")
+		assert.Same(t, call, follower)
+		require.NoError(t, follower.Err())
+	})
+
+	t.Run("nil oracle disables eviction", func(t *testing.T) {
+		t.Parallel()
+		a := newHarness(nil, time.Millisecond)
+
+		call, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		require.True(t, owner)
+		time.Sleep(5 * time.Millisecond)
+
+		follower, owner, err := a.claim(t.Context(), "k", "wf", 3, false)
+		require.NoError(t, err)
+		assert.False(t, owner)
+		assert.Same(t, call, follower)
+	})
+}

--- a/pkg/actors/targets/workflow/activity/factory.go
+++ b/pkg/actors/targets/workflow/activity/factory.go
@@ -70,6 +70,12 @@ type Options struct {
 	// claim uses it to tell a live in-flight execution from one whose work
 	// item was lost (see staleClaim). Nil disables eviction.
 	ExecutionHeld func(workflowInstanceID string, taskID int32) bool
+
+	// RegisterResolver registers the owner execution's resolve hook with the
+	// engine's completion waiter, which invokes it before releasing the held
+	// registration (the stale-claim handshake). Nil when the engine backend
+	// does not support it; the resolve then happens on callback receipt.
+	RegisterResolver func(workflowInstanceID string, taskID int32, resolve func()) func()
 }
 
 type factory struct {
@@ -96,8 +102,9 @@ type factory struct {
 	// executionHeld and staleClaimAfter power the stale-claim eviction in
 	// claim (see execute.go). staleClaimAfter is a field only so unit tests
 	// can compress the grace; it is set once in New.
-	executionHeld   func(workflowInstanceID string, taskID int32) bool
-	staleClaimAfter time.Duration
+	executionHeld    func(workflowInstanceID string, taskID int32) bool
+	registerResolver func(workflowInstanceID string, taskID int32, resolve func()) func()
+	staleClaimAfter  time.Duration
 
 	// inflight tracks activity executions whose WorkItem is currently in
 	// the durabletask queue or being processed by the SDK. Keyed by the
@@ -163,6 +170,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		actorType:              opts.ActivityActorType,
 		fastPath:               opts.FastPath,
 		executionHeld:          opts.ExecutionHeld,
+		registerResolver:       opts.RegisterResolver,
 		staleClaimAfter:        2 * common.JanitorPeriod(),
 		driveCtx:               driveCtx,
 		driveCancel:            driveCancel,

--- a/pkg/actors/targets/workflow/activity/inflight/call.go
+++ b/pkg/actors/targets/workflow/activity/inflight/call.go
@@ -15,15 +15,17 @@ package inflight
 
 import (
 	"sync"
+	"sync/atomic"
 	"time"
 )
 
 // Call tracks a single in-flight activity execution.
 type Call struct {
-	done    chan struct{}
-	once    sync.Once
-	err     error
-	created time.Time
+	resolving atomic.Bool
+	done      chan struct{}
+	once      sync.Once
+	err       error
+	created   time.Time
 }
 
 func newCall() *Call {
@@ -34,6 +36,20 @@ func newCall() *Call {
 // eviction check (see the activity target's claim).
 func (c *Call) Age() time.Duration {
 	return time.Since(c.created)
+}
+
+// BeginResolve marks the call as resolving: its engine work item has
+// completed and the result is being published into the parent workflow.
+// The engine's held registration is released at completion, so without this
+// phase the publish window (which contends on the parent's turn lock) would
+// read as not-held and a stale-claim check could evict a healthy execution.
+func (c *Call) BeginResolve() {
+	c.resolving.Store(true)
+}
+
+// Resolving reports whether the call has entered the resolve phase.
+func (c *Call) Resolving() bool {
+	return c.resolving.Load()
 }
 
 // Settled reports whether Finish has been called.

--- a/pkg/actors/targets/workflow/activity/inflight/call.go
+++ b/pkg/actors/targets/workflow/activity/inflight/call.go
@@ -21,11 +21,11 @@ import (
 
 // Call tracks a single in-flight activity execution.
 type Call struct {
-	resolving atomic.Bool
-	done      chan struct{}
-	once      sync.Once
-	err       error
-	created   time.Time
+	phase   atomic.Int32
+	done    chan struct{}
+	once    sync.Once
+	err     error
+	created time.Time
 }
 
 func newCall() *Call {
@@ -38,18 +38,37 @@ func (c *Call) Age() time.Duration {
 	return time.Since(c.created)
 }
 
-// BeginResolve marks the call as resolving: its engine work item has
-// completed and the result is being published into the parent workflow.
-// The engine's held registration is released at completion, so without this
-// phase the publish window (which contends on the parent's turn lock) would
-// read as not-held and a stale-claim check could evict a healthy execution.
-func (c *Call) BeginResolve() {
-	c.resolving.Store(true)
+// Call phases: a call starts executing; the owner moves it to resolving when
+// its engine work item completes and the result publish begins; a stale-claim
+// check moves it to evicted. Resolve and evict both CAS out of executing, so
+// exactly one transition wins: an eviction can never land mid-publish, and a
+// resolve can never resurrect an evicted call.
+const (
+	phaseExecuting = int32(iota)
+	phaseResolving
+	phaseEvicted
+)
+
+// BeginResolve moves the call from executing to resolving: its engine work
+// item has completed and the result is being published into the parent
+// workflow. The engine's held registration is released at completion, so
+// without this phase the publish window (which contends on the parent's
+// turn lock) would read as not-held and a stale-claim check could evict a
+// healthy execution. Returns false if an eviction won the race first.
+func (c *Call) BeginResolve() bool {
+	return c.phase.CompareAndSwap(phaseExecuting, phaseResolving)
+}
+
+// TryEvict moves the call from executing to evicted. Returns false if the
+// call is resolving (or already evicted): the caller must then treat the
+// claim as live.
+func (c *Call) TryEvict() bool {
+	return c.phase.CompareAndSwap(phaseExecuting, phaseEvicted)
 }
 
 // Resolving reports whether the call has entered the resolve phase.
 func (c *Call) Resolving() bool {
-	return c.resolving.Load()
+	return c.phase.Load() == phaseResolving
 }
 
 // Settled reports whether Finish has been called.

--- a/pkg/actors/targets/workflow/activity/invoke.go
+++ b/pkg/actors/targets/workflow/activity/invoke.go
@@ -152,7 +152,7 @@ func (a *activity) handleReminder(ctx context.Context, reminder *actorapi.Remind
 		return errors.New("activity reminder missing history event")
 	}
 
-	err := a.executeActivity(ctx, reminder.Name, &invocation)
+	err := a.executeActivity(ctx, reminder.Name, &invocation, reminder.SkipLock)
 
 	// Returning nil signals that we want the execution to be retried in the next
 	// period interval

--- a/pkg/actors/targets/workflow/activity/owner.go
+++ b/pkg/actors/targets/workflow/activity/owner.go
@@ -58,6 +58,10 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 	//       introduce some kind of heartbeat protocol to help identify such cases.
 	callback := make(chan bool, 1)
 	wi.Properties[todo.CallbackChannelProperty] = callback
+	unregister := func() {}
+	if a.registerResolver != nil {
+		unregister = a.registerResolver(workflowID, taskEvent.GetEventId(), func() { call.BeginResolve() })
+	}
 	log.Debugf("Activity actor '%s': scheduling activity '%s' for workflow with instanceId '%s'", a.actorID, name, wi.InstanceID)
 	start := time.Now()
 	err := a.scheduler(ctx, wi)
@@ -66,12 +70,14 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 	if errors.Is(err, context.DeadlineExceeded) {
 		diag.DefaultWorkflowMonitoring.ActivityOperationEvent(ctx, activityName, diag.StatusRecoverable, elapsed)
 		wfErr := wferrors.NewRecoverable(fmt.Errorf("timed-out trying to schedule an activity execution - this can happen if too many activities are running in parallel or if the workflow engine isn't running: %w", err))
+		unregister()
 		a.inflight.Release(key, call)
 		call.Finish(wfErr)
 		return wfErr
 	} else if err != nil {
 		diag.DefaultWorkflowMonitoring.ActivityOperationEvent(ctx, activityName, diag.StatusRecoverable, elapsed)
 		wfErr := wferrors.NewRecoverable(fmt.Errorf("failed to schedule an activity execution: %w", err))
+		unregister()
 		a.inflight.Release(key, call)
 		call.Finish(wfErr)
 		return wfErr
@@ -91,7 +97,7 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 		// Snapshot the actorID since the *activity may be recycled
 		// (HaltAll/HaltNonHosted) before the watcher finishes; everything
 		// else the watcher uses is factory-level read-only state or args.
-		go a.watchAndPublish(ctx, a.actorID, key, call, callback, wi, taskEvent, name, activityName, workflowID, start)
+		go a.watchAndPublish(ctx, a.actorID, key, call, unregister, callback, wi, taskEvent, name, activityName, workflowID, start)
 		return ctx.Err()
 	case completed := <-callback:
 		// A lost race here means an eviction already finished the call and a
@@ -100,6 +106,7 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 		_ = call.BeginResolve()
 		execErr := a.publishResult(ctx, a.actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 		call.Finish(execErr)
+		unregister()
 		// On success, cache the outcome briefly so a cron retry that arrived
 		// while we were running becomes a follower and acks SUCCESS without
 		// dispatching a duplicate WorkItem. On error, release immediately so

--- a/pkg/actors/targets/workflow/activity/owner.go
+++ b/pkg/actors/targets/workflow/activity/owner.go
@@ -94,7 +94,10 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 		go a.watchAndPublish(ctx, a.actorID, key, call, callback, wi, taskEvent, name, activityName, workflowID, start)
 		return ctx.Err()
 	case completed := <-callback:
-		call.BeginResolve()
+		// A lost race here means an eviction already finished the call and a
+		// fresh execution is running; publish anyway, the orchestrator's
+		// duplicate-completion dedup absorbs whichever copy arrives second.
+		_ = call.BeginResolve()
 		execErr := a.publishResult(ctx, a.actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 		call.Finish(execErr)
 		// On success, cache the outcome briefly so a cron retry that arrived

--- a/pkg/actors/targets/workflow/activity/owner.go
+++ b/pkg/actors/targets/workflow/activity/owner.go
@@ -36,11 +36,12 @@ const InflightCacheTTL = 60 * time.Second
 
 // runOwned drives a single activity execution from WorkItem dispatch through
 // to publishing the result back to the workflow actor. It is invoked by
-// exactly one reminder per activity actor at a time (the owner). On caller
-// ctx cancellation it hands off to a background watcher so the WorkItem
-// already in the durabletask queue still has its result published; the
-// owner returns ctx.Err() so the actor framework can release its lock and
-// preserve turn-based semantics.
+// exactly one reminder per inflight key at a time (the owner), and runs
+// outside the actor lock: the inflight entry claimed in executeActivity is
+// the execution guard. On caller ctx cancellation it hands off to a
+// background watcher so the WorkItem already in the durabletask queue still
+// has its result published; the owner returns ctx.Err() so the caller can
+// surface the cancellation.
 func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call, name, activityName, workflowID string, taskEvent *backend.HistoryEvent, invocation *protos.ActivityInvocation) error {
 	wi := &backend.ActivityWorkItem{
 		SequenceNumber:  int64(taskEvent.GetEventId()),
@@ -82,9 +83,8 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 	// the actor framework is signalling cancel because the app went
 	// unhealthy), hand off to a background watcher so the WorkItem already
 	// in the durabletask queue still has its eventual result published and
-	// the inflight entry is finalised. Returning ctx.Err() here releases the
-	// actor lock so cron retries can become followers and observe the
-	// watcher's outcome via call.Done.
+	// the inflight entry is finalised. Cron retries arriving meanwhile become
+	// followers and observe the watcher's outcome via call.Done.
 	start = time.Now()
 	select {
 	case <-ctx.Done():
@@ -94,6 +94,7 @@ func (a *activity) runOwned(ctx context.Context, key string, call *inflight.Call
 		go a.watchAndPublish(ctx, a.actorID, key, call, callback, wi, taskEvent, name, activityName, workflowID, start)
 		return ctx.Err()
 	case completed := <-callback:
+		call.BeginResolve()
 		execErr := a.publishResult(ctx, a.actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 		call.Finish(execErr)
 		// On success, cache the outcome briefly so a cron retry that arrived

--- a/pkg/actors/targets/workflow/activity/publish.go
+++ b/pkg/actors/targets/workflow/activity/publish.go
@@ -53,7 +53,10 @@ func (f *factory) watchAndPublish(origCtx context.Context, actorID, key string, 
 	completed := <-callback
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(origCtx), detachedPublishTimeout)
 	defer cancel()
-	call.BeginResolve()
+	// A lost race here means an eviction already finished the call and a
+	// fresh execution is running; publish anyway, the orchestrator's
+	// duplicate-completion dedup absorbs whichever copy arrives second.
+	_ = call.BeginResolve()
 	execErr := f.publishResult(pubCtx, actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 	call.Finish(execErr)
 	// Cache the outcome for follower retries only on success; on error,

--- a/pkg/actors/targets/workflow/activity/publish.go
+++ b/pkg/actors/targets/workflow/activity/publish.go
@@ -49,7 +49,7 @@ const detachedPublishTimeout = 30 * time.Second
 // cancellation but keep trace context and values via context.WithoutCancel,
 // then apply a fresh detachedPublishTimeout deadline so a misbehaving
 // downstream cannot block this goroutine indefinitely.
-func (f *factory) watchAndPublish(origCtx context.Context, actorID, key string, call *inflight.Call, callback chan bool, wi *backend.ActivityWorkItem, taskEvent *backend.HistoryEvent, name, activityName, workflowID string, start time.Time) {
+func (f *factory) watchAndPublish(origCtx context.Context, actorID, key string, call *inflight.Call, unregister func(), callback chan bool, wi *backend.ActivityWorkItem, taskEvent *backend.HistoryEvent, name, activityName, workflowID string, start time.Time) {
 	completed := <-callback
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(origCtx), detachedPublishTimeout)
 	defer cancel()
@@ -59,6 +59,7 @@ func (f *factory) watchAndPublish(origCtx context.Context, actorID, key string, 
 	_ = call.BeginResolve()
 	execErr := f.publishResult(pubCtx, actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 	call.Finish(execErr)
+	unregister()
 	// Cache the outcome for follower retries only on success; on error,
 	// release immediately so subsequent cron retries become fresh owners
 	// and can re-attempt rather than seeing the cached failure for the

--- a/pkg/actors/targets/workflow/activity/publish.go
+++ b/pkg/actors/targets/workflow/activity/publish.go
@@ -35,7 +35,7 @@ import (
 // detachedPublishTimeout bounds how long publishResult waits when the caller
 // ctx was already canceled before the SDK callback fired.
 // context.WithoutCancel strips the original deadline, so we apply a fresh one
-// to keep a misbehaving downstream from blocking the actor lock indefinitely.
+// to keep a misbehaving downstream from blocking the watcher indefinitely.
 const detachedPublishTimeout = 30 * time.Second
 
 // watchAndPublish runs on the factory (not the activity) so it cannot be
@@ -53,6 +53,7 @@ func (f *factory) watchAndPublish(origCtx context.Context, actorID, key string, 
 	completed := <-callback
 	pubCtx, cancel := context.WithTimeout(context.WithoutCancel(origCtx), detachedPublishTimeout)
 	defer cancel()
+	call.BeginResolve()
 	execErr := f.publishResult(pubCtx, actorID, completed, wi, taskEvent, name, activityName, workflowID, start)
 	call.Finish(execErr)
 	// Cache the outcome for follower retries only on success; on error,

--- a/pkg/actors/targets/workflow/common/janitor.go
+++ b/pkg/actors/targets/workflow/common/janitor.go
@@ -28,16 +28,21 @@ var log = logger.NewLogger("dapr.runtime.actors.targets.workflow.common")
 // in-flight activity whose local drive AND escalation were both lost.
 const defaultJanitorPeriod = 20 * time.Second
 
-// JanitorPeriod resolves the janitor repeat interval once per process. The
-// DAPR_WORKFLOW_JANITOR_PERIOD environment variable override exists for
-// integration tests that exercise janitor-driven recovery without waiting
-// the production interval; it is not a supported production knob.
-var JanitorPeriod = sync.OnceValue(func() time.Duration {
-	if v := os.Getenv("DAPR_WORKFLOW_JANITOR_PERIOD"); v != "" {
+// EnvDurationOr returns the positive duration parsed from the named
+// environment variable, or def. The env overrides exist for integration
+// tests that exercise time-driven behavior without waiting production
+// intervals; they are not supported production knobs.
+func EnvDurationOr(name string, def time.Duration) time.Duration {
+	if v := os.Getenv(name); v != "" {
 		if d, err := time.ParseDuration(v); err == nil && d > 0 {
 			return d
 		}
-		log.Warnf("Ignoring invalid DAPR_WORKFLOW_JANITOR_PERIOD %q", v)
+		log.Warnf("Ignoring invalid %s %q", name, v)
 	}
-	return defaultJanitorPeriod
+	return def
+}
+
+// JanitorPeriod resolves the janitor repeat interval once per process.
+var JanitorPeriod = sync.OnceValue(func() time.Duration {
+	return EnvDurationOr("DAPR_WORKFLOW_JANITOR_PERIOD", defaultJanitorPeriod)
 })

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -373,7 +373,7 @@ func (f *factory) deactivate(orchestrator *orchestrator) {
 
 	select {
 	case f.deactivateCh <- orchestrator:
-	default:
+	case <-f.deactivateCtx.Done():
 	}
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	workflowacl "github.com/dapr/dapr/pkg/acl/workflow"
 	"github.com/dapr/dapr/pkg/actors"
@@ -98,26 +99,38 @@ type factory struct {
 
 	scheduler todo.WorkflowScheduler
 
-	deactivateCh chan *orchestrator
+	deactivateCh  chan *orchestrator
+	deactivateCtx context.Context
 
-	// fastPath and the wake* fields drive the detached local wake
-	// goroutines (see wake.go). wakeCtx is factory-owned rather than scoped
-	// to the per-stream ctx given to New. HaltAll (which also fires on
-	// placement stream churn, not only shutdown) cancels and drains the
-	// in-flight wakes, then recreates the context for subsequent
-	// activations. wakeLock serializes spawns against that cancel/recreate
-	// cycle so the WaitGroup Add never races the Wait.
+	// fastPath and the wake* fields drive the detached local wake goroutines
+	// (see wake.go). wakeCtx is factory-owned rather than scoped to the
+	// per-stream ctx given to New. HaltAll (which also fires on placement stream
+	// churn, not only shutdown) cancels and drains the in-flight wakes, then
+	// recreates the context for subsequent activations. wakeLock serializes
+	// spawns against that cancel/recreate cycle so the WaitGroup Add never races
+	// the Wait.
 	fastPath   bool
 	wakeLock   sync.Mutex
 	wakeCtx    context.Context
 	wakeCancel context.CancelFunc
 	wakeWG     sync.WaitGroup
 
-	// rootCtx bounds wake-failure escalation goroutines (see wake.go
-	// escalate): unlike wakeCtx it survives HaltAll, because a reminder
-	// create is host-agnostic and must be able to complete during the
-	// placement churn that cancels wakeCtx. escWG is waited nowhere on the
-	// churn path; the goroutines are rootCtx+timeout bounded.
+	// Escalation hysteresis schedule. Set once in New, before any drive loop can
+	// read them; fields only so unit tests can compress the schedule per
+	// factory. A nil driveRetryBackoffs selects the default jittered schedule .
+	driveRetryBackoffs []time.Duration
+	driveAliveWindow   time.Duration
+
+	bgWG sync.WaitGroup
+
+	// lockWaitSample drives 1-in-16 sampling of the lock_wait histogram: it
+	// advances on every orchestrator invocation of this factory and the
+	// distribution is what matters, not every observation.
+	lockWaitSample atomic.Uint64
+
+	reaperScanInterval time.Duration
+	reaperIdleTTL      time.Duration
+
 	rootCtx context.Context
 	escLock sync.Mutex
 	escWG   sync.WaitGroup
@@ -151,16 +164,14 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		return nil, err
 	}
 
-	deactivateCh := make(chan *orchestrator, 100)
-	go func() {
-		for orchestrator := range deactivateCh {
-			orchestrator.Deactivate(ctx)
-		}
-	}()
+	deactivateCh := make(chan *orchestrator, 1024)
 
 	wakeCtx, wakeCancel := context.WithCancel(context.Background())
 
-	return &factory{
+	reaperScanInterval := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_SCAN_INTERVAL", 5*time.Second)
+	reaperIdleTTL := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_IDLE_TTL", max(common.JanitorPeriod()/2, 5*time.Second))
+
+	f := &factory{
 		appID:                  opts.AppID,
 		namespace:              opts.Namespace,
 		actorType:              opts.WorkflowActorType,
@@ -180,10 +191,36 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		scheduler:              opts.Scheduler,
 		deactivateCh:           deactivateCh,
 		fastPath:               opts.FastPath,
+		reaperScanInterval:     reaperScanInterval,
+		reaperIdleTTL:          reaperIdleTTL,
+		deactivateCtx:          ctx,
 		wakeCtx:                wakeCtx,
 		wakeCancel:             wakeCancel,
+		driveAliveWindow:       defaultDriveAliveWindow,
 		rootCtx:                ctx,
-	}, nil
+	}
+
+	// The worker pool and reaper are factory-lifetime: they exit when the
+	// engine's context dies and are joined by the final HaltAll, so engine
+	// close leaks no goroutines.
+	for range 8 {
+		f.bgWG.Go(func() {
+			for {
+				select {
+				case <-ctx.Done():
+					return
+				case orchestrator := <-deactivateCh:
+					orchestrator.Deactivate(ctx)
+				}
+			}
+		})
+	}
+
+	f.bgWG.Go(func() {
+		f.reapIdle(ctx)
+	})
+
+	return f, nil
 }
 
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
@@ -202,6 +239,12 @@ func (f *factory) initOrchestrator(o any, actorID string) *orchestrator {
 	or.factory = f
 	or.actorID = actorID
 	or.closed.Store(false)
+	or.lastActive.Store(time.Now().UnixNano())
+
+	// Deliberately zero, not now: progress must only ever mean a durable commit
+	// by THIS residency, so a just-activated actor (e.g. the new owner after a
+	// crash) reads as stalled and the janitor recovers it.
+	or.lastProgress.Store(0)
 	or.janitorAsserted.Store(false)
 	or.janitorRedispatched = nil
 	or.driveRunning.Store(false)
@@ -272,12 +315,13 @@ func (f *factory) HaltAll(ctx context.Context) error {
 	wg.Wait()
 	f.wakeWG.Wait()
 
-	// HaltAll also fires on placement disconnection, after which this
-	// factory keeps serving new activations: recreate the wake context so
-	// the fast path survives the churn.
 	f.wakeLock.Lock()
 	f.wakeCtx, f.wakeCancel = context.WithCancel(context.Background())
 	f.wakeLock.Unlock()
+
+	if f.rootCtx.Err() != nil {
+		f.bgWG.Wait()
+	}
 
 	return errors.Join(errs.Slice()...)
 }
@@ -326,5 +370,36 @@ func (f *factory) deactivate(orchestrator *orchestrator) {
 	if !orchestrator.closed.CompareAndSwap(false, true) {
 		return
 	}
-	f.deactivateCh <- orchestrator
+
+	select {
+	case f.deactivateCh <- orchestrator:
+	default:
+		go orchestrator.Deactivate(f.deactivateCtx)
+	}
+}
+
+func (f *factory) reapIdle(ctx context.Context) {
+	t := time.NewTicker(f.reaperScanInterval)
+	defer t.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-t.C:
+		}
+		cutoff := time.Now().Add(-f.reaperIdleTTL).UnixNano()
+		f.table.Range(func(_, v any) bool {
+			o, ok := v.(*orchestrator)
+			if !ok {
+				return true
+			}
+			// driveRunning actors are mid-drive by definition; their lastActive is
+			// refreshed on the next lock acquisition.
+			if o.lastActive.Load() < cutoff && !o.driveRunning.Load() {
+				log.Debugf("Workflow actor '%s': reaping idle actor", o.actorID)
+				f.deactivate(o)
+			}
+			return true
+		})
+	}
 }

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -374,7 +374,6 @@ func (f *factory) deactivate(orchestrator *orchestrator) {
 	select {
 	case f.deactivateCh <- orchestrator:
 	default:
-		go orchestrator.Deactivate(f.deactivateCtx)
 	}
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -169,7 +169,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 	wakeCtx, wakeCancel := context.WithCancel(context.Background())
 
 	reaperScanInterval := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_SCAN_INTERVAL", 5*time.Second)
-	reaperIdleTTL := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_IDLE_TTL", max(common.JanitorPeriod()/2, 5*time.Second))
+	reaperIdleTTL := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_IDLE_TTL", max(2*common.JanitorPeriod(), time.Minute))
 
 	f := &factory{
 		appID:                  opts.AppID,
@@ -394,7 +394,7 @@ func (f *factory) reapIdle(ctx context.Context) {
 			}
 			// driveRunning actors are mid-drive by definition; their lastActive is
 			// refreshed on the next lock acquisition.
-			if o.lastActive.Load() < cutoff && !o.driveRunning.Load() {
+			if o.lastActive.Load() < cutoff && !o.driveRunning.Load() && o.inTurn.Load() == 0 {
 				log.Debugf("Workflow actor '%s': reaping idle actor", o.actorID)
 				f.deactivate(o)
 			}

--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -24,6 +24,10 @@ import (
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/anypb"
 
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -34,9 +38,6 @@ import (
 	"github.com/dapr/dapr/pkg/resiliency"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
-	"github.com/dapr/durabletask-go/api"
-	"github.com/dapr/durabletask-go/backend"
-	"github.com/dapr/durabletask-go/backend/runtimestate"
 )
 
 func (o *orchestrator) handleInvoke(ctx context.Context, req *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
@@ -211,12 +212,23 @@ func (o *orchestrator) runJanitor(ctx context.Context, reminder *actorapi.Remind
 		// WorkflowsFastPath). Stalled workflows are excluded:
 		// re-dispatching would replay the condition that stalled them.
 		if o.rstate.GetStalled() == nil {
+			if o.redispatchSuppressed() {
+				// Recent life: in-flight activities are covered by their live
+				// executions and the next period re-checks. Firing the re-dispatch
+				// machinery against a merely-slow instance replays full-cost turns
+				// through the scheduler (the measured collapse amplifier); a genuinely
+				// idle-stalled instance goes stale within one period and re-dispatches
+				// below.
+				diag.DefaultWorkflowMonitoring.WorkflowLocalActivity(ctx, diag.StatusJanitorRedispatchSuppressed)
+				return nil
+			}
 			// Completions held for folding suppress the re-dispatch of their
 			// tasks below, on the assumption their senders are alive and
 			// re-driving. At a placement handoff that assumption breaks both
 			// ways at once: the sender dies with its pod before re-delivering,
 			// and the arming drive of the folding turn is lost (a wakeCtx
-			// cancellation window). The completion is then captive in memory with no
+			// cancellation window, or a failed drive whose escalation was
+			// suppressed). The completion is then captive in memory with no
 			// driver at all, and this fire is the only thing that ever runs on
 			// the instance. Drive a turn: runWorkflow folds pending
 			// completions into its commit even with an empty inbox, restoring
@@ -241,7 +253,25 @@ func (o *orchestrator) runJanitor(ctx context.Context, reminder *actorapi.Remind
 
 func (o *orchestrator) runWorkflowFromReminder(ctx context.Context, reminder *actorapi.Reminder) error {
 	completed, err := o.runWorkflow(ctx, reminder)
-	if completed == todo.RunCompletedTrue {
+	if o.rstate != nil && completed != todo.RunCompletedTrue && runtimestate.IsCompleted(o.rstate) {
+		// The workflow completed on THIS turn (which reports RunCompletedFalse
+		// because it consumed events). Release the cached state graph right here:
+		// the history is the heavy part of a resident completed actor, and
+		// dropping it in-turn frees the memory with no teardown machinery, no
+		// channel, and no race with the drive-loop reclaim handshake.
+		// The actor SHELL stays until swept by a follow-up empty-inbox ack or the
+		// factory's idle reaper; post-completion client calls (status, purge)
+		// reload the terminal state from the store.
+		o.invalidateCachedState()
+	}
+	if completed == todo.RunCompletedTrue && (o.rstate == nil || runtimestate.IsCompleted(o.rstate)) {
+		// Deactivate on empty-inbox acks only for terminal (or unknown-state)
+		// workflows. A live workflow acking an empty-inbox reminder (routine after
+		// batched turns) stays resident: its next event arrives shortly and the
+		// cached state saves a full history reload Residency is bounded by the
+		// engine's max concurrent workflow invocations, terminal turns releasing
+		// their state above, and the factory idle reaper; placement churn and host
+		// shutdown still halt resident actors.
 		defer o.deactivate(o)
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -146,14 +146,21 @@ func (o *orchestrator) InvokeReminder(ctx context.Context, reminder *actorapi.Re
 // as the lock_wait histogram (sampled 1-in-16), splitting observed
 // invocation latency into queueing vs turn body.
 func (o *orchestrator) contextLockMeasured(ctx context.Context, kind string) (context.CancelFunc, error) {
-	o.lastActive.Store(time.Now().UnixNano())
 	if o.lockWaitSample.Add(1)%16 != 0 {
-		return o.lock.ContextLock(ctx)
+		unlock, err := o.lock.ContextLock(ctx)
+		if err == nil {
+			// Only a successful acquisition is residency: a waiter that
+			// times out or is cancelled took no turn, and stamping it would
+			// let failed waiters keep an idle actor resident.
+			o.lastActive.Store(time.Now().UnixNano())
+		}
+		return unlock, err
 	}
 	start := time.Now()
 	unlock, err := o.lock.ContextLock(ctx)
 	elapsed := float64(time.Since(start)) / float64(time.Millisecond)
 	if err == nil {
+		o.lastActive.Store(time.Now().UnixNano())
 		diag.DefaultWorkflowMonitoring.WorkflowLockWait(ctx, kind, elapsed)
 	}
 	return unlock, err

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -57,6 +57,17 @@ type orchestrator struct {
 	// and its escalation.
 	driveNotify  chan struct{}
 	driveRunning atomic.Bool
+
+	// lastActive is the UnixNano of the most recent turn-lock acquisition,
+	// stamped for the factory idle reaper. Also stamped at creation so a fresh
+	// actor is never reaped before its first turn.
+	lastActive atomic.Int64
+	// lastProgress is the UnixNano of the most recent durable state commit
+	// (stamped in signAndSaveState). Zero on a fresh activation, so an actor
+	// recreated after a crash reads as stalled and the durable backstops
+	// recover it. INVARIANT: never stamped by the janitor fire or by lock
+	// traffic; it distinguishes "alive and progressing" from "being polled".
+	lastProgress atomic.Int64
 	driveInfo    atomic.Pointer[driveInfo]
 	// foldPending holds sender-retried completions awaiting their folding
 	// turn (WorkflowsFastPath; see fold.go). INVARIANT: only touched
@@ -132,9 +143,13 @@ func (o *orchestrator) InvokeReminder(ctx context.Context, reminder *actorapi.Re
 }
 
 // contextLockMeasured acquires the per-actor turn lock and records the wait
-// as the lock_wait histogram, splitting observed invocation latency into
-// queueing vs turn body.
+// as the lock_wait histogram (sampled 1-in-16), splitting observed
+// invocation latency into queueing vs turn body.
 func (o *orchestrator) contextLockMeasured(ctx context.Context, kind string) (context.CancelFunc, error) {
+	o.lastActive.Store(time.Now().UnixNano())
+	if o.lockWaitSample.Add(1)%16 != 0 {
+		return o.lock.ContextLock(ctx)
+	}
 	start := time.Now()
 	unlock, err := o.lock.ContextLock(ctx)
 	elapsed := float64(time.Since(start)) / float64(time.Millisecond)

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -62,6 +62,11 @@ type orchestrator struct {
 	// stamped for the factory idle reaper. Also stamped at creation so a fresh
 	// actor is never reaped before its first turn.
 	lastActive atomic.Int64
+	// inTurn counts currently-held turn locks (0 or 1 plus queued stream
+	// claims): the reaper must never deactivate an actor mid-turn, and
+	// lastActive alone cannot show that once a turn (an app roundtrip of
+	// arbitrary length) outlives the idle TTL.
+	inTurn atomic.Int32
 	// lastProgress is the UnixNano of the most recent durable state commit
 	// (stamped in signAndSaveState). Zero on a fresh activation, so an actor
 	// recreated after a crash reads as stalled and the durable backstops
@@ -148,22 +153,32 @@ func (o *orchestrator) InvokeReminder(ctx context.Context, reminder *actorapi.Re
 func (o *orchestrator) contextLockMeasured(ctx context.Context, kind string) (context.CancelFunc, error) {
 	if o.lockWaitSample.Add(1)%16 != 0 {
 		unlock, err := o.lock.ContextLock(ctx)
-		if err == nil {
-			// Only a successful acquisition is residency: a waiter that
-			// times out or is cancelled took no turn, and stamping it would
-			// let failed waiters keep an idle actor resident.
-			o.lastActive.Store(time.Now().UnixNano())
+		if err != nil {
+			return unlock, err
 		}
-		return unlock, err
+		return o.turnHeld(unlock), nil
 	}
 	start := time.Now()
 	unlock, err := o.lock.ContextLock(ctx)
 	elapsed := float64(time.Since(start)) / float64(time.Millisecond)
-	if err == nil {
-		o.lastActive.Store(time.Now().UnixNano())
-		diag.DefaultWorkflowMonitoring.WorkflowLockWait(ctx, kind, elapsed)
+	if err != nil {
+		return unlock, err
 	}
-	return unlock, err
+	diag.DefaultWorkflowMonitoring.WorkflowLockWait(ctx, kind, elapsed)
+	return o.turnHeld(unlock), nil
+}
+
+func (o *orchestrator) turnHeld(unlock context.CancelFunc) context.CancelFunc {
+	o.lastActive.Store(time.Now().UnixNano())
+	o.inTurn.Add(1)
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			o.lastActive.Store(time.Now().UnixNano())
+			o.inTurn.Add(-1)
+		})
+		unlock()
+	}
 }
 
 // InvokeTimer implements actors.InternalActor

--- a/pkg/actors/targets/workflow/orchestrator/redispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/redispatch.go
@@ -33,6 +33,18 @@ import (
 // fresh execution.
 const redispatchCallTimeout = 30 * time.Second
 
+// redispatchSuppressed reports whether the janitor should skip the re-dispatch
+// check this fire: a running drive loop or a durable commit within the last
+// janitor period is positive evidence the instance is alive, and its in-flight
+// activities are then covered by their live executions. lastActive is
+// deliberately NOT consulted: the janitor fire itself stamps it on the way in,
+// so lock traffic cannot tell progress from polling. Suppression adds at most
+// one period to the recovery latency of an activity-host crash. A
+// freshly-activated actor has zero lastProgress and never suppresses.
+func (o *orchestrator) redispatchSuppressed() bool {
+	return o.driveRunning.Load() || o.progressWithin(janitorPeriod())
+}
+
 // redispatchActivities re-dispatches TaskScheduled events whose resolution
 // has not been observed. It is the durable re-driver for in-flight
 // activities: under WorkflowsFastPath an activity host crash

--- a/pkg/actors/targets/workflow/orchestrator/redispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/redispatch.go
@@ -33,16 +33,16 @@ import (
 // fresh execution.
 const redispatchCallTimeout = 30 * time.Second
 
-// redispatchSuppressed reports whether the janitor should skip the re-dispatch
-// check this fire: a running drive loop or a durable commit within the last
-// janitor period is positive evidence the instance is alive, and its in-flight
-// activities are then covered by their live executions. lastActive is
-// deliberately NOT consulted: the janitor fire itself stamps it on the way in,
-// so lock traffic cannot tell progress from polling. Suppression adds at most
-// one period to the recovery latency of an activity-host crash. A
-// freshly-activated actor has zero lastProgress and never suppresses.
+// redispatchSuppressed defers the re-dispatch pass only while a drive is
+// mid-flight on THIS instance: its commit may resolve tasks momentarily, and
+// the deferral is bounded (the drive ends and the next fire re-checks).
+// Instance-wide progress is deliberately NOT a suppression signal: sibling
+// activities or external events can keep committing forever while one
+// activity host is dead, and per-task liveness is what the re-dispatch
+// itself probes (a live execution on the target host absorbs it as a
+// follower; only a lost one re-executes).
 func (o *orchestrator) redispatchSuppressed() bool {
-	return o.driveRunning.Load() || o.progressWithin(janitorPeriod())
+	return o.driveRunning.Load()
 }
 
 // redispatchActivities re-dispatches TaskScheduled events whose resolution

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"time"
 
 	"google.golang.org/protobuf/types/known/anypb"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -169,6 +170,10 @@ func (o *orchestrator) signAndSaveState(ctx context.Context, state *wfenginestat
 		o.invalidateCachedState()
 		return err
 	}
+	// A durable commit is the progress signal the wake-escalation and
+	// janitor-redispatch hysteresis keys on. Unlike lastActive it is never
+	// stamped by mere lock traffic or by the janitor fire itself.
+	o.lastProgress.Store(time.Now().UnixNano())
 	return nil
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/wake.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake.go
@@ -18,6 +18,8 @@ import (
 	"time"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 )
 
@@ -30,6 +32,64 @@ const localWakeTimeout = time.Minute
 // (overwrite-by-name) and host-agnostic, and the janitor remains the net if
 // it also fails.
 const escalateTimeout = 30 * time.Second
+
+// Escalation hysteresis defaults. A failed drive against an instance that
+// shows recent life is retried in place, and if still failing is handed to the
+// janitor rather than escalated.
+const (
+	driveRetryBudget        = 6 * time.Second
+	defaultDriveAliveWindow = 3 * time.Second
+)
+
+func (o *orchestrator) aliveWithin(window time.Duration) bool {
+	cutoff := time.Now().Add(-window).UnixNano()
+	return o.lastProgress.Load() >= cutoff || o.lastActive.Load() >= cutoff
+}
+
+func (o *orchestrator) progressWithin(window time.Duration) bool {
+	return o.lastProgress.Load() >= time.Now().Add(-window).UnixNano()
+}
+
+func (o *orchestrator) driveLost(wakeCtx context.Context, err error) bool {
+	return wakeCtx.Err() != nil || o.closed.Load() || targeterrors.IsClosed(err)
+}
+
+// driveRetrySchedule yields the waits before each in-place retry of a failed
+// drive: the factory-injected fixed schedule when set (tests), otherwise
+// decorrelated exponential jitter bounded by driveRetryBudget of total sleep.
+type driveRetrySchedule struct {
+	fixed  []time.Duration
+	idx    int
+	jitter *common.JitterBackoff
+	slept  time.Duration
+}
+
+func (o *orchestrator) newDriveRetrySchedule() *driveRetrySchedule {
+	if o.driveRetryBackoffs != nil {
+		return &driveRetrySchedule{fixed: o.driveRetryBackoffs}
+	}
+	return &driveRetrySchedule{
+		jitter: common.NewJitterBackoff(common.RetryBackoffBase, common.RetryBackoffCap),
+	}
+}
+
+func (s *driveRetrySchedule) next() (time.Duration, bool) {
+	if s.fixed != nil {
+		if s.idx >= len(s.fixed) {
+			return 0, false
+		}
+		d := s.fixed[s.idx]
+		s.idx++
+		return d, true
+	}
+
+	d := s.jitter.NextBackOff()
+	if s.slept+d > driveRetryBudget {
+		return 0, false
+	}
+	s.slept += d
+	return d, true
+}
 
 // driveInfo carries the identity of the latest wake so a drive (or its
 // escalation) can name the reminder it stands in for. Any new-event-prefixed
@@ -62,12 +122,16 @@ type driveInfo struct {
 //
 // The loop is detached (the arming invocation holds the actor lock the turn
 // needs) and scoped to the factory's wake context, drained in HaltAll. On a
-// drive error it ESCALATES by creating today's durable per-event reminder
+// drive error it first retries in place (bounded; see driveRetrySchedule),
+// then either ESCALATES by creating today's durable per-event reminder
 // (deterministic name, idempotent) on a context bounded by the factory root
 // context, NOT wakeCtx: migration is exactly the case where wakeCtx is
 // cancelled, and the reminder create is host-agnostic (the scheduler routes
-// the fire to the current owner). If the escalation also fails, the janitor
-// drives recovery within one period.
+// the fire to the current owner); or, when the instance still shows recent
+// life, SUPPRESSES the escalation and leaves recovery to the janitor (see
+// driveLoop). Hard errors (cancelled wakeCtx, closed actor) always escalate.
+// If the escalation also fails, the janitor drives recovery within one
+// period.
 //
 // No-op when the WorkflowsFastPath preview feature is off or the
 // wake is scheduled in the future (delayed starts must keep their scheduler
@@ -114,8 +178,9 @@ func (o *orchestrator) localDrive(reminderName string, dueTime time.Time, wfName
 // driveLoop consumes drive notifications for this instance, running one turn
 // per notification. It never blocks on the notification channel (HaltAll
 // safety: cancellation surfaces through the turn call), exits when idle, and
-// on a failed turn hands over to the escalation path and exits: the durable
-// reminder (or janitor) owns recovery from there.
+// on a failed turn (after the bounded in-place retries) hands over to the
+// escalation decision and exits: the durable reminder (or janitor) owns
+// recovery from there.
 func (o *orchestrator) driveLoop(wakeCtx context.Context) {
 	defer o.wakeWG.Done()
 
@@ -148,36 +213,65 @@ func (o *orchestrator) driveLoop(wakeCtx context.Context) {
 
 		info := o.driveInfo.Load()
 
-		ctx, cancel := context.WithTimeout(wakeCtx, localWakeTimeout)
-		start := time.Now()
-		// Data is nil: wake-up reminders carry no payload; the turn reloads
-		// the durable inbox. The router resolves placement, so if the actor
-		// migrated between arming and wake the turn is delivered to the new
-		// owner host. SkipRetries: this loop owns its recovery (a failed
-		// drive escalates to a durable reminder within ~1s), so the router's
-		// blind 1s-backoff retries would only add tail latency before the
-		// same outcome.
-		err := o.router.CallReminder(ctx, &actorapi.Reminder{
-			Name:        info.reminderName,
-			ActorType:   actorType,
-			ActorID:     actorID,
-			SkipRetries: true,
-		})
-		elapsed := float64(time.Since(start)) / float64(time.Millisecond)
-		cancel()
+		err := o.driveOnce(wakeCtx, actorType, actorID, info)
 
-		if err != nil {
-			log.Debugf("Workflow actor '%s': local wake '%s' failed; escalating to a durable reminder: %v", actorID, info.reminderName, err)
-			diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusFailed)
-			diag.DefaultWorkflowMonitoring.WorkflowLocalWakeDrive(context.Background(), diag.StatusFailed, elapsed)
-			o.driveRunning.Store(false)
-			o.escalate(info)
-			return
+		// Bounded in-place retries: a live instance's failed drive is
+		// re-attempted here (same coverage, no scheduler involvement)
+		// instead of escalating on first failure. Retries stop early when
+		// the drive is lost outright or the instance stops showing life.
+		retries := o.newDriveRetrySchedule()
+		for err != nil {
+			if o.driveLost(wakeCtx, err) || !o.aliveWithin(o.driveAliveWindow) {
+				break
+			}
+			d, ok := retries.next()
+			if !ok {
+				break
+			}
+			if !sleepWake(wakeCtx, d) {
+				break
+			}
+			err = o.driveOnce(wakeCtx, actorType, actorID, info)
 		}
 
-		diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusSuccess)
-		diag.DefaultWorkflowMonitoring.WorkflowLocalWakeDrive(context.Background(), diag.StatusSuccess, elapsed)
+		if err != nil {
+			o.driveRunning.Store(false)
+			if o.driveLost(wakeCtx, err) || !o.aliveWithin(o.driveAliveWindow) {
+				log.Debugf("Workflow actor '%s': local wake '%s' failed; escalating to a durable reminder: %v", actorID, info.reminderName, err)
+				o.escalate(info)
+			} else {
+				// Alive and slow: a durable reminder here would only add
+				// scheduler re-drive load against an actor that is already
+				// working. The janitor drives any stranded inbox row within
+				// one period; that is the recovery contract this suppression
+				// leans on.
+				log.Debugf("Workflow actor '%s': local wake '%s' failed but the instance shows recent progress; suppressing escalation, the janitor covers: %v", actorID, info.reminderName, err)
+				diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusEscalateSuppressed)
+			}
+			return
+		}
 	}
+}
+
+func (o *orchestrator) driveOnce(wakeCtx context.Context, actorType, actorID string, info *driveInfo) error {
+	ctx, cancel := context.WithTimeout(wakeCtx, localWakeTimeout)
+	start := time.Now()
+	err := o.router.CallReminder(ctx, &actorapi.Reminder{
+		Name:        info.reminderName,
+		ActorType:   actorType,
+		ActorID:     actorID,
+		SkipRetries: true,
+	})
+	elapsed := float64(time.Since(start)) / float64(time.Millisecond)
+	cancel()
+
+	status := diag.StatusSuccess
+	if err != nil {
+		status = diag.StatusFailed
+	}
+	diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), status)
+	diag.DefaultWorkflowMonitoring.WorkflowLocalWakeDrive(context.Background(), status, elapsed)
+	return err
 }
 
 // escalate creates the durable per-event wake-up reminder after a failed
@@ -213,4 +307,15 @@ func (o *orchestrator) escalate(info *driveInfo) {
 		}
 		diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusEscalated)
 	}()
+}
+
+func sleepWake(wakeCtx context.Context, d time.Duration) bool {
+	t := time.NewTimer(d)
+	defer t.Stop()
+	select {
+	case <-wakeCtx.Done():
+		return false
+	case <-t.C:
+		return true
+	}
 }

--- a/pkg/actors/targets/workflow/orchestrator/wake_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake_test.go
@@ -376,10 +376,14 @@ func Test_hysteresisSignals(t *testing.T) {
 	assert.False(t, o.redispatchSuppressed(),
 		"a fresh activation must never suppress the janitor re-dispatch")
 
-	// A durable commit makes both signals fresh.
+	// A durable commit refreshes progress (the escalation signal), but must
+	// NOT suppress the re-dispatch pass: sibling activities or external
+	// events can keep committing forever while one activity host is dead,
+	// so instance-wide progress proves nothing about a given task.
 	o.lastProgress.Store(time.Now().UnixNano())
 	assert.True(t, o.progressWithin(janitorPeriod()))
-	assert.True(t, o.redispatchSuppressed())
+	assert.False(t, o.redispatchSuppressed(),
+		"instance progress must not gate task re-dispatch")
 
 	// A running drive loop suppresses regardless of commit age.
 	o.lastProgress.Store(0)

--- a/pkg/actors/targets/workflow/orchestrator/wake_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake_test.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -36,6 +37,7 @@ import (
 	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
 	actorstate "github.com/dapr/dapr/pkg/actors/state"
 	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -55,7 +57,8 @@ type wakeHarness struct {
 	createErrFor    map[string]error
 	reminderGate    chan struct{} // when non-nil, CallReminder blocks on it (or ctx)
 
-	calls []*actorapi.Reminder
+	attempts atomic.Int64 // CallReminder invocations, successful or not
+	calls    []*actorapi.Reminder
 
 	fact *factory
 	orch *orchestrator
@@ -104,6 +107,7 @@ func newWakeHarness(t *testing.T, instanceID string, fastPath bool) *wakeHarness
 		})
 
 	fakeRouter := routerfake.New().WithCallReminderFn(func(ctx context.Context, rem *actorapi.Reminder) error {
+		h.attempts.Add(1)
 		if h.reminderGate != nil {
 			select {
 			case <-h.reminderGate:
@@ -292,16 +296,103 @@ func Test_localWake_callReminderErrorKeepsBackstop(t *testing.T) {
 
 	h := newWakeHarness(t, instanceID, true)
 	h.callReminderErr = errors.New("wake failed")
+	h.reminderGate = make(chan struct{})
 	h.primeRunning(t, instanceID, 7)
 
 	require.NoError(t, h.orch.addWorkflowEvent(t.Context(), taskCompletedEvent(7)))
 
-	// v2: a failed drive ESCALATES to the durable per-event reminder so
-	// recovery is ~1s via the scheduler instead of a janitor period.
+	// Park the drive on the gate, then age both life signals so the failure
+	// resolves as stalled: escalation must fire without in-place retries.
+	stale := time.Now().Add(-time.Minute).UnixNano()
+	h.orch.lastActive.Store(stale)
+	h.orch.lastProgress.Store(stale)
+	close(h.reminderGate)
+
+	// v2: a failed drive against a stalled instance ESCALATES to the durable
+	// per-event reminder so recovery is ~1s via the scheduler instead of a
+	// janitor period.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		assert.Equal(c, []string{"save", "create:new-event-janitor", "create:new-event-tc-7"}, h.snapshotOps())
 	}, time.Second*5, time.Millisecond*5,
-		"a failed local drive must escalate to the durable per-event reminder")
+		"a failed local drive against a stalled instance must escalate to the durable per-event reminder")
+}
+
+func Test_localWake_failureAliveSuppressesEscalation(t *testing.T) {
+	const instanceID = "test-wake-suppress"
+
+	h := newWakeHarness(t, instanceID, true)
+	// Compress the retry schedule and stretch the alive window so the
+	// retries exhaust quickly while the instance still reads alive.
+	h.fact.driveRetryBackoffs = []time.Duration{time.Millisecond * 5, time.Millisecond * 5, time.Millisecond * 5}
+	h.fact.driveAliveWindow = time.Minute
+	h.callReminderErr = errors.New("wake failed")
+	h.primeRunning(t, instanceID, 7)
+
+	// The save inside addWorkflowEvent stamps lastProgress, so the instance
+	// reads alive for the whole (compressed) retry schedule: the failure
+	// must exhaust the retries and then be handed to the janitor, never
+	// escalated to a durable reminder.
+	require.NoError(t, h.orch.addWorkflowEvent(t.Context(), taskCompletedEvent(7)))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(4), h.attempts.Load(), "the initial attempt plus every in-place retry must run")
+		assert.False(c, h.orch.driveRunning.Load(), "the drive loop must wind down after suppression")
+	}, time.Second*5, time.Millisecond*5)
+
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(t, []string{"save", "create:new-event-janitor"}, h.snapshotOps(),
+		"a failed drive against a live instance must not create the durable per-event reminder")
+}
+
+func Test_localWake_closedActorEscalatesDespiteFreshness(t *testing.T) {
+	const instanceID = "test-wake-closed"
+
+	h := newWakeHarness(t, instanceID, true)
+	h.callReminderErr = targeterrors.NewClosed("test")
+	h.primeRunning(t, instanceID, 7)
+
+	require.NoError(t, h.orch.addWorkflowEvent(t.Context(), taskCompletedEvent(7)))
+
+	// A closed actor is the migration/teardown path: the drive is lost, not
+	// slow, and the host-agnostic durable create must fire immediately even
+	// though lastProgress was stamped by the save moments ago.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, []string{"save", "create:new-event-janitor", "create:new-event-tc-7"}, h.snapshotOps())
+	}, time.Second*5, time.Millisecond*5,
+		"a closed-actor drive failure must escalate without retries or suppression")
+}
+
+func Test_hysteresisSignals(t *testing.T) {
+	const instanceID = "test-hysteresis-signals"
+
+	h := newWakeHarness(t, instanceID, true)
+	o := h.orch
+
+	// Fresh activation: lastActive is stamped, lastProgress is deliberately
+	// zero, so the actor is alive for escalation purposes but shows no
+	// progress to the janitor gate.
+	assert.True(t, o.aliveWithin(time.Second*3))
+	assert.False(t, o.progressWithin(janitorPeriod()))
+	assert.False(t, o.redispatchSuppressed(),
+		"a fresh activation must never suppress the janitor re-dispatch")
+
+	// A durable commit makes both signals fresh.
+	o.lastProgress.Store(time.Now().UnixNano())
+	assert.True(t, o.progressWithin(janitorPeriod()))
+	assert.True(t, o.redispatchSuppressed())
+
+	// A running drive loop suppresses regardless of commit age.
+	o.lastProgress.Store(0)
+	o.driveRunning.Store(true)
+	assert.True(t, o.redispatchSuppressed())
+	o.driveRunning.Store(false)
+
+	// Both signals stale: stalled on every axis.
+	stale := time.Now().Add(-time.Minute).UnixNano()
+	o.lastActive.Store(stale)
+	o.lastProgress.Store(stale)
+	assert.False(t, o.aliveWithin(time.Second*3))
+	assert.False(t, o.redispatchSuppressed())
 }
 
 func Test_localWake_janitorOncePerResidency(t *testing.T) {

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -40,10 +40,14 @@ const (
 	// escalated to a durable reminder (or that escalation itself failed,
 	// leaving the janitor as the net), and a janitor fire that found and
 	// drove a pending inbox (the recovery event; ~0 in healthy steady state).
-	StatusEscalated        = "escalated"
-	StatusEscalateFailed   = "escalate_failed"
-	StatusEscalateSkipped  = "escalate_skipped_shutdown"
-	StatusJanitorRecovered = "janitor_recovered"
+	StatusEscalated       = "escalated"
+	StatusEscalateFailed  = "escalate_failed"
+	StatusEscalateSkipped = "escalate_skipped_shutdown"
+	// A failed drive against an instance that shows recent life was NOT
+	// escalated to a durable reminder: the janitor covers it within one
+	// period instead of the scheduler re-driving a merely-slow actor.
+	StatusEscalateSuppressed = "escalate_suppressed"
+	StatusJanitorRecovered   = "janitor_recovered"
 	// A janitor fire found completions held for folding with no live driver
 	// (their arming drive was lost and their senders stopped re-delivering,
 	// e.g. died with their pod at a placement handoff) and drove a turn to
@@ -64,6 +68,10 @@ const (
 	// (a placement-handoff loss window). The durable rescue event; ~0 in
 	// healthy steady state.
 	StatusJanitorRedispatchEscalated = "janitor_redispatch_escalated"
+	// The janitor skipped the re-dispatch check because the instance showed
+	// recent progress (fresh durable commit or a running drive loop); the
+	// next period re-checks.
+	StatusJanitorRedispatchSuppressed = "janitor_redispatch_suppressed"
 	// An activity arrival found the in-flight claim held by a dead execution
 	// (no engine-held work item after the stale grace) and evicted it so the
 	// arrival re-executes; the rescue event of the janitor-livelock class

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -251,6 +251,7 @@ func (abe *Actors) RegisterActors(ctx context.Context) error {
 		WorkflowsRemoteActivityReminder: abe.workflowsRemoteActivityReminder,
 		FastPath:                        abe.workflowsFastPath,
 		ExecutionHeld:                   abe.ActivityExecutionHeld,
+		RegisterResolver:                abe.RegisterActivityResolver,
 	}
 
 	opts := workflow.Options{
@@ -1029,7 +1030,16 @@ func (abe *Actors) WaitForActivityCompletion(request *protos.ActivityRequest) fu
 		// then leak, blinding stale-claim eviction for this key forever.
 		release := abe.activityExecs.add(key)
 		defer release()
-		return wait(ctx)
+		resp, err := wait(ctx)
+		if err == nil {
+			// Handshake with the owner execution: mark its call resolving
+			// BEFORE the deferred release drops the held registration. The
+			// callback channel to the owner is a separate scheduling hop,
+			// and in that gap a stale-claim check would otherwise see
+			// not-held + not-resolving and evict a healthy execution.
+			abe.activityExecs.resolve(key)
+		}
+		return resp, err
 	}
 }
 
@@ -1041,6 +1051,12 @@ func (abe *Actors) WaitForWorkflowTaskCompletion(request *protos.WorkflowRequest
 // ActivityExecutionHeld reports whether the engine on this host currently
 // holds a completion registration for the given activity work item; wired
 // into the activity target as its stale-claim liveness oracle.
+// RegisterActivityResolver wires the owner execution's resolve hook into
+// the completion waiter's pre-release handshake; see registerResolver.
+func (abe *Actors) RegisterActivityResolver(instanceID string, taskID int32, resolve func()) func() {
+	return abe.activityExecs.registerResolver(instanceID, taskID, resolve)
+}
+
 func (abe *Actors) ActivityExecutionHeld(instanceID string, taskID int32) bool {
 	return abe.activityExecs.heldFor(instanceID, taskID)
 }

--- a/pkg/runtime/wfengine/backends/actors/pendingexec.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingexec.go
@@ -27,12 +27,13 @@ import (
 // it to tell a live long-running execution (never evicted) from one whose
 // work item was lost without ever resolving (the janitor-livelock class).
 type activityExecutions struct {
-	lock sync.Mutex
-	held map[string]int
+	lock      sync.Mutex
+	held      map[string]int
+	resolvers map[string]func()
 }
 
 func newActivityExecutions() *activityExecutions {
-	return &activityExecutions{held: make(map[string]int)}
+	return &activityExecutions{held: make(map[string]int), resolvers: make(map[string]func())}
 }
 
 func activityExecutionKey(instanceID string, taskID int32) string {
@@ -63,4 +64,25 @@ func (a *activityExecutions) heldFor(instanceID string, taskID int32) bool {
 	a.lock.Lock()
 	defer a.lock.Unlock()
 	return a.held[activityExecutionKey(instanceID, taskID)] > 0
+}
+
+func (a *activityExecutions) registerResolver(instanceID string, taskID int32, resolve func()) func() {
+	key := activityExecutionKey(instanceID, taskID)
+	a.lock.Lock()
+	a.resolvers[key] = resolve
+	a.lock.Unlock()
+	return func() {
+		a.lock.Lock()
+		delete(a.resolvers, key)
+		a.lock.Unlock()
+	}
+}
+
+func (a *activityExecutions) resolve(key string) {
+	a.lock.Lock()
+	fn := a.resolvers[key]
+	a.lock.Unlock()
+	if fn != nil {
+		fn()
+	}
 }

--- a/pkg/runtime/wfengine/backends/actors/pendingexec.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingexec.go
@@ -29,11 +29,11 @@ import (
 type activityExecutions struct {
 	lock      sync.Mutex
 	held      map[string]int
-	resolvers map[string]func()
+	resolvers map[string]*func()
 }
 
 func newActivityExecutions() *activityExecutions {
-	return &activityExecutions{held: make(map[string]int), resolvers: make(map[string]func())}
+	return &activityExecutions{held: make(map[string]int), resolvers: make(map[string]*func())}
 }
 
 func activityExecutionKey(instanceID string, taskID int32) string {
@@ -68,21 +68,24 @@ func (a *activityExecutions) heldFor(instanceID string, taskID int32) bool {
 
 func (a *activityExecutions) registerResolver(instanceID string, taskID int32, resolve func()) func() {
 	key := activityExecutionKey(instanceID, taskID)
+	entry := &resolve
 	a.lock.Lock()
-	a.resolvers[key] = resolve
+	a.resolvers[key] = entry
 	a.lock.Unlock()
 	return func() {
 		a.lock.Lock()
-		delete(a.resolvers, key)
+		if a.resolvers[key] == entry {
+			delete(a.resolvers, key)
+		}
 		a.lock.Unlock()
 	}
 }
 
 func (a *activityExecutions) resolve(key string) {
 	a.lock.Lock()
-	fn := a.resolvers[key]
+	entry := a.resolvers[key]
 	a.lock.Unlock()
-	if fn != nil {
-		fn()
+	if entry != nil {
+		(*entry)()
 	}
 }

--- a/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
+++ b/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
@@ -142,6 +142,21 @@ func Test_activityCompletionHandshake(t *testing.T) {
 		unregister2()
 	})
 
+	t.Run("a stale owner's unregister must not delete the fresh owner's resolver", func(t *testing.T) {
+		t.Parallel()
+		a := newActivityExecutions()
+		var fresh int
+		staleUnregister := a.registerResolver("wf1", 8, func() {})
+		a.registerResolver("wf1", 8, func() { fresh++ })
+
+		// The evicted owner settles late and unregisters: the fresh owner's
+		// registration must survive, or the eviction window reopens for the
+		// healthy execution.
+		staleUnregister()
+		a.resolve(activityExecutionKey("wf1", 8))
+		assert.Equal(t, 1, fresh, "the fresh registration must survive a stale unregister")
+	})
+
 	t.Run("waiter never resolves without a wait error even when nothing registered", func(t *testing.T) {
 		t.Parallel()
 		fake := &fakePendingBackend{deliver: make(chan *protos.ActivityResponse, 1)}

--- a/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
+++ b/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// fakePendingBackend delivers activity completions on demand so the waiter's
+// resolve/release ordering can be observed at the exact delivery instant.
+type fakePendingBackend struct {
+	PendingTasksBackend
+	deliver chan *protos.ActivityResponse
+	err     error
+}
+
+func (f *fakePendingBackend) WaitForActivityCompletion(*protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error) {
+	return func(ctx context.Context) (*protos.ActivityResponse, error) {
+		if f.err != nil {
+			return nil, f.err
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case resp := <-f.deliver:
+			return resp, nil
+		}
+	}
+}
+
+func activityRequest(iid string, taskID int32) *protos.ActivityRequest {
+	return &protos.ActivityRequest{
+		WorkflowInstance: &protos.WorkflowInstance{InstanceId: iid},
+		TaskId:           taskID,
+	}
+}
+
+// Test_activityCompletionHandshake pins the stale-claim handshake contract:
+// the registered resolver runs BEFORE the waiter's held registration is
+// released, so at no observable instant is a completed execution both
+// not-held and not-resolving.
+func Test_activityCompletionHandshake(t *testing.T) {
+	t.Parallel()
+
+	t.Run("resolver runs while the registration is still held", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakePendingBackend{deliver: make(chan *protos.ActivityResponse, 1)}
+		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+
+		heldAtResolve := make(chan bool, 1)
+		unregister := abe.RegisterActivityResolver("wf1", 3, func() {
+			heldAtResolve <- abe.ActivityExecutionHeld("wf1", 3)
+		})
+		defer unregister()
+
+		wait := abe.WaitForActivityCompletion(activityRequest("wf1", 3))
+		done := make(chan error, 1)
+		go func() {
+			_, err := wait(t.Context())
+			done <- err
+		}()
+
+		// The wait is in flight: the execution must read as held.
+		assert.Eventually(t, func() bool { return abe.ActivityExecutionHeld("wf1", 3) }, time.Second*5, time.Millisecond)
+
+		fake.deliver <- &protos.ActivityResponse{TaskId: 3}
+		require.NoError(t, <-done)
+
+		select {
+		case held := <-heldAtResolve:
+			assert.True(t, held, "the resolver must observe the registration still held: releasing first reopens the eviction window")
+		default:
+			require.Fail(t, "the resolver was never invoked on successful completion")
+		}
+		assert.False(t, abe.ActivityExecutionHeld("wf1", 3), "the registration must be released after the wait returns")
+	})
+
+	t.Run("error paths do not resolve, keeping the execution evictable", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakePendingBackend{err: api.ErrTaskCancelled}
+		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+
+		resolved := false
+		unregister := abe.RegisterActivityResolver("wf1", 4, func() { resolved = true })
+		defer unregister()
+
+		wait := abe.WaitForActivityCompletion(activityRequest("wf1", 4))
+		_, err := wait(t.Context())
+		require.ErrorIs(t, err, api.ErrTaskCancelled)
+		assert.False(t, resolved, "a cancelled or lost work item must not enter resolve: it must stay evictable")
+		assert.False(t, abe.ActivityExecutionHeld("wf1", 4))
+	})
+
+	t.Run("unregistered or foreign keys resolve as a no-op", func(t *testing.T) {
+		t.Parallel()
+		a := newActivityExecutions()
+		a.resolve(activityExecutionKey("wf9", 9))
+
+		calls := 0
+		unregister := a.registerResolver("wf1", 5, func() { calls++ })
+		a.resolve(activityExecutionKey("wf2", 5))
+		a.resolve(activityExecutionKey("wf1", 6))
+		assert.Zero(t, calls, "only the exact execution key may resolve")
+
+		a.resolve(activityExecutionKey("wf1", 5))
+		assert.Equal(t, 1, calls)
+
+		unregister()
+		a.resolve(activityExecutionKey("wf1", 5))
+		assert.Equal(t, 1, calls, "resolve after unregister must be a no-op")
+		unregister()
+	})
+
+	t.Run("re-registration overwrites for a fresh owner", func(t *testing.T) {
+		t.Parallel()
+		a := newActivityExecutions()
+		var first, second int
+		a.registerResolver("wf1", 7, func() { first++ })
+		unregister2 := a.registerResolver("wf1", 7, func() { second++ })
+		a.resolve(activityExecutionKey("wf1", 7))
+		assert.Zero(t, first, "an evicted owner's stale resolver must not fire")
+		assert.Equal(t, 1, second)
+		unregister2()
+	})
+
+	t.Run("waiter never resolves without a wait error even when nothing registered", func(t *testing.T) {
+		t.Parallel()
+		fake := &fakePendingBackend{deliver: make(chan *protos.ActivityResponse, 1)}
+		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+		fake.deliver <- &protos.ActivityResponse{TaskId: 8}
+		wait := abe.WaitForActivityCompletion(activityRequest("wf1", 8))
+		_, err := wait(t.Context())
+		require.NoError(t, err)
+	})
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"fmt"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -104,25 +105,30 @@ func (i *inboxoverload) Run(t *testing.T, ctx context.Context) {
 	actorType := "dapr.internal.default." + appID + ".workflow"
 	actorID := "inboxoverloadi"
 
-	// Inject the deactivation reminder via the scheduler directly: the
-	// daprd RegisterActorReminder API rejects "dapr.internal.*" actor
-	// types because they are reserved for the workflow runtime.
 	_, err = i.workflow.Scheduler().Client(t, ctx).ScheduleJob(ctx,
 		i.workflow.Scheduler().JobNowActor("new-event-deactivate", "default", appID, actorType, actorID))
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		meta := i.workflow.Dapr().GetMetadata(c, ctx)
-		if !assert.NotNil(c, meta.ActorRuntime) {
-			return
-		}
-		for _, a := range meta.ActorRuntime.ActiveActors {
-			if a.Type == actorType {
-				assert.Zero(c, a.Count, "workflow actor %q still has %d active instance(s)", actorType, a.Count)
-				return
+		var count int
+		for _, key := range i.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs") {
+			if strings.Contains(key, "new-event-deactivate") {
+				count++
 			}
 		}
+		assert.Zero(c, count, "the injected empty-inbox reminder must be acked and deleted")
 	}, 10*time.Second, 50*time.Millisecond)
+
+	// The new residency contract: the live workflow remains active after
+	// the empty-inbox ack.
+	dmeta := i.workflow.Dapr().GetMetadata(t, ctx)
+	if dmeta.ActorRuntime != nil {
+		for _, a := range dmeta.ActorRuntime.ActiveActors {
+			if a.Type == actorType {
+				require.Equal(t, 1, a.Count, "live workflow actor %q must stay resident after an empty-inbox ack", actorType)
+			}
+		}
+	}
 
 	db := i.workflow.DB().GetConnection(t)
 	tableName := i.workflow.DB().TableName()
@@ -140,9 +146,9 @@ func (i *inboxoverload) Run(t *testing.T, ctx context.Context) {
 	}, time.Second*30, 10*time.Millisecond)
 	drainMode.Store(true)
 
-	meta, err := client.WaitForWorkflowCompletion(ctx, id)
+	wmeta, err := client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
-	require.NotNil(t, meta.GetOutput())
+	require.NotNil(t, wmeta.GetOutput())
 
 	mu.Lock()
 	defer mu.Unlock()

--- a/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
@@ -122,13 +122,15 @@ func (i *inboxoverload) Run(t *testing.T, ctx context.Context) {
 	// The new residency contract: the live workflow remains active after
 	// the empty-inbox ack.
 	dmeta := i.workflow.Dapr().GetMetadata(t, ctx)
-	if dmeta.ActorRuntime != nil {
-		for _, a := range dmeta.ActorRuntime.ActiveActors {
-			if a.Type == actorType {
-				require.Equal(t, 1, a.Count, "live workflow actor %q must stay resident after an empty-inbox ack", actorType)
-			}
+	require.NotNil(t, dmeta.ActorRuntime)
+	found := false
+	for _, a := range dmeta.ActorRuntime.ActiveActors {
+		if a.Type == actorType {
+			found = true
+			require.Equal(t, 1, a.Count, "live workflow actor %q must stay resident after an empty-inbox ack", actorType)
 		}
 	}
+	require.True(t, found, "workflow actor type %q must be active; absence means it was deactivated", actorType)
 
 	db := i.workflow.DB().GetConnection(t)
 	tableName := i.workflow.DB().TableName()

--- a/tests/integration/suite/daprd/workflow/scheduler/reapresume.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/reapresume.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(reapresume))
+}
+
+// reapresume parks a workflow on an external event, waits for the idle reaper
+// to release its actor, then raises the event and requires the workflow to
+// resume and complete.
+type reapresume struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (r *reapresume) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	r.place = placement.New(t)
+	r.scheduler = procscheduler.New(t)
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+		daprd.WithSchedulerAddresses(r.scheduler.Address()),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_WORKFLOW_JANITOR_PERIOD", "4s",
+			"DAPR_WORKFLOW_REAPER_SCAN_INTERVAL", "500ms",
+			"DAPR_WORKFLOW_REAPER_IDLE_TTL", "1s",
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.scheduler, r.place, app, r.daprd),
+	}
+}
+
+func (r *reapresume) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	require.NoError(t, reg.AddWorkflowN("ParkThenResume", func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.WaitForSingleEvent("go", time.Minute).Await(&out); err != nil {
+			return nil, err
+		}
+		return "resumed-" + out, nil
+	}))
+
+	backendClient := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
+
+	resp, err := r.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "ParkThenResume",
+		Input:             []byte(`"x"`),
+	})
+	require.NoError(t, err)
+
+	workflowActors := func() int {
+		for _, a := range r.daprd.GetMetadata(t, ctx).ActorRuntime.ActiveActors {
+			if strings.HasSuffix(a.Type, ".workflow") {
+				return a.Count
+			}
+		}
+		return 0
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Positive(c, workflowActors())
+	}, time.Second*10, time.Millisecond*10)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, workflowActors())
+	}, time.Second*20, time.Millisecond*10)
+
+	_, err = r.daprd.GRPCClient(t, ctx).RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
+		InstanceId:        resp.GetInstanceId(),
+		WorkflowComponent: "dapr",
+		EventName:         "go",
+		EventData:         []byte(`"y"`),
+	})
+	require.NoError(t, err)
+
+	wctx, cancel := context.WithTimeout(ctx, time.Second*60)
+	defer cancel()
+	metadata, err := backendClient.WaitForWorkflowCompletion(wctx, api.InstanceID(resp.GetInstanceId()))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `"resumed-y"`, metadata.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/residencychurn.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/residencychurn.go
@@ -1,0 +1,146 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(residencychurn))
+}
+
+// residencychurn drives many short workflows under constant deactivation
+// pressure and requires prompt completion without janitor recovery, a drained
+// scheduler, and reloadable terminal state.
+type residencychurn struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (r *residencychurn) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	r.place = placement.New(t)
+	r.scheduler = procscheduler.New(t)
+	r.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+		daprd.WithSchedulerAddresses(r.scheduler.Address()),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.scheduler, r.place, app, r.daprd),
+	}
+}
+
+func (r *residencychurn) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	require.NoError(t, reg.AddWorkflowN("ChurnSeq", func(c *task.WorkflowContext) (any, error) {
+		var out string
+		for i := range 3 {
+			if err := c.CallActivity("Step",
+				task.WithActivityInput(fmt.Sprintf("s%d", i)),
+			).Await(&out); err != nil {
+				return nil, err
+			}
+		}
+		return out, nil
+	}))
+	require.NoError(t, reg.AddActivityN("Step", func(c task.ActivityContext) (any, error) {
+		var in string
+		if err := c.GetInput(&in); err != nil {
+			return nil, err
+		}
+		return in + "-done", nil
+	}))
+
+	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, cl.StartWorkItemListener(ctx, reg))
+
+	const total = 60
+	ids := make([]api.InstanceID, total)
+
+	var wg sync.WaitGroup
+	errs := make([]error, total)
+	for i := range total {
+		id, err := cl.ScheduleNewWorkflow(ctx, "ChurnSeq",
+			api.WithInstanceID(api.InstanceID(fmt.Sprintf("churn-%03d", i))))
+		require.NoError(t, err)
+		ids[i] = id
+
+		wg.Add(1)
+		go func(idx int, wid api.InstanceID) {
+			defer wg.Done()
+			wctx, cancel := context.WithTimeout(ctx, 45*time.Second)
+			defer cancel()
+			meta, werr := cl.WaitForWorkflowCompletion(wctx, wid)
+			if werr != nil {
+				errs[idx] = werr
+				return
+			}
+			if !strings.Contains(meta.GetRuntimeStatus().String(), "COMPLETED") {
+				errs[idx] = fmt.Errorf("workflow %s ended %s", wid, meta.GetRuntimeStatus())
+			}
+		}(i, id)
+	}
+	wg.Wait()
+	for i, err := range errs {
+		require.NoError(t, err, "workflow churn-%03d must complete promptly without janitor recovery", i)
+	}
+
+	for _, i := range []int{0, total / 2, total - 1} {
+		meta, err := cl.FetchWorkflowMetadata(ctx, ids[i])
+		require.NoError(t, err)
+		require.NotNil(t, meta)
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		var leaked int
+		for _, key := range r.scheduler.ListAllKeys(t, ctx, "dapr/jobs") {
+			if strings.Contains(key, "new-event") && !strings.Contains(key, "janitor") {
+				leaked++
+			}
+			if strings.Contains(key, "run-activity") || strings.Contains(key, "activity-result") {
+				leaked++
+			}
+		}
+		assert.Zero(c, leaked, "scheduler must drain to zero workflow one-shot jobs")
+	}, 30*time.Second, 10*time.Millisecond)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
@@ -125,6 +125,8 @@ func (w *restart) Run(t *testing.T, ctx context.Context) {
 	metadata, err := client2.WaitForWorkflowCompletion(wctx, api.InstanceID(resp.GetInstanceId()))
 	require.NoError(t, err)
 	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Positive(t, daprd2.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_wake_count", "status:janitor_recovered"),
+		"the restart recovery must be attributed to the janitor")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		janitors := w.scheduler.JobKeyCount(t, ctx, "new-event-janitor")


### PR DESCRIPTION
Actor residency is bounded: an idle reaper walks the actor table and releases orchestrators that have taken no turn within the idle TTL, stamped via lastActive on every turn-lock acquisition, with lastProgress (durable commit time) distinguishing alive-and- progressing from merely-polled so a recreated actor reads as stalled and the durable backstops recover it. The reaper scan interval and idle TTL are resolved in the factory constructor (env-overridable for tests via a shared EnvDurationOr helper); the TTL defaults to half the janitor period, since the janitor fire re-stamps lastActive every period and a TTL at or above it would leave the reaper inert for exactly the instances holding memory. The deactivation worker pool and reaper exit on the engine context and are joined by the final HaltAll, so engine shutdown leaks no goroutines.

Escalation and the janitor gain pressure-aware hysteresis: a failed drive against an instance showing recent life is not escalated to a durable reminder, and the janitor skips re-dispatch checks for instances with fresh progress, so overload sheds to the next period instead of amplifying into scheduler churn.

The activity actor lock is scoped to the execution claim rather than the whole invocation: the app roundtrip and result delivery run outside it, with the inflight entry as the execution guard. The inflight call gains a resolving phase covering the window between the engine releasing its held registration and the result publish settling the call, so the stale-claim check can never evict a healthy execution mid-publish. Lock waits are recorded as a per-factory sampled lock_wait histogram splitting queueing from turn body.