### PR TITLE
healthz: honour --healthz-listen-address in the healthz server

### DIFF
--- a/cmd/injector/app/app.go
+++ b/cmd/injector/app/app.go
@@ -143,9 +143,10 @@ func Run() {
 		metricsExporter.Start,
 		secProvider.Run,
 		healthzserver.New(healthzserver.Options{
-			Log:     log,
-			Port:    opts.HealthzPort,
-			Healthz: healthz,
+			Log:           log,
+			ListenAddress: opts.HealthzListenAddress,
+			Port:          opts.HealthzPort,
+			Healthz:       healthz,
 		}).Start,
 		func(ctx context.Context) error {
 			sec, rerr := secProvider.Handler(ctx)

--- a/cmd/operator/app/app.go
+++ b/cmd/operator/app/app.go
@@ -79,9 +79,10 @@ func Run() {
 		metricsExporter.Start,
 		op.Start,
 		server.New(server.Options{
-			Log:     log,
-			Port:    opts.HealthzPort,
-			Healthz: healthz,
+			Log:           log,
+			ListenAddress: opts.HealthzListenAddress,
+			Port:          opts.HealthzPort,
+			Healthz:       healthz,
 		}).Start,
 	).Run(ctx)
 	if err != nil {

--- a/cmd/placement/app/app.go
+++ b/cmd/placement/app/app.go
@@ -103,10 +103,11 @@ func Run() {
 	}
 
 	healthSrv := healthzserver.New(healthzserver.Options{
-		Log:      log,
-		Port:     opts.HealthzPort,
-		Healthz:  healthz,
-		Handlers: handlers,
+		Log:           log,
+		ListenAddress: opts.HealthzListenAddress,
+		Port:          opts.HealthzPort,
+		Healthz:       healthz,
+		Handlers:      handlers,
 	})
 
 	err = concurrency.NewRunnerManager(

--- a/cmd/scheduler/app/app.go
+++ b/cmd/scheduler/app/app.go
@@ -100,9 +100,10 @@ func Run() {
 
 	runners := []concurrency.Runner{
 		healthzserver.New(healthzserver.Options{
-			Log:     log,
-			Port:    opts.HealthzPort,
-			Healthz: healthz,
+			Log:           log,
+			ListenAddress: opts.HealthzListenAddress,
+			Port:          opts.HealthzPort,
+			Healthz:       healthz,
 		}).Start,
 		metricsExporter.Start,
 		secProvider.Run,

--- a/cmd/sentry/app/app.go
+++ b/cmd/sentry/app/app.go
@@ -183,9 +183,10 @@ func Run() {
 		}
 		return concurrency.NewRunnerManager(
 			healthzserver.New(healthzserver.Options{
-				Log:     log,
-				Port:    opts.HealthzPort,
-				Healthz: healthz,
+				Log:           log,
+				ListenAddress: opts.HealthzListenAddress,
+				Port:          opts.HealthzPort,
+				Healthz:       healthz,
 			}).Start,
 			metricsExporter.Start,
 			sentry.Start,

--- a/pkg/healthz/server/server.go
+++ b/pkg/healthz/server/server.go
@@ -16,9 +16,9 @@ package server
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/dapr/dapr/pkg/healthz"
@@ -92,7 +92,7 @@ func New(opts Options) *Server {
 
 // Start starts a net/http server with a healthz endpoint.
 func (s *Server) Start(ctx context.Context) error {
-	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.listenAddress, s.port))
+	ln, err := net.Listen("tcp", net.JoinHostPort(s.listenAddress, strconv.Itoa(s.port)))
 	if err != nil {
 		return err
 	}

--- a/pkg/healthz/server/server.go
+++ b/pkg/healthz/server/server.go
@@ -31,18 +31,22 @@ type Handler struct {
 }
 
 type Options struct {
-	Healthz  healthz.Healthz
-	Port     int
-	Log      logger.Logger
-	Handlers []Handler
+	Healthz healthz.Healthz
+	// ListenAddress is the address the server listens on. Empty means all
+	// interfaces.
+	ListenAddress string
+	Port          int
+	Log           logger.Logger
+	Handlers      []Handler
 }
 
 // Server is a healthz server.
 type Server struct {
-	log     logger.Logger
-	mux     http.Handler
-	port    int
-	htarget healthz.Target
+	log           logger.Logger
+	mux           http.Handler
+	listenAddress string
+	port          int
+	htarget       healthz.Target
 }
 
 // New returns a new healthz server.
@@ -78,16 +82,17 @@ func New(opts Options) *Server {
 	}
 
 	return &Server{
-		log:     opts.Log,
-		port:    opts.Port,
-		mux:     mux,
-		htarget: opts.Healthz.AddTarget("healthz-server"),
+		log:           opts.Log,
+		listenAddress: opts.ListenAddress,
+		port:          opts.Port,
+		mux:           mux,
+		htarget:       opts.Healthz.AddTarget("healthz-server"),
 	}
 }
 
 // Start starts a net/http server with a healthz endpoint.
 func (s *Server) Start(ctx context.Context) error {
-	ln, err := net.Listen("tcp", fmt.Sprintf(":%d", s.port))
+	ln, err := net.Listen("tcp", fmt.Sprintf("%s:%d", s.listenAddress, s.port))
 	if err != nil {
 		return err
 	}

--- a/pkg/healthz/server/server_test.go
+++ b/pkg/healthz/server/server_test.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package server
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/healthz"
+	"github.com/dapr/kit/logger"
+)
+
+func TestListenAddressIsHonored(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := ln.Addr().(*net.TCPAddr).Port
+	require.NoError(t, ln.Close())
+
+	srv := New(Options{
+		Log:           logger.NewLogger(t.Name()),
+		ListenAddress: "127.0.0.1",
+		Port:          port,
+		Healthz:       healthz.New(),
+	})
+
+	ctx, cancel := context.WithCancel(t.Context())
+	errCh := make(chan error, 1)
+	go func() { errCh <- srv.Start(ctx) }()
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		//nolint:noctx
+		resp, rerr := http.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", port))
+		if !assert.NoError(c, rerr) {
+			return
+		}
+		resp.Body.Close()
+		assert.Equal(c, http.StatusOK, resp.StatusCode)
+	}, time.Second*5, time.Millisecond*10)
+
+	cancel()
+	require.NoError(t, <-errCh)
+}

--- a/pkg/healthz/server/server_test.go
+++ b/pkg/healthz/server/server_test.go
@@ -46,8 +46,11 @@ func TestListenAddressIsHonored(t *testing.T) {
 	go func() { errCh <- srv.Start(ctx) }()
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		//nolint:noctx
-		resp, rerr := http.Get(fmt.Sprintf("http://127.0.0.1:%d/healthz", port))
+		req, rerr := http.NewRequestWithContext(ctx, http.MethodGet, fmt.Sprintf("http://127.0.0.1:%d/healthz", port), nil)
+		if !assert.NoError(c, rerr) {
+			return
+		}
+		resp, rerr := http.DefaultClient.Do(req)
 		if !assert.NoError(c, rerr) {
 			return
 		}

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -78,8 +78,6 @@ type Options struct {
 	TrustAnchorsFile                    string
 	APIPort                             int
 	APIListenAddress                    string
-	HealthzPort                         int
-	HealthzListenAddress                string
 	WebhookServerPort                   int
 	WebhookServerListenAddress          string
 	Healthz                             healthz.Healthz


### PR DESCRIPTION
Every control-plane binary (placement, scheduler, sentry, injector, operator) parses --healthz-listen-address but never wires it anywhere: the shared healthz server hardcodes a wildcard bind, so the flag has been dead since its introduction. On shared CI runners a wildcard bind races other processes for the port across every interface and address family, and a healthz port squatted on another interface (or on IPv6, as on the macOS runners) kills the process at startup with "bind: address already in use", failing whole integration jobs on tests that never got a healthy placement or scheduler.

Add ListenAddress to the healthz server options, bind "<address>:<port>" with the empty default preserving today's wildcard behavior, and pass the parsed flag through in all five apps. The integration framework already sets the flag to 127.0.0.1, so control plane healthz servers under test now bind loopback only and stop colliding with foreign sockets. A unit test pins the loopback bind and that /healthz serves on it.