### PR TITLE
fix: skip binary gRPC metadata when forwarding to output binding metadata

### DIFF
--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -546,6 +546,15 @@ func (a *api) InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRe
 		}
 
 		for key, val := range incomingMD {
+			// Binary gRPC transport metadata (keys ending in "-bin") carries
+			// arbitrary bytes that are not representable as component metadata:
+			// grpc-go has already decoded the Base64 value, so copying it into
+			// the string metadata of the output binding corrupts bindings that
+			// sanitize headers or require valid UTF-8 (e.g. Azure Blob Storage
+			// signature mismatches, Service Bus AMQP UTF-8 failures).
+			if strings.HasSuffix(key, "-bin") {
+				continue
+			}
 			sanitizedKey := invokev1.ReservedGRPCMetadataToDaprPrefixHeader(key)
 			// Not to overwrite the existing metadata
 			// But if the key is traceparent or tracestate, we allow overwrite the existing metadata.

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -2673,7 +2673,7 @@ func TestInvokeBinding(t *testing.T) {
 	_, err = client.InvokeBinding(t.Context(), &runtimev1pb.InvokeBindingRequest{Name: "error-binding"})
 	assert.Equal(t, codes.Internal, status.Code(err))
 
-	ctx := grpcMetadata.AppendToOutgoingContext(t.Context(), "traceparent", "Test", "userMetadata", "overwrited", "additional", "val2")
+	ctx := grpcMetadata.AppendToOutgoingContext(t.Context(), "traceparent", "Test", "userMetadata", "overwrited", "additional", "val2", "grpc-trace-bin", string([]byte{0x94, 0x80, 0x09}))
 	resp, err := client.InvokeBinding(ctx, &runtimev1pb.InvokeBindingRequest{Metadata: map[string]string{"userMetadata": "val1"}})
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
@@ -2683,6 +2683,10 @@ func TestInvokeBinding(t *testing.T) {
 	assert.Equal(t, "val1", resp.GetMetadata()["userMetadata"])
 	assert.Contains(t, resp.GetMetadata(), "additional")
 	assert.Equal(t, "val2", resp.GetMetadata()["additional"])
+	// Binary gRPC metadata (grpc-trace-bin) must not be forwarded to
+	// output binding metadata — the raw bytes corrupt string metadata.
+	assert.NotContains(t, resp.GetMetadata(), "grpc-trace-bin")
+	assert.NotContains(t, resp.GetMetadata(), "dapr-grpc-trace-bin")
 }
 
 func TestTransactionStateStoreNotConfigured(t *testing.T) {


### PR DESCRIPTION
## Description

Binary gRPC transport metadata (keys ending in `-bin`) carries arbitrary bytes that are not representable as component metadata string values. grpc-go has already decoded the Base64 representation, so copying `val[0]` into `req.Metadata` corrupts downstream bindings.

### Impact

- **Azure Blob Storage**: TAB characters (`0x09`) in trace ID bytes cause Shared Key signature mismatch (403 AuthenticationFailed)
- **Azure Service Bus**: invalid UTF-8 in AMQP application properties (`connlost: not a valid UTF-8 string`)

### Fix

Skip `-bin`-suffixed keys in the metadata-forwarding loop (L548–555 in `grpc.go`). Text-based tracing metadata (`traceparent`, `tracestate`, `baggage`) continues to propagate to output bindings unchanged.

## Related issue

Fixes #10387

## Checklist

- [x] The PR targets the `master` branch
- [x] DCO sign-off is present
- [x] Test updated (binary metadata filtered, text metadata preserved)
