### PR TITLE
perf(workflow): elide no-op start trigger

### DIFF
--- a/pkg/actors/targets/workflow/common/backoff.go
+++ b/pkg/actors/targets/workflow/common/backoff.go
@@ -25,8 +25,7 @@ import (
 
 const (
 	// RetryBackoffBase and RetryBackoffCap bound the jittered retry
-	// backoffs on the workflow drive and reminder paths, mirroring the
-	// create path's createRetryBackoff in the wfengine actors backend.
+	// backoffs on the workflow drive, reminder and create paths.
 	RetryBackoffBase = 50 * time.Millisecond
 	RetryBackoffCap  = 2 * time.Second
 )

--- a/pkg/actors/targets/workflow/orchestrator/factory.go
+++ b/pkg/actors/targets/workflow/orchestrator/factory.go
@@ -131,6 +131,8 @@ type factory struct {
 	reaperScanInterval time.Duration
 	reaperIdleTTL      time.Duration
 
+	foldWaitTimeout time.Duration
+
 	rootCtx context.Context
 	escLock sync.Mutex
 	escWG   sync.WaitGroup
@@ -170,6 +172,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 
 	reaperScanInterval := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_SCAN_INTERVAL", 5*time.Second)
 	reaperIdleTTL := common.EnvDurationOr("DAPR_WORKFLOW_REAPER_IDLE_TTL", max(2*common.JanitorPeriod(), time.Minute))
+	foldWaitTimeout := common.EnvDurationOr("DAPR_WORKFLOW_FOLD_WAIT_TIMEOUT", 2*time.Minute)
 
 	f := &factory{
 		appID:                  opts.AppID,
@@ -187,6 +190,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 		retentionPolicy:        opts.RetentionPolicy,
 		signer:                 opts.Signer,
 		maxRequestBodySize:     opts.MaxRequestBodySize,
+		foldWaitTimeout:        foldWaitTimeout,
 		workflowAccessPolicies: opts.WorkflowAccessPolicies,
 		scheduler:              opts.Scheduler,
 		deactivateCh:           deactivateCh,

--- a/pkg/actors/targets/workflow/orchestrator/fold.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold.go
@@ -45,11 +45,6 @@ import (
 // unboundedly. Overflow stays pending and the taking turn re-drives.
 const maxFoldPerTurn = 128
 
-// foldWaitTimeout bounds how long a folding submit waits for its turn to
-// commit before nacking the sender into its retry loop. Generous: the wait
-// covers actor lock queueing plus a full turn including the app round trip.
-const foldWaitTimeout = 2 * time.Minute
-
 // foldEntry is one sender-retried completion held in memory awaiting its
 // folding turn. committed is closed exactly once when the entry resolves,
 // with err set first: nil after the turn's commit persisted the event into
@@ -116,7 +111,7 @@ func (o *orchestrator) invokeAddEventFold(ctx context.Context, req *internalsv1p
 			// flushed at deactivation.
 			diag.DefaultWorkflowMonitoring.WorkflowCompletionsFold(context.Background(), diag.StatusFoldNacked)
 			return nil, ctx.Err()
-		case <-time.After(foldWaitTimeout):
+		case <-time.After(o.foldWaitTimeout):
 			diag.DefaultWorkflowMonitoring.WorkflowCompletionsFold(context.Background(), diag.StatusFoldNacked)
 			return nil, wferrors.NewRecoverable(fmt.Errorf("workflow actor '%s': timed out waiting for the folding turn to commit", o.actorID))
 		case <-entry.committed:
@@ -125,7 +120,6 @@ func (o *orchestrator) invokeAddEventFold(ctx context.Context, req *internalsv1p
 			if err != nil {
 				return nil, err
 			}
-			diag.DefaultWorkflowMonitoring.WorkflowCompletionsFold(context.Background(), diag.StatusFolded)
 		}
 	}
 
@@ -288,10 +282,16 @@ func (o *orchestrator) foldEvents() []*backend.HistoryEvent {
 }
 
 // foldAck signals the taken entries' senders that the commit containing
-// their event succeeded.
+// their event succeeded, and records the folded outcome. The record lives
+// here, on the commit side, not with a waiter: a sender whose invocation
+// timed out before the folding turn committed is no longer waiting (its
+// redelivery is absorbed as a duplicate), and a retry that joined a pending
+// entry waits alongside the original, so waiter-side attribution both
+// undercounts and overcounts. Every committed entry folds exactly once.
 func foldAck(taken []*foldEntry) {
 	for _, p := range taken {
 		close(p.committed)
+		diag.DefaultWorkflowMonitoring.WorkflowCompletionsFold(context.Background(), diag.StatusFolded)
 	}
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -303,3 +303,36 @@ func (o *orchestrator) deleteAllReminders(ctx context.Context) error {
 
 	return nil
 }
+
+// deleteStartReminder removes the pending start one-shot from the scheduler
+// once the turn that consumed the ExecutionStarted event has durably
+// committed.
+func (o *orchestrator) deleteStartReminder(startEvent *backend.HistoryEvent) {
+	name := events.EventReminderName(reminderPrefixStart, startEvent)
+
+	o.escLock.Lock()
+	rootCtx := o.rootCtx
+	if rootCtx.Err() != nil {
+		o.escLock.Unlock()
+		return
+	}
+	o.escWG.Add(1)
+	o.escLock.Unlock()
+
+	go func() {
+		defer o.escWG.Done()
+
+		ctx, cancel := context.WithTimeout(rootCtx, escalateTimeout)
+		defer cancel()
+
+		if err := o.reminders.Delete(ctx, &actorapi.DeleteReminderRequest{
+			Name:      name,
+			ActorType: o.actorTypeBuilder.Workflow(o.appID),
+			ActorID:   o.actorID,
+		}); err != nil {
+			if s, ok := grpcstatus.FromError(err); !ok || s.Code() != codes.NotFound {
+				log.Debugf("Workflow actor '%s': failed to delete pending start reminder '%s' (it will fire as a no-op): %v", o.actorID, name, err)
+			}
+		}
+	}()
+}

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -330,6 +330,13 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 				// including folded completions: their senders are acked.
 				foldedCommitted = true
 
+				// The save above durably committed the consumed
+				// ExecutionStarted, so the pending start one-shot is a no-op
+				// here exactly as on the normal commit path below: elide it.
+				if esHistoryEvent != nil && o.fastPath {
+					o.deleteStartReminder(esHistoryEvent)
+				}
+
 				if len(carryover) > 0 {
 					reminderName := events.EventReminderName(reminderPrefixNewEvent, carryover[0])
 					if o.fastPath {

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -577,6 +577,13 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// history and their senders are acked (see the deferred fold handling).
 	foldedCommitted = true
 
+	// This turn consumed the ExecutionStarted event and its commit above is
+	// durable, so the pending start one-shot can only ever fire as a no-op:
+	// elide it from the scheduler, detached and best-effort.
+	if esHistoryEvent != nil && o.fastPath {
+		o.deleteStartReminder(esHistoryEvent)
+	}
+
 	rstatus := runtimestate.RuntimeStatus(rs)
 	if diagnoseStatus != "" {
 		// If workflow is not completed, set executionStatus to empty string
@@ -692,6 +699,13 @@ const retentionReminderName = "retention"
 // per workflow. The dueTime is anchored to the workflow's completion time
 // (not time.Now()) so retries on a transient scheduler failure converge to
 // the same dueTime instead of pushing retention back on every attempt.
+//
+// One one-shot per instance is deliberate, not batched per app: this
+// reminder is idempotently re-creatable from the instance's own durable
+// state (the empty-inbox completion path above re-asserts it after a lost
+// Create), while a shared per-appID bucket job would need a read-modify-write
+// of job data that is not atomic with the completion save, with no durable
+// per-instance anchor (and no completion-time index) to recover a lost join.
 func (o *orchestrator) handleRetention(ctx context.Context, status protos.OrchestrationStatus) error {
 	if o.retentionPolicy == nil {
 		return nil

--- a/pkg/actors/targets/workflow/orchestrator/wake.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake.go
@@ -108,7 +108,9 @@ type driveInfo struct {
 // MUST be called only after BOTH the state save AND a durable re-driver are
 // in place: either the per-instance janitor reminder (ensureJanitor) or a
 // durable one-shot reminder created by the caller (assertStartReminder keeps
-// its scheduler entry for delayed starts and pending-start recovery).
+// its scheduler entry for delayed starts and pending-start recovery; it is
+// elided best-effort once the first turn durably commits, see
+// deleteStartReminder).
 //
 // Wakes are delivered through a per-instance DRIVE LOOP: localDrive posts a
 // notification (buffered-1 channel: pending notifications coalesce, mirroring

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -479,7 +479,7 @@ func (abe *Actors) CreateWorkflowInstance(ctx context.Context, req *backend.Crea
 		}
 
 		return backoff.Permanent(eerr)
-	}, backoff.WithContext(backoff.NewConstantBackOff(time.Second), ctx))
+	}, backoff.WithContext(common.NewJitterBackoff(common.RetryBackoffBase, common.RetryBackoffCap), ctx))
 
 	elapsed := diag.ElapsedSince(start)
 	if err != nil {

--- a/tests/integration/suite/daprd/workflow/disk/quotamidrun.go
+++ b/tests/integration/suite/daprd/workflow/disk/quotamidrun.go
@@ -54,7 +54,12 @@ func (m *quotamidrun) Setup(t *testing.T) []framework.Option {
 			return nil, nil
 		}),
 		workflow.WithAddOrchestrator(t, "multiTimerFlow", func(ctx *task.WorkflowContext) (any, error) {
-			for range 5 {
+			// Enough iterations that timer jobs keep churning for the whole
+			// test: the healthz flip needs an armed timer job to straddle the
+			// quota-hit instant (its fire-side write is what the scheduler
+			// sees fail), and a workflow that completes before a slow fill
+			// finishes would leave healthz reporting 200 forever.
+			for range 300 {
 				if err := ctx.CreateTimer(time.Second).Await(nil); err != nil {
 					return nil, err
 				}

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/senderlapse.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/senderlapse.go
@@ -36,18 +36,16 @@ import (
 )
 
 func init() {
-	suite.Register(new(captive))
+	suite.Register(new(senderlapse))
 }
 
-// captive strands a fold-held completion with no driver and asserts the
-// janitor's recovery turn commits it.
-type captive struct {
+type senderlapse struct {
 	daprd     *daprd.Daprd
 	place     *placement.Placement
 	scheduler *procscheduler.Scheduler
 }
 
-func (f *captive) Setup(t *testing.T) []framework.Option {
+func (f *senderlapse) Setup(t *testing.T) []framework.Option {
 	f.place = placement.New(t)
 	f.scheduler = procscheduler.New(t)
 	db := sqlite.New(t,
@@ -64,6 +62,7 @@ func (f *captive) Setup(t *testing.T) []framework.Option {
 		daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_WORKFLOW_JANITOR_PERIOD", "2s",
 			"DAPR_WORKFLOW_TEST_DROP_FOLD_DRIVES", "100",
+			"DAPR_WORKFLOW_FOLD_WAIT_TIMEOUT", "200ms",
 		)),
 	)
 
@@ -72,7 +71,7 @@ func (f *captive) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (f *captive) Run(t *testing.T, ctx context.Context) {
+func (f *senderlapse) Run(t *testing.T, ctx context.Context) {
 	f.scheduler.WaitUntilRunning(t, ctx)
 	f.place.WaitUntilRunning(t, ctx)
 	f.daprd.WaitUntilRunning(t, ctx)
@@ -103,18 +102,17 @@ func (f *captive) Run(t *testing.T, ctx context.Context) {
 	wctx, cancel := context.WithTimeout(ctx, time.Second*45)
 	defer cancel()
 	metadata, err := cl.WaitForWorkflowCompletion(wctx, api.InstanceID(resp.GetInstanceId()))
-	require.NoError(t, err, "workflow stranded on a captive fold-held completion (janitor never drove the folding turn)")
+	require.NoError(t, err, "workflow stranded despite sender retries and janitor recovery")
 	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
 	assert.Equal(t, `"ok"`, metadata.GetOutput().GetValue())
 
-	assert.GreaterOrEqual(t, f.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_wake_count", "status:janitor_fold_recovered"), float64(1),
-		"at least one captive completion must be recovered by a janitor-driven turn")
-
 	folded := f.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_completions_fold_count", "status:folded")
 	nacked := f.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_completions_fold_count", "status:fold_nacked")
-	assert.GreaterOrEqual(t, folded, float64(2))
+	assert.GreaterOrEqual(t, folded, float64(2),
+		"non-terminal captive entries must fold: any committing turn takes them first")
 	assert.LessOrEqual(t, folded, float64(3), "folded is commit-attributed: at most one record per completion")
-	assert.GreaterOrEqual(t, folded+nacked, float64(3), "every captive completion must resolve as folded or nacked")
+	assert.GreaterOrEqual(t, nacked, float64(3),
+		"every completion's first submit must lapse at the shortened fold wait")
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		janitors := f.scheduler.JobKeyCount(t, ctx, "new-event-janitor")

--- a/tests/integration/suite/daprd/workflow/scheduler/startelide.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/startelide.go
@@ -1,0 +1,137 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(startelide))
+}
+
+// startelide pins the fast-path start-trigger elision: the pending start
+// one-shot is deleted without ever firing once the first turn commits, while
+// a delayed start keeps its entry until the due time.
+type startelide struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (s *startelide) Setup(t *testing.T) []framework.Option {
+	app := app.New(t)
+	s.place = placement.New(t)
+	s.scheduler = procscheduler.New(t)
+	s.daprd = daprd.New(t,
+		daprd.WithAppPort(app.Port()),
+		daprd.WithPlacementAddresses(s.place.Address()),
+		daprd.WithInMemoryActorStateStore("statestore"),
+		daprd.WithSchedulerAddresses(s.scheduler.Address()),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_WORKFLOW_JANITOR_PERIOD", "5m",
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.scheduler, s.place, app, s.daprd),
+	}
+}
+
+func (s *startelide) Run(t *testing.T, ctx context.Context) {
+	s.scheduler.WaitUntilRunning(t, ctx)
+	s.place.WaitUntilRunning(t, ctx)
+	s.daprd.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	require.NoError(t, reg.AddWorkflowN("Park", func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.WaitForSingleEvent("go", time.Minute*3).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, reg.AddWorkflowN("Quick", func(c *task.WorkflowContext) (any, error) {
+		return "done", nil
+	}))
+
+	backendClient := client.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
+
+	triggered := func() int {
+		return int(s.scheduler.Metrics(t, ctx).All()["dapr_scheduler_jobs_triggered_total"])
+	}
+
+	resp, err := s.daprd.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "Park",
+		Input:             []byte(`"x"`),
+	})
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, s.scheduler.JobKeyCount(t, ctx, "||start-es-"))
+	}, time.Second*20, time.Millisecond*50)
+	meta, err := backendClient.FetchWorkflowMetadata(ctx, api.InstanceID(resp.GetInstanceId()))
+	require.NoError(t, err)
+	require.False(t, api.WorkflowMetadataIsComplete(meta),
+		"the workflow must still be parked when its start entry disappears")
+	assert.Zero(t, triggered(),
+		"the start one-shot must be elided without a scheduler trigger cycle")
+
+	_, err = s.daprd.GRPCClient(t, ctx).RaiseEventWorkflowBeta1(ctx, &rtv1.RaiseEventWorkflowRequest{
+		InstanceId:        resp.GetInstanceId(),
+		WorkflowComponent: "dapr",
+		EventName:         "go",
+		EventData:         []byte(`"y"`),
+	})
+	require.NoError(t, err)
+	meta, err = backendClient.WaitForWorkflowCompletion(ctx, api.InstanceID(resp.GetInstanceId()))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+
+	// A delayed start must keep its entry until the due time: the elision
+	// only runs after the first turn commits.
+	id, err := backendClient.ScheduleNewWorkflow(ctx, "Quick",
+		api.WithInstanceID("delayed"),
+		api.WithStartTime(time.Now().Add(time.Second*3)))
+	require.NoError(t, err)
+	assert.Equal(t, 1, s.scheduler.JobKeyCount(t, ctx, "||start-es-"),
+		"the delayed start entry must survive until its due time")
+	meta, err = backendClient.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, s.scheduler.JobKeyCount(t, ctx, "||start-es-"))
+	}, time.Second*10, time.Millisecond*50)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/startelide.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/startelide.go
@@ -84,6 +84,17 @@ func (s *startelide) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, reg.AddWorkflowN("Quick", func(c *task.WorkflowContext) (any, error) {
 		return "done", nil
 	}))
+	require.NoError(t, reg.AddWorkflowN("Spin", func(c *task.WorkflowContext) (any, error) {
+		var n int
+		if err := c.GetInput(&n); err != nil {
+			return nil, err
+		}
+		if n < 30 {
+			c.ContinueAsNew(n + 1)
+			return nil, nil
+		}
+		return "spun", nil
+	}))
 
 	backendClient := client.NewTaskHubGrpcClient(s.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
 	require.NoError(t, backendClient.StartWorkItemListener(ctx, reg))
@@ -119,6 +130,22 @@ func (s *startelide) Run(t *testing.T, ctx context.Context) {
 	meta, err = backendClient.WaitForWorkflowCompletion(ctx, api.InstanceID(resp.GetInstanceId()))
 	require.NoError(t, err)
 	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+
+	// A first turn ending in the engine's abandoned-CAN save path (30 CANs
+	// against the tight-loop cap of 20) must elide the start entry too, and
+	// still without a single scheduler trigger.
+	spinID, err := backendClient.ScheduleNewWorkflow(ctx, "Spin",
+		api.WithInstanceID("spin"), api.WithInput(0))
+	require.NoError(t, err)
+	meta, err = backendClient.WaitForWorkflowCompletion(ctx, spinID)
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+	assert.Equal(t, `"spun"`, meta.GetOutput().GetValue())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, s.scheduler.JobKeyCount(t, ctx, "||start-es-"))
+	}, time.Second*10, time.Millisecond*50)
+	assert.Zero(t, triggered(),
+		"the CAN-abandon commit path must elide without a scheduler trigger cycle")
 
 	// A delayed start must keep its entry until the due time: the elision
 	// only runs after the first turn commits.

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/restart.go
@@ -84,12 +84,26 @@ func (w *restart) Run(t *testing.T, ctx context.Context) {
 		return "done", nil
 	}))
 
+	// daprd1's app blocks the resumed turn forever, so the raised event can
+	// never commit before the kill: the recovery MUST come from daprd2's
+	// janitor rather than racing daprd1's local drive against the shutdown.
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	registry1 := task.NewTaskRegistry()
+	require.NoError(t, registry1.AddWorkflowN("WaitForGo", func(c *task.WorkflowContext) (any, error) {
+		if err := c.WaitForSingleEvent("go", time.Minute*3).Await(new([]byte)); err != nil {
+			return nil, err
+		}
+		<-block
+		return "done", nil
+	}))
+
 	daprd1 := newDaprd()
 	daprd1.Run(t, ctx)
 	daprd1.WaitUntilRunning(t, ctx)
 
 	client1 := client.NewTaskHubGrpcClient(daprd1.GRPCConn(t, ctx), backend.DefaultLogger())
-	require.NoError(t, client1.StartWorkItemListener(ctx, registry))
+	require.NoError(t, client1.StartWorkItemListener(ctx, registry1))
 
 	resp, err := daprd1.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
 		WorkflowComponent: "dapr",


### PR DESCRIPTION
Every create pays a fixed scheduler job lifecycle on the scheduler even when the local wake fast path drives all real work. The start one-shot is kept after the locally driven first turn commits, so it later fires as a no-op and still costs a row read, trigger cycle, delivery, ack and delete on the shared instance.

Once the turn that consumed the ExecutionStarted event has durably committed, delete the pending start entry, detached and best effort.

Also replace the constant 1s backoff in CreateWorkflowInstance with decorrelated exponential jitter (50ms start, 2s cap), keeping the retryable error classification, so overload retries spread instead of re-colliding.