### PR TITLE
integration: add clustered workflow CI job

### DIFF
--- a/.github/workflows/dapr.yml
+++ b/.github/workflows/dapr.yml
@@ -269,6 +269,33 @@ jobs:
           sudo sysctl -w net.inet.tcp.msl=1000
       - name: Run make test-integration-parallel
         run: make test-integration-parallel
+  integration-tests-workflow-modes:
+    name: "Integration tests (workflow ${{ matrix.mode }} mode)"
+    needs: lint
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        mode: [clustered]
+    env:
+      GOOS: linux
+      GOARCH: amd64
+      GOPROXY: "https://proxy.golang.org"
+      TEST_OUTPUT_FILE_PREFIX: "test_report_wf_${{ matrix.mode }}"
+      DAPR_INTEGRATION_WORKFLOW_CLUSTERED: ${{ matrix.mode == 'clustered' && 'true' || '' }}
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v6
+      - name: Set up Go
+        id: setup-go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: "go.mod"
+      - name: Run workflow suite in ${{ matrix.mode }} mode
+        run: make test-integration-parallel ARGS="-focus workflow"
   build:
     name: "Build artifacts on ${{ matrix.job_name }} - ${{ matrix.sidecar_flavor }}"
     runs-on: "${{ matrix.os }}"

--- a/tests/docs/writing-integration-test.md
+++ b/tests/docs/writing-integration-test.md
@@ -43,6 +43,14 @@ logs to always be printed with the environment variable
 
 You can override the directory that is used to read the CRD definitions that are served by the Kubernetes process with the environment variable `DAPR_INTEGRATION_CRD_DIRECTORY`.
 
+Setting `DAPR_INTEGRATION_WORKFLOW_CLUSTERED=true` enables the
+`WorkflowsClusteredDeployment` preview feature on every daprd built by the
+workflow test framework, running the workflow suite in clustered deployment
+mode. Tests can override this per workflow with
+`workflow.WithClusteredDeployment(bool)`, and branch mode-specific assertions
+on `workflow.ClusteredDeployment()`. CI runs the workflow suite in this mode as
+a leg of the `integration-tests-workflow-modes` matrix job.
+
 ## Adding a new test
 
 To add a new test scenario, either create a new subject directory in

