### PR TITLE
fix: apply max body size in bytes to HTTP channel response body

### DIFF
--- a/pkg/channel/http/http_channel.go
+++ b/pkg/channel/http/http_channel.go
@@ -673,7 +673,7 @@ func (h *Channel) parseChannelResponse(channelResp *http.Response) (*invokev1.In
 	// Limit response body if needed
 	var body io.ReadCloser
 	if h.maxResponseBodySize > 0 {
-		body = streamutils.LimitReadCloser(channelResp.Body, int64(h.maxResponseBodySize)<<20)
+		body = streamutils.LimitReadCloser(channelResp.Body, int64(h.maxResponseBodySize))
 	} else {
 		body = channelResp.Body
 	}


### PR DESCRIPTION
## Description

Removes the leftover `<<20` bitshift in `parseChannelResponse` that was introduced when `maxResponseBodySizeMB` (MiB) was renamed to `maxResponseBodySize` (bytes) in commit `c920e2667` (2024-02-16).

The response side was capping at `maxResponseBodySize << 20` — with the default `4 << 20` bytes, this evaluates to `4 << 40` (~4 TiB) instead of the intended 4 MiB. The `--max-body-size` flag was effectively ignored for app response bodies.

The request side (`MaxBodySizeMiddleware` in `server.go:299`) applies the same value without a shift and is unaffected.

## Related issue

Closes #10353