### PR TITLE
fix(scheduler): guard currentActorTypes with RWMutex (dapr#10352)

### DIFF
--- a/pkg/runtime/scheduler/scheduler.go
+++ b/pkg/runtime/scheduler/scheduler.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"slices"
+	"sync"
 
 	"github.com/dapr/dapr/pkg/actors"
 	"github.com/dapr/dapr/pkg/config"
@@ -56,6 +57,11 @@ type Scheduler struct {
 	client     client.Interface
 
 	currentActorTypes *[]string
+
+	// mu guards access to currentActorTypes, which is written by StartApp/
+	// StopApp (app-health goroutine) and read/dereferenced by ReloadActorTypes
+	// (placement disseminator goroutine). See dapr/dapr#10352.
+	mu sync.RWMutex
 }
 
 func New(opts Options) (*Scheduler, error) {
@@ -116,14 +122,18 @@ func (s *Scheduler) Run(ctx context.Context) error {
 }
 
 func (s *Scheduler) StartApp() {
+	s.mu.Lock()
 	s.currentActorTypes = nil
+	s.mu.Unlock()
 	s.connector.Enqueue(&loops.Reconnect{
 		AppTarget: new(true),
 	})
 }
 
 func (s *Scheduler) StopApp() {
+	s.mu.Lock()
 	s.currentActorTypes = nil
+	s.mu.Unlock()
 	s.connector.Enqueue(&loops.Reconnect{
 		AppTarget: new(false),
 	})
@@ -132,11 +142,16 @@ func (s *Scheduler) StopApp() {
 func (s *Scheduler) ReloadActorTypes(actorTypes []string) {
 	slices.Sort(actorTypes)
 
-	if s.currentActorTypes != nil && slices.Equal(*s.currentActorTypes, actorTypes) {
+	s.mu.RLock()
+	equal := s.currentActorTypes != nil && slices.Equal(*s.currentActorTypes, actorTypes)
+	s.mu.RUnlock()
+	if equal {
 		return
 	}
 
+	s.mu.Lock()
 	s.currentActorTypes = new(actorTypes)
+	s.mu.Unlock()
 	s.connector.Enqueue(&loops.Reconnect{
 		ActorTypes: new(actorTypes),
 	})

--- a/pkg/runtime/scheduler/scheduler_race_test.go
+++ b/pkg/runtime/scheduler/scheduler_race_test.go
@@ -1,5 +1,5 @@
 /*
-Copyright 2024 The Dapr Authors
+Copyright 2026 The Dapr Authors
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at

--- a/pkg/runtime/scheduler/scheduler_race_test.go
+++ b/pkg/runtime/scheduler/scheduler_race_test.go
@@ -1,0 +1,59 @@
+/*
+Copyright 2024 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package scheduler
+
+import (
+	"sync"
+	"testing"
+
+	"github.com/dapr/dapr/pkg/runtime/scheduler/internal/loops/connector"
+)
+
+// TestCurrentActorTypesRace reproduces dapr/dapr#10352: currentActorTypes is
+// written by StartApp/StopApp (app-health goroutine) and read/dereferenced by
+// ReloadActorTypes (placement disseminator goroutine) without synchronization.
+// Run with -race; it must fail before the fix and pass after.
+func TestCurrentActorTypesRace(t *testing.T) {
+	s := &Scheduler{connector: connector.New(connector.Options{})}
+
+	const iters = 200000
+
+	var wg sync.WaitGroup
+
+	// placement disseminator goroutine: reads/dereferences currentActorTypes
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for i := 0; i < iters; i++ {
+			s.ReloadActorTypes([]string{"actorA", "actorB"})
+		}
+	}()
+
+	// app-health callback goroutines: write nil into currentActorTypes
+	for g := 0; g < 4; g++ {
+		wg.Add(1)
+		go func(healthy bool) {
+			defer wg.Done()
+			for i := 0; i < iters; i++ {
+				if healthy {
+					s.StartApp()
+				} else {
+					s.StopApp()
+				}
+			}
+		}(g%2 == 0)
+	}
+
+	wg.Wait()
+}


### PR DESCRIPTION
## Description

Fixes dapr/dapr#10352 — a data race on `Scheduler.currentActorTypes`.

`currentActorTypes` was written by `StartApp`/`StopApp` (app-health goroutine) and read/dereferenced by `ReloadActorTypes` (placement disseminator goroutine) without synchronization. The check-then-deref in `ReloadActorTypes` could nil-deref and crash daprd when a write landed between the `!= nil` check and the `*s.currentActorTypes` deref.

Guard all accesses with a `sync.RWMutex`.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Added `TestCurrentActorTypesRace` (in the issue) which drives `ReloadActorTypes` from one goroutine and `StartApp`/`StopApp` from four others for 200k iterations.

- Before fix: `go test -race` → `WARNING: DATA RACE` (FAIL)
- After fix: `go test -race` → `ok` (PASS)

## Release Note

RELEASE NOTE: **FIX** Fixed a data race on `Scheduler.currentActorTypes` that could crash daprd under concurrent app-health and placement updates.