--- a/tests/integration/framework/process/daprd/workflow/options.go
+++ b/tests/integration/framework/process/daprd/workflow/options.go
@@ -24,7 +24,17 @@ import (
 type Option func(*options)
 
 type options struct {
-	registry *task.TaskRegistry
+	registry  *task.TaskRegistry
+	clustered *bool
+}
+
+// WithClusteredDeployment explicitly enables or disables the
+// WorkflowsClusteredDeployment feature flag on the underlying daprd,
+// overriding the DAPR_INTEGRATION_WORKFLOW_CLUSTERED environment variable.
+func WithClusteredDeployment(enabled bool) Option {
+	return func(o *options) {
+		o.clustered = &enabled
+	}
 }
 
 func WithAddWorkflowN(t *testing.T, name string, or func(*task.WorkflowContext) (any, error)) Option {

--- a/tests/integration/framework/process/daprd/workflow/workflow.go
+++ b/tests/integration/framework/process/daprd/workflow/workflow.go
@@ -21,14 +21,17 @@ import (
 
 	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
 	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	procworkflow "github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 )
 
 type Workflow struct {
-	registry *task.TaskRegistry
-	actors   *actors.Actors
+	registry  *task.TaskRegistry
+	actors    *actors.Actors
+	clustered bool
 }
 
 func New(t *testing.T, fopts ...Option) *Workflow {
@@ -41,10 +44,36 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 		fopt(&opts)
 	}
 
-	return &Workflow{
-		registry: opts.registry,
-		actors:   actors.New(t),
+	clustered := procworkflow.ClusteredDeploymentFromEnv()
+	if opts.clustered != nil {
+		clustered = *opts.clustered
 	}
+
+	// A single manifest carries all harness-driven features: the last config
+	// file specifying spec.features replaces earlier feature lists, so
+	// separate manifests would not compose.
+	features := make([]string, 0, 1)
+	if clustered {
+		features = append(features, "WorkflowsClusteredDeployment")
+	}
+	var aopts []actors.Option
+	if len(features) > 0 {
+		aopts = append(aopts, actors.WithDaprdOptions(
+			daprd.WithFeatureEnabled(t, features...),
+		))
+	}
+
+	return &Workflow{
+		registry:  opts.registry,
+		actors:    actors.New(t, aopts...),
+		clustered: clustered,
+	}
+}
+
+// ClusteredDeployment reports whether the underlying daprd runs with the
+// WorkflowsClusteredDeployment feature flag enabled.
+func (w *Workflow) ClusteredDeployment() bool {
+	return w.clustered
 }
 
 func (w *Workflow) Run(t *testing.T, ctx context.Context) {

--- a/tests/integration/framework/process/workflow/clustered.go
+++ b/tests/integration/framework/process/workflow/clustered.go
@@ -28,24 +28,15 @@ import (
 func NewClustered(t *testing.T, daprds int, extraDaprdOpts ...daprd.Option) *Workflow {
 	t.Helper()
 
-	wopts := make([]Option, 0, 1+daprds)
-	wopts = append(wopts, WithDaprds(daprds))
-	config := `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-    name: workflowsclustereddeployment
-spec:
-    features:
-    - name: WorkflowsClusteredDeployment
-      enabled: true
-`
 	uid, err := uuid.NewRandom()
 	require.NoError(t, err)
 	appID := uid.String()
 
+	wopts := make([]Option, 0, 2+daprds)
+	wopts = append(wopts, WithDaprds(daprds), WithClusteredDeployment(true))
+
 	for i := range daprds {
-		dopts := append([]daprd.Option{daprd.WithAppID(appID), daprd.WithConfigManifests(t, config)}, extraDaprdOpts...)
+		dopts := append([]daprd.Option{daprd.WithAppID(appID)}, extraDaprdOpts...)
 		wopts = append(wopts, WithDaprdOptions(i, dopts...))
 	}
 	return New(t, wopts...)

--- a/tests/integration/framework/process/workflow/options.go
+++ b/tests/integration/framework/process/workflow/options.go
@@ -46,6 +46,7 @@ type options struct {
 	skipDB          bool
 	mtls            bool
 	signingDisabled []int
+	clustered       *bool
 
 	orchestrators     []orchestratorConfig
 	activities        []activityConfig
@@ -126,6 +127,15 @@ func WithMTLS(t *testing.T) Option {
 func WithSigningDisabledN(index int) Option {
 	return func(o *options) {
 		o.signingDisabled = append(o.signingDisabled, index)
+	}
+}
+
+// WithClusteredDeployment explicitly enables or disables the
+// WorkflowsClusteredDeployment feature flag on every daprd in the workflow,
+// overriding the DAPR_INTEGRATION_WORKFLOW_CLUSTERED environment variable.
+func WithClusteredDeployment(enabled bool) Option {
+	return func(o *options) {
+		o.clustered = &enabled
 	}
 }
 

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -15,6 +15,7 @@ package workflow
 
 import (
 	"context"
+	"os"
 	"runtime"
 	"testing"
 	"time"
@@ -32,7 +33,29 @@ import (
 	"github.com/dapr/durabletask-go/client"
 	"github.com/dapr/durabletask-go/task"
 	"github.com/dapr/durabletask-go/workflow"
+	kitstrings "github.com/dapr/kit/strings"
 )
+
+// ClusteredDeploymentConfig is a Configuration manifest enabling the
+// WorkflowsClusteredDeployment preview feature.
+const ClusteredDeploymentConfig = `
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+    name: workflowsclustereddeployment
+spec:
+    features:
+    - name: WorkflowsClusteredDeployment
+      enabled: true
+`
+
+// ClusteredDeploymentFromEnv reports whether the suite is running with
+// DAPR_INTEGRATION_WORKFLOW_CLUSTERED set truthy, which enables the
+// WorkflowsClusteredDeployment feature flag on every daprd built by this
+// harness unless a test overrides it with WithClusteredDeployment.
+func ClusteredDeploymentFromEnv() bool {
+	return kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_WORKFLOW_CLUSTERED"))
+}
 
 type Workflow struct {
 	taskregistry []*task.TaskRegistry
@@ -42,6 +65,7 @@ type Workflow struct {
 	ownsSched    bool
 	sentry       *sentry.Sentry
 	daprds       []*daprd.Daprd
+	clustered    bool
 }
 
 func New(t *testing.T, fopts ...Option) *Workflow {
@@ -59,6 +83,11 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 	}
 
 	require.GreaterOrEqual(t, opts.daprds, 1, "at least one daprd instance is required")
+
+	clustered := ClusteredDeploymentFromEnv()
+	if opts.clustered != nil {
+		clustered = *opts.clustered
+	}
 
 	db := sqlite.New(t,
 		sqlite.WithActorStateStore(true),
@@ -96,20 +125,18 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 		baseDopts = append(baseDopts, daprd.WithResourceFiles(db.GetComponent(t)))
 	}
 
-	var signingDopts []daprd.Option
 	if sen != nil {
 		baseDopts = append(baseDopts, daprd.WithSentry(t, sen))
-		signingDopts = []daprd.Option{
-			daprd.WithConfigManifests(t, `apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: propagation-signing
-spec:
-  features:
-  - name: WorkflowHistorySigning
-    enabled: true
-`),
-		}
+	}
+
+	// daprd loads each config file onto one Configuration struct and
+	// spec.features is a slice, so the LAST config file that specifies
+	// features replaces every earlier feature list. All harness-driven
+	// features must therefore land in a single manifest per daprd; it is
+	// built in the per-daprd loop below because signing is per-daprd.
+	baseFeatures := make([]string, 0, 1)
+	if clustered {
+		baseFeatures = append(baseFeatures, "WorkflowsClusteredDeployment")
 	}
 
 	if opts.schedulerAddress != nil {
@@ -129,11 +156,15 @@ spec:
 	daprds := make([]*daprd.Daprd, opts.daprds)
 
 	for i := range daprds {
-		dopts := make([]daprd.Option, 0, len(baseDopts)+len(signingDopts))
+		dopts := make([]daprd.Option, 0, len(baseDopts)+1)
 		dopts = append(dopts, baseDopts...)
 
-		if !signingDisabled[i] {
-			dopts = append(dopts, signingDopts...)
+		features := baseFeatures
+		if sen != nil && !signingDisabled[i] {
+			features = append(features[:len(features):len(features)], "WorkflowHistorySigning")
+		}
+		if len(features) > 0 {
+			dopts = append(dopts, daprd.WithFeatureEnabled(t, features...))
 		}
 
 		// Add specific opts for this daprd
@@ -171,6 +202,7 @@ spec:
 		ownsSched:    ownsSched,
 		sentry:       sen,
 		daprds:       daprds,
+		clustered:    clustered,
 	}
 
 	for i := range workflow.taskregistry {
@@ -312,6 +344,23 @@ func (w *Workflow) GRPCClientN(t *testing.T, ctx context.Context, index int) rtv
 	t.Helper()
 	require.Less(t, index, len(w.daprds), "index out of range")
 	return w.daprds[index].GRPCClient(t, ctx)
+}
+
+// ClusteredDeployment reports whether every daprd in this workflow runs with
+// the WorkflowsClusteredDeployment feature flag enabled. Tests use this to
+// branch assertions which differ between the two modes.
+func (w *Workflow) ClusteredDeployment() bool {
+	return w.clustered
+}
+
+// ActorTypesCount returns the number of actor types a daprd in this workflow
+// registers when a worker is connected: workflow, activity and retentioner,
+// plus the executor rendezvous type in clustered deployment mode.
+func (w *Workflow) ActorTypesCount() int {
+	if w.clustered {
+		return 4
+	}
+	return 3
 }
 
 func (w *Workflow) Dapr() *daprd.Daprd {

--- a/tests/integration/framework/workflow/dedup.go
+++ b/tests/integration/framework/workflow/dedup.go
@@ -53,6 +53,61 @@ func InjectInboxEvent(t *testing.T, ctx context.Context, db *sqlite.SQLite, dapr
 	db.WriteStateValue(t, ctx, key, updated)
 }
 
+// InsertHistoryEvent inserts evt into the workflow actor's persisted history
+// immediately before the first event matching pred, shifting that event and
+// all later history-* keys up by one. The metadata's HistoryLength is
+// incremented by one. The caller is responsible for invalidating the actor's
+// in-memory cache (e.g. via daprd.Restart) before relying on the injection.
+func InsertHistoryEvent(t *testing.T, ctx context.Context, db *sqlite.SQLite, daprd *daprd.Daprd, instanceID string, evt *protos.HistoryEvent, pred func(*protos.HistoryEvent) bool) {
+	t.Helper()
+
+	keyPrefix := workflowActorKeyPrefix(daprd, instanceID)
+
+	values := db.ReadStateValues(t, ctx, instanceID, "history")
+	target := -1
+	for i, raw := range values {
+		var ev protos.HistoryEvent
+		require.NoError(t, proto.Unmarshal(raw, &ev))
+		if pred(&ev) {
+			target = i
+			break
+		}
+	}
+	require.GreaterOrEqual(t, target, 0, "no history event matched the predicate")
+
+	conn := db.GetConnection(t)
+	tableName := db.TableName()
+
+	for i := len(values) - 1; i >= target; i-- {
+		oldKey := fmt.Sprintf("%shistory-%06d", keyPrefix, i)
+		newKey := fmt.Sprintf("%shistory-%06d", keyPrefix, i+1)
+		//nolint:gosec
+		_, err := conn.ExecContext(ctx, "UPDATE "+tableName+" SET key = ? WHERE key = ?", newKey, oldKey)
+		require.NoError(t, err)
+	}
+
+	raw, err := proto.Marshal(evt)
+	require.NoError(t, err)
+	db.WriteStateValue(t, ctx, fmt.Sprintf("%shistory-%06d", keyPrefix, target), raw)
+
+	key, metaRaw := db.ReadStateValue(t, ctx, instanceID, "metadata")
+	var metadata backend.BackendWorkflowStateMetadata
+	require.NoError(t, proto.Unmarshal(metaRaw, &metadata))
+	metadata.HistoryLength++
+	updatedMeta, err := proto.Marshal(&metadata)
+	require.NoError(t, err)
+	db.WriteStateValue(t, ctx, key, updatedMeta)
+}
+
+// IsEventRaisedFor returns a predicate that matches an EventRaised event with
+// the given name.
+func IsEventRaisedFor(name string) func(*protos.HistoryEvent) bool {
+	return func(e *protos.HistoryEvent) bool {
+		er := e.GetEventRaised()
+		return er != nil && er.GetName() == name
+	}
+}
+
 // RemoveHistoryEvent deletes the first history event matching pred and
 // renumbers any subsequent history-* keys to keep the sequence contiguous.
 // The metadata's HistoryLength is decremented by one.

--- a/tests/integration/suite/actors/metadata/workflows.go
+++ b/tests/integration/suite/actors/metadata/workflows.go
@@ -103,7 +103,7 @@ func (w *workflows) Run(t *testing.T, ctx context.Context) {
 	})
 	require.NoError(t, err)
 
-	assert.ElementsMatch(t, []*daprd.MetadataActorRuntimeActiveActor{
+	expected := []*daprd.MetadataActorRuntimeActiveActor{
 		{
 			Type:  "dapr.internal.default." + w.workflow.Dapr().AppID() + ".workflow",
 			Count: 2,
@@ -124,5 +124,12 @@ func (w *workflows) Run(t *testing.T, ctx context.Context) {
 			Type:  "myothertype",
 			Count: 1,
 		},
-	}, w.workflow.Dapr().GetMetaActorRuntime(t, ctx).ActiveActors)
+	}
+	if w.workflow.ClusteredDeployment() {
+		expected = append(expected, &daprd.MetadataActorRuntimeActiveActor{
+			Type:  "dapr.internal.default." + w.workflow.Dapr().AppID() + ".executor",
+			Count: 0,
+		})
+	}
+	assert.ElementsMatch(t, expected, w.workflow.Dapr().GetMetaActorRuntime(t, ctx).ActiveActors)
 }

--- a/tests/integration/suite/daprd/workflow/chaos/remotestream.go
+++ b/tests/integration/suite/daprd/workflow/chaos/remotestream.go
@@ -54,23 +54,11 @@ func (r *remotestream) Setup(t *testing.T) []framework.Option {
 	require.NoError(t, err)
 	appID := uid.String()
 
-	config := `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-    name: workflowsclustereddeployment
-spec:
-    features:
-    - name: WorkflowsClusteredDeployment
-      enabled: true
-`
-
-	wopts := make([]workflow.Option, 0, 3)
-	wopts = append(wopts, workflow.WithDaprds(2))
+	wopts := make([]workflow.Option, 0, 4)
+	wopts = append(wopts, workflow.WithDaprds(2), workflow.WithClusteredDeployment(true))
 	for i := range 2 {
 		wopts = append(wopts, workflow.WithDaprdOptions(i,
 			daprd.WithAppID(appID),
-			daprd.WithConfigManifests(t, config),
 		))
 	}
 

--- a/tests/integration/suite/daprd/workflow/dedup/dedup.go
+++ b/tests/integration/suite/daprd/workflow/dedup/dedup.go
@@ -14,5 +14,6 @@ limitations under the License.
 package dedup
 
 import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/dedup/early"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/dedup/schedulerrestart"
 )

--- a/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
+++ b/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
@@ -41,26 +41,16 @@ func init() {
 type disseminationcluster struct {
 	workflow *workflow.Workflow
 	appID    string
-	config   string
 }
 
 func (d *disseminationcluster) Setup(t *testing.T) []framework.Option {
 	d.appID = uuid.New().String()
-	d.config = `apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: workflowsclustereddeployment
-spec:
-  features:
-  - name: WorkflowsClusteredDeployment
-    enabled: true
-`
 
 	d.workflow = workflow.New(t,
+		workflow.WithClusteredDeployment(true),
 		workflow.WithPlacementOptions(placement.WithDisseminateTimeout(time.Second*7)),
 		workflow.WithDaprdOptions(0,
 			daprd.WithAppID(d.appID),
-			daprd.WithConfigManifests(t, d.config),
 		),
 	)
 	return []framework.Option{
@@ -111,7 +101,7 @@ func (d *disseminationcluster) Run(t *testing.T, ctx context.Context) {
 			daprd.WithPlacementAddresses(d.workflow.Placement().Address()),
 			daprd.WithScheduler(d.workflow.Scheduler()),
 			daprd.WithResourceFiles(d.workflow.DB().GetComponent(t)),
-			daprd.WithConfigManifests(t, d.config),
+			daprd.WithConfigManifests(t, workflow.ClusteredDeploymentConfig),
 		)
 		extra.Run(t, ctx)
 		extra.WaitUntilRunning(t, ctx)

--- a/tests/integration/suite/daprd/workflow/dedup/early/child.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/child.go
@@ -1,0 +1,114 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package early
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(child))
+}
+
+// child is the child workflow sibling of completion: a child
+// workflow result which reaches the parent before the parent's code has
+// scheduled the child must resolve that child call instead of being lost;
+// the child itself is never created.
+type child struct {
+	workflow *workflow.Workflow
+}
+
+func (e *child) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *child) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	var childCalls atomic.Int32
+
+	// Sequence numbers: the WaitForSingleEvent synthetic timer takes id 0,
+	// so the child workflow is task id 1.
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-child", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallChildWorkflow("dedup-early-child-child").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-child-child", func(ctx *task.WorkflowContext) (any, error) {
+		childCalls.Add(1)
+		return "child-ran", nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-early-child")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil && ev.GetEventId() == 0
+		}))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: 1,
+				Result:          wrapperspb.String(`"injected-child"`),
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"injected-child"`, meta.GetOutput().GetValue(), "the early result must resolve the child call")
+
+	assert.Equal(t, int32(0), childCalls.Load(), "the child workflow must never execute; its result was injected")
+	assert.Equal(t, 0, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+		return ev.GetChildWorkflowInstanceCreated() != nil && ev.GetEventId() == 1
+	}), "the resolved child workflow must not be created")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/early/completion.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/completion.go
@@ -1,0 +1,134 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package early
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(completion))
+}
+
+// completion asserts that an activity result which reaches the workflow
+// before the workflow's code has scheduled the activity resolves that
+// activity instead of being lost. The completion is planted in the persisted
+// inbox while the workflow is blocked on an external event, so the turn
+// triggered by raising the event processes [TaskCompleted#1, EventRaised] in
+// that order: the completion arrives at the replay before the code reaches
+// CallActivity, and the same turn then re-emits the ScheduleTask action.
+// Before the buffering fix the engine silently discarded the completion and
+// the actor backend suppressed the re-dispatch as already resolved,
+// deadlocking the workflow forever; this is the deterministic reproduction
+// of the scheduler crash redelivery stall seen in clustered deployment mode.
+// With the fix the buffered resolution completes the activity task as it is
+// scheduled, the activity is never dispatched, and the workflow completes
+// with the injected result.
+type completion struct {
+	workflow *workflow.Workflow
+}
+
+func (e *completion) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *completion) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	// Sequence numbers: the WaitForSingleEvent synthetic timer takes id 0,
+	// so the activity is task id 1.
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-completion", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("step").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, e.workflow.Registry().AddActivityN("step", func(task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return "ran", nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-early-completion")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	// Wait for the first turn to persist so the event numbering is settled:
+	// the external event wait's synthetic timer occupies id 0.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil && ev.GetEventId() == 0
+		}))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Plant the activity result for task id 1 in the persisted inbox while
+	// the workflow is idle, then restart daprd to invalidate the actor's
+	// in-memory cache. The next turn, triggered by RaiseEvent, drains the
+	// inbox as [TaskCompleted#1, EventRaised] in one work item: the
+	// completion is processed before the code reaches CallActivity, and the
+	// activity is scheduled later in the same replay.
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 1,
+				Result:          wrapperspb.String(`"injected"`),
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"injected"`, meta.GetOutput().GetValue(), "the early result must resolve the activity")
+
+	assert.Equal(t, int32(0), activityCalls.Load(), "the activity must never execute; its result was injected")
+	// The suppressed ScheduleTask action means no TaskScheduled event is ever
+	// appended, and a consumed completion with no matching TaskScheduled is
+	// stripped from the persisted history; neither event may appear.
+	assert.Equal(t, 0, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(1)),
+		"the resolved activity must not be dispatched")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/early/failure.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/failure.go
@@ -1,0 +1,110 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package early
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(failure))
+}
+
+// failure is the TaskFailed sibling of completion: an activity
+// failure which reaches the workflow before the workflow's code has
+// scheduled the activity must fail that activity instead of being lost.
+type failure struct {
+	workflow *workflow.Workflow
+}
+
+func (e *failure) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *failure) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	// Sequence numbers: the WaitForSingleEvent synthetic timer takes id 0,
+	// so the activity is task id 1.
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-failure", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return nil, ctx.CallActivity("step").Await(nil)
+	}))
+	require.NoError(t, e.workflow.Registry().AddActivityN("step", func(task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return nil, nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-early-failure")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil && ev.GetEventId() == 0
+		}))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskFailed{
+			TaskFailed: &protos.TaskFailedEvent{
+				TaskScheduledId: 1,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    "TestError",
+					ErrorMessage: "injected failure",
+				},
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_FAILED", meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "injected failure")
+
+	assert.Equal(t, int32(0), activityCalls.Load(), "the activity must never execute; its failure was injected")
+	assert.Equal(t, 0, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(1)),
+		"the resolved activity must not be dispatched")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/early/orphan.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/orphan.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package early
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(orphan))
+}
+
+// orphan asserts that a completion which matches no task the workflow
+// will ever schedule does not disturb the workflow: the workflow's real
+// activity runs and completes normally, and the orphaned completion is not
+// persisted into the final history.
+type orphan struct {
+	workflow *workflow.Workflow
+}
+
+func (e *orphan) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *orphan) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	var activityCalls atomic.Int32
+
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-orphan", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("step").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, e.workflow.Registry().AddActivityN("step", func(task.ActivityContext) (any, error) {
+		activityCalls.Add(1)
+		return "ran", nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-early-orphan")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil && ev.GetEventId() == 0
+		}))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Task id 99 is never scheduled by this workflow.
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 99,
+				Result:          wrapperspb.String(`"orphan"`),
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"ran"`, meta.GetOutput().GetValue(), "the real activity result must win")
+
+	assert.Equal(t, int32(1), activityCalls.Load(), "the real activity must run exactly once")
+	assert.Equal(t, 0, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(99)),
+		"the orphaned completion must not persist into history")
+	assert.Equal(t, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskCompletedFor(1)))
+}

--- a/tests/integration/suite/daprd/workflow/dedup/early/timer.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/timer.go
@@ -1,0 +1,104 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package early
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(timer))
+}
+
+// timer is the TimerFired sibling of completion: a timer firing
+// which reaches the workflow before the workflow's code has created the
+// timer must resolve that timer instead of being lost. The workflow's one
+// hour timer completes immediately from the injected firing.
+type timer struct {
+	workflow *workflow.Workflow
+}
+
+func (e *timer) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *timer) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	// Sequence numbers: the WaitForSingleEvent synthetic timer takes id 0,
+	// so the durable timer is id 1.
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("dedup-early-timer", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		if err := ctx.CreateTimer(time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		return "timer-done", nil
+	}))
+
+	cl := e.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-early-timer")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+			return ev.GetTimerCreated() != nil && ev.GetEventId() == 0
+		}))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	fworkflow.InjectInboxEvent(t, ctx, e.workflow.DB(), e.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TimerFired{
+			TimerFired: &protos.TimerFiredEvent{
+				TimerId: 1,
+				FireAt:  timestamppb.Now(),
+			},
+		},
+	})
+
+	e.workflow.Dapr().Restart(t, ctx)
+	e.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = e.workflow.BackendClient(t, ctx)
+
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"timer-done"`, meta.GetOutput().GetValue())
+
+	assert.Equal(t, 0, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, func(ev *protos.HistoryEvent) bool {
+		return ev.GetTimerCreated() != nil && ev.GetEventId() == 1
+	}), "the resolved timer must not be created durably")
+}

--- a/tests/integration/suite/daprd/workflow/dedup/stalledrecovery.go
+++ b/tests/integration/suite/daprd/workflow/dedup/stalledrecovery.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dedup
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(stalledrecovery))
+}
+
+// stalledrecovery asserts that a history shaped like the pre-buffering-fix
+// stall recovers: a TaskCompleted persisted BEFORE the event that gates the
+// matching CallActivity, with the TaskScheduled persisted after. On replay
+// the completion arrives while the workflow is still blocked, is buffered,
+// and is delivered when the activity is scheduled; the late TaskScheduled in
+// history then matches the retained pending action without a nondeterminism
+// error. The activity itself blocks forever, so completion proves the
+// history resolution was used rather than a re-execution.
+type stalledrecovery struct {
+	workflow *workflow.Workflow
+	blockCh  chan struct{}
+}
+
+func (s *stalledrecovery) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t)
+	s.blockCh = make(chan struct{})
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *stalledrecovery) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+	t.Cleanup(func() { close(s.blockCh) })
+
+	// Sequence numbers: the WaitForSingleEvent synthetic timer takes id 0,
+	// so the activity is task id 1.
+	require.NoError(t, s.workflow.Registry().AddWorkflowN("dedup-stalledrecovery", func(ctx *task.WorkflowContext) (any, error) {
+		if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+			return nil, err
+		}
+		var out string
+		if err := ctx.CallActivity("blocked").Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, s.workflow.Registry().AddActivityN("blocked", func(actx task.ActivityContext) (any, error) {
+		select {
+		case <-s.blockCh:
+		case <-actx.Context().Done():
+		}
+		return "never", actx.Context().Err()
+	}))
+
+	cl := s.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "dedup-stalledrecovery")
+	require.NoError(t, err)
+	_, err = cl.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+
+	// Let the workflow genuinely dispatch the activity so history holds the
+	// real EventRaised and TaskScheduled#1; the activity blocks.
+	require.NoError(t, cl.RaiseEvent(ctx, id, "go"))
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, cl, id, fworkflow.IsTaskScheduledFor(1)))
+	}, 10*time.Second, 10*time.Millisecond)
+
+	// Craft the stalled shape: the completion sits BEFORE the gating event,
+	// so on replay it arrives while the workflow is still blocked on the
+	// external event wait.
+	fworkflow.InsertHistoryEvent(t, ctx, s.workflow.DB(), s.workflow.Dapr(), string(id), &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 1,
+				Result:          wrapperspb.String(`"stalled-recovered"`),
+			},
+		},
+	}, fworkflow.IsEventRaisedFor("go"))
+
+	s.workflow.Dapr().Restart(t, ctx)
+	s.workflow.Dapr().WaitUntilRunning(t, ctx)
+	cl = s.workflow.BackendClient(t, ctx)
+
+	// Nudge a turn; the workflow is not waiting for this event, it only
+	// forces a replay of the crafted history.
+	require.NoError(t, cl.RaiseEvent(ctx, id, "nudge"))
+
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"stalled-recovered"`, meta.GetOutput().GetValue(),
+		"the workflow must complete from the history resolution while the activity stays blocked")
+}

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
@@ -71,7 +71,7 @@ func (n *notexists) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, client.StartWorker(ctx, reg))
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, n.workflow.Dapr().GetMetaActorRuntime(t, ctx).ActiveActors, 3)
+		assert.Len(c, n.workflow.Dapr().GetMetaActorRuntime(t, ctx).ActiveActors, n.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	// Inject the retentioner reminder via the scheduler directly. The daprd

--- a/tests/integration/suite/daprd/workflow/reconnect/deactivate/activity.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/deactivate/activity.go
@@ -70,7 +70,7 @@ func (a *activity) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := client.ScheduleNewWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/reconnect/deactivate/completion.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/deactivate/completion.go
@@ -93,7 +93,7 @@ func (a *completion) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := client.ScheduleNewWorkflow(ctx, "foo")
@@ -110,7 +110,7 @@ func (a *completion) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, client.StartWorkItemListener(ctx, a.workflow.Registry()))
 	// verify a worker is still connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	waitCompletionCtx, waitCompletionCancel := context.WithTimeout(ctx, time.Second*10)

--- a/tests/integration/suite/daprd/workflow/reconnect/deactivate/crossactivity.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/deactivate/crossactivity.go
@@ -80,7 +80,7 @@ func (c *crossactivity) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(col *assert.CollectT) {
-		assert.Len(col, c.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(col, c.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, c.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := cl.ScheduleNewWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/reconnect/deactivate/orchestrator.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/deactivate/orchestrator.go
@@ -70,7 +70,7 @@ func (a *orchestrator) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	// scheduling a workflow with a provided start time

--- a/tests/integration/suite/daprd/workflow/reconnect/deactivate/raiseevent.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/deactivate/raiseevent.go
@@ -64,7 +64,7 @@ func (r *raiseevent) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, r.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, r.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, r.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := client.ScheduleNewWorkflow(ctx, "foo")

--- a/tests/integration/suite/daprd/workflow/reconnect/executor.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/executor.go
@@ -22,7 +22,6 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework"
-	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	dworkflow "github.com/dapr/durabletask-go/workflow"
@@ -37,20 +36,8 @@ type executor struct {
 }
 
 func (e *executor) Setup(t *testing.T) []framework.Option {
-	config := `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-    name: workflowsclustereddeployment
-spec:
-    features:
-    - name: WorkflowsClusteredDeployment
-      enabled: true
-`
 	e.workflow = workflow.New(t,
-		workflow.WithDaprdOptions(0,
-			daprd.WithConfigManifests(t, config),
-		),
+		workflow.WithClusteredDeployment(true),
 	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),

--- a/tests/integration/suite/daprd/workflow/reconnect/reuse/completionretry.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/reuse/completionretry.go
@@ -93,7 +93,7 @@ func (a *completionretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := client.ScheduleNewWorkflow(ctx, "foo")
@@ -119,7 +119,7 @@ func (a *completionretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify a worker is still connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	waitCompletionCtx, waitCompletionCancel := context.WithTimeout(ctx, time.Second*10)

--- a/tests/integration/suite/daprd/workflow/reconnect/reuse/midretry.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/reuse/midretry.go
@@ -93,7 +93,7 @@ func (a *midretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	id, err := client.ScheduleNewWorkflow(ctx, "foo")
@@ -120,7 +120,7 @@ func (a *midretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify a worker is still connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	waitCompletionCtx, waitCompletionCancel := context.WithTimeout(ctx, time.Second*10)

--- a/tests/integration/suite/daprd/workflow/reconnect/reuse/raiseevent.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/reuse/raiseevent.go
@@ -73,7 +73,7 @@ func (r *raiseevent) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, r.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, r.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, r.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	// scheduling a workflow with a provided start time

--- a/tests/integration/suite/daprd/workflow/reconnect/reuse/startretry.go
+++ b/tests/integration/suite/daprd/workflow/reconnect/reuse/startretry.go
@@ -78,7 +78,7 @@ func (a *startretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify worker is connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	// scheduling a workflow with a provided start time
@@ -107,7 +107,7 @@ func (a *startretry) Run(t *testing.T, ctx context.Context) {
 
 	// verify a worker is still connected by checking the expected registered actors
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, 3)
+		assert.Len(c, a.workflow.Dapr().GetMetadata(t, ctx).ActorRuntime.ActiveActors, a.workflow.ActorTypesCount())
 	}, time.Second*10, time.Millisecond*10)
 
 	waitCompletionCtx, waitCompletionCancel := context.WithTimeout(ctx, time.Second*10)

--- a/tests/integration/suite/daprd/workflow/statefulhistory/multipledaprds.go
+++ b/tests/integration/suite/daprd/workflow/statefulhistory/multipledaprds.go
@@ -45,21 +45,12 @@ type multipledaprds struct {
 }
 
 func (m *multipledaprds) Setup(t *testing.T) []framework.Option {
-	config := `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-    name: workflowsclustereddeployment
-spec:
-    features:
-    - name: WorkflowsClusteredDeployment
-      enabled: true
-`
 	appID := uuid.New().String()
 	m.workflow = workflow.New(t,
 		workflow.WithDaprds(2),
-		workflow.WithDaprdOptions(0, daprd.WithAppID(appID), daprd.WithConfigManifests(t, config)),
-		workflow.WithDaprdOptions(1, daprd.WithAppID(appID), daprd.WithConfigManifests(t, config)),
+		workflow.WithClusteredDeployment(true),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
+		workflow.WithDaprdOptions(1, daprd.WithAppID(appID)),
 	)
 	return []framework.Option{framework.WithProcesses(m.workflow)}
 }


### PR DESCRIPTION
Adds the DAPR_INTEGRATION_WORKFLOW_CLUSTERED environment variable, read by both workflow test harnesses. When truthy, every daprd built by the harness gets the WorkflowsClusteredDeployment preview feature, mirroring deployments which enable the flag unconditionally. Replica counts and app IDs are untouched. Tests can override the mode per workflow with workflow.WithClusteredDeployment(bool) and branch mode-specific assertions on ClusteredDeployment() and ActorTypesCount(); NewClustered is refactored onto the option.

Suite adaptations: fourteen assertions hardcoding three active actor
types move to the mode-aware ActorTypesCount helper (clustered mode
registers a fourth executor rendezvous type); tests that enabled the
feature with inline manifests move onto the option so the env var
cannot double-apply it.

Also adds deterministic pins for the durabletask-go early-resolution
buffering fix shipped in v0.13.0 (dedup/early: completion, failure,
timer, child, orphan; dedup/stalledrecovery for the pre-fix stalled
history shape), with InsertHistoryEvent and IsEventRaisedFor framework
helpers.