### PR TITLE
fix: prevent sidecar panic on timeout cancellation during response streaming (#10371)

### DIFF
--- a/pkg/resiliency/policy.go
+++ b/pkg/resiliency/policy.go
@@ -150,39 +150,28 @@ func NewRunnerWithOptions[T any](ctx context.Context, def *PolicyDefinition, opt
 				done := make(chan doneCh[T], 1)
 				go func() {
 					rRes, rErr := operCopy(ctx)
-
-					// If the channel is full, it means we had a timeout
-					select {
-					case done <- doneCh[T]{rRes, rErr}:
-						// No timeout, all good
-					default:
-						// The operation has timed out
-						// Invoke the disposer if we have a non-zero return value
-						// Note that in case of timeouts we do not invoke the accumulator
-						if opts.Disposer != nil && !isZero(rRes) {
-							opts.Disposer(rRes)
-						}
-					}
+					done <- doneCh[T]{rRes, rErr}
 				}()
 
 				select {
 				case v := <-done:
 					return v.res, v.err
 				case <-ctx.Done():
-					// Because done has a capacity of 1, adding a message on the channel signals that there was a timeout
-					// However, the response may have arrived in the meanwhile, so we need to also check if something was added
-					select {
-					case done <- doneCh[T]{}:
-						// All good, nothing to do here
-					default:
-						// The response arrived at the same time as the context deadline, and the channel has a message
-						v := <-done
+					// The operation has timed out. Wait for the operation
+					// goroutine to finish before returning to the caller:
+					// the operation may still be writing to caller-owned
+					// resources (e.g. the http.ResponseWriter used to stream
+					// HTTP service invocation responses), and returning while
+					// it is still running lets the caller recycle those
+					// resources underneath it, causing a panic
+					// (dapr/dapr#10371).
+					v := <-done
 
-						// Invoke the disposer if the return value is non-zero
-						// Note that in case of timeouts we do not invoke the accumulator
-						if opts.Disposer != nil && !isZero(v.res) {
-							opts.Disposer(v.res)
-						}
+					// Invoke the disposer if the return value is non-zero.
+					// Note that in case of timeouts we do not invoke the
+					// accumulator.
+					if opts.Disposer != nil && !isZero(v.res) {
+						opts.Disposer(v.res)
 					}
 					if def.addTimeoutActivatedMetric != nil && timeoutMetricsActivated.CompareAndSwap(false, true) {
 						def.addTimeoutActivatedMetric()

--- a/pkg/resiliency/policy_test.go
+++ b/pkg/resiliency/policy_test.go
@@ -178,19 +178,19 @@ func TestPolicyTimeout(t *testing.T) {
 		name      string
 		sleepTime time.Duration
 		timeout   time.Duration
-		expected  bool
+		wantErr   bool
 	}{
 		{
 			name:      "Timeout expires",
 			sleepTime: time.Millisecond * 100,
 			timeout:   time.Millisecond * 10,
-			expected:  false,
+			wantErr:   true,
 		},
 		{
 			name:      "Timeout OK",
 			sleepTime: time.Millisecond * 10,
 			timeout:   time.Millisecond * 100,
-			expected:  true,
+			wantErr:   false,
 		},
 	}
 
@@ -209,9 +209,17 @@ func TestPolicyTimeout(t *testing.T) {
 				name: "timeout",
 				t:    test.timeout,
 			})
-			policy(fn)
+			_, err := policy(fn)
 
-			assert.Equal(t, test.expected, called.Load())
+			if test.wantErr {
+				assert.ErrorIs(t, err, context.DeadlineExceeded)
+			} else {
+				assert.NoError(t, err)
+			}
+			// The operation goroutine is always joined before the policy
+			// returns, even on timeout: this prevents the operation from
+			// outliving a caller that owns its resources (dapr/dapr#10371).
+			assert.True(t, called.Load())
 		})
 	}
 }


### PR DESCRIPTION
## Description

Fixes #10371 — the Dapr sidecar (daprd) panics with a nil pointer dereference when an HTTP service invocation with a resiliency timeout is cancelled while the response body is still streaming.

### Root cause

In `NewRunnerWithOptions` (pkg/resiliency/policy.go), when a timeout fires, the wrapper returns `ctx.Err()` immediately and **abandons the operation goroutine**. The operation can then outlive the caller: in the HTTP service invocation path, `onDirectMessage` streams the response body with `io.Copy(w, reader)` inside the policy function, so on cancellation the handler returns while the orphaned goroutine is still writing to the `http.ResponseWriter`. `net/http` then recycles the `*bufio.Writer` (returned to a `sync.Pool` after `Reset(nil)`), and the goroutine's next `Flush()` dereferences a nil writer — SIGSEGV, daprd exits code 2, killing every in-flight invocation on the pod. The flush-every-write behavior that turns the stray write into a crash was introduced by #9638, on top of the timeout contract from #7270.

### Fix

On timeout, **wait for the operation goroutine to finish before returning to the caller** (one of the options suggested in the issue). The operation shares the same now-cancelled context, so it observes the cancellation and returns promptly (the next `Read` on the stream fails). This closes the use-after-recycle window: the caller never returns while anything can still write to its resources.

### Changes

- `pkg/resiliency/policy.go`: the timeout branch now blocks on the `done` channel (which always receives a value, since the goroutine's send no longer races a timeout marker), disposes the result, and only then returns `ctx.Err()`.
- `pkg/resiliency/policy_test.go`: `TestPolicyTimeout` now asserts the returned error type (`context.DeadlineExceeded`) and that the operation goroutine has been joined (`called == true`) even on timeout.

### Related

- #9638 added the `flushWriter` with an unconditional `Flush()` after every write (first release v1.17.2)
- #9914 flaky direct-messaging resiliency tests — same orphaned-goroutine code path

## Release Note

RELEASE NOTE: **FIX** Sidecar no longer panics when an HTTP service invocation with a resiliency timeout is cancelled while the response body is streaming.