### PR TITLE
Drop binary gRPC metadata from output binding component metadata

### DIFF
--- a/cmd/daprd/components/bindings_metadataprobe.go
+++ b/cmd/daprd/components/bindings_metadataprobe.go
@@ -1,0 +1,60 @@
+//go:build bindings_metadataprobe
+
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package components
+
+import (
+	"context"
+	"encoding/json"
+
+	contribbindings "github.com/dapr/components-contrib/bindings"
+	bindingsLoader "github.com/dapr/dapr/pkg/components/bindings"
+	"github.com/dapr/kit/logger"
+)
+
+// metadataProbeBinding is an integration-test-only output binding that echoes
+// the request metadata it receives as JSON in the response data, letting a
+// test assert exactly which metadata daprd forwards to a component.
+//
+// It is gated behind the bindings_metadataprobe build tag, set only for the
+// integration-test daprd binary and never for a released flavor, so it is
+// never shipped.
+type metadataProbeBinding struct{}
+
+func (m *metadataProbeBinding) Init(context.Context, contribbindings.Metadata) error {
+	return nil
+}
+
+func (m *metadataProbeBinding) Close() error {
+	return nil
+}
+
+func (m *metadataProbeBinding) Operations() []contribbindings.OperationKind {
+	return []contribbindings.OperationKind{contribbindings.GetOperation}
+}
+
+func (m *metadataProbeBinding) Invoke(_ context.Context, req *contribbindings.InvokeRequest) (*contribbindings.InvokeResponse, error) {
+	data, err := json.Marshal(req.Metadata)
+	if err != nil {
+		return nil, err
+	}
+	return &contribbindings.InvokeResponse{Data: data}, nil
+}
+
+func init() {
+	bindingsLoader.DefaultRegistry.RegisterOutputBinding(func(logger.Logger) contribbindings.OutputBinding {
+		return &metadataProbeBinding{}
+	}, "metadataprobe")
+}

--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -3,6 +3,7 @@
 This update contains the following bug fixes:
 - [Workflow left permanently PENDING when its start reminder fails during a scheduler restart](#workflow-left-permanently-pending-when-its-start-reminder-fails-during-a-scheduler-restart)
 - [Parent workflow deadlocked forever when a child workflow created after ContinueAsNew collided with a still-running child's instance ID](#parent-workflow-deadlocked-forever-when-a-child-workflow-created-after-continueasnew-collided-with-a-still-running-childs-instance-id)
+- [Output binding invocations over gRPC forwarding binary trace metadata to components](#output-binding-invocations-over-grpc-forwarding-binary-trace-metadata-to-components)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -62,3 +63,43 @@ The dedup check now compares it as well: when the stored child's parent executio
 That error faults the parent's child workflow task, so the parent either handles it or transitions to `FAILED` with a clear message, matching the existing behavior for creating a child under an instance ID occupied by an unrelated running workflow.
 
 Reusing a child instance ID whose previous holder has completed also works exactly as before.
+
+## Output binding invocations over gRPC forwarding binary trace metadata to components
+
+### Problem
+
+Invoking an output binding through the gRPC API copied every incoming gRPC metadata entry into the metadata handed to the binding component, including binary metadata (keys ending in `-bin`, most notably `grpc-trace-bin`).
+Binary gRPC metadata is base64-decoded by the gRPC server before the runtime sees it, so raw trace bytes were written into the component's string metadata under the key `dapr-grpc-trace-bin`.
+
+Components that require text metadata failed on these bytes.
+The Azure Service Bus binding rejected the message outright:
+
+```
+Error invoking output binding <binding-name>: (connlost): not a valid UTF-8 string
+```
+
+The Azure Blob Storage binding with Shared Key authentication failed intermittently, whenever the trace ID happened to contain a horizontal TAB byte (`0x09`) that survived the component's header sanitizer but was removed by Azure's canonicalization:
+
+```
+403 AuthenticationFailed
+The MAC signature found in the HTTP request is not the same as any computed signature
+```
+
+### Impact
+
+You were affected if your application invoked output bindings through the gRPC Dapr API using a client that sends the `grpc-trace-bin` header, and the target component treats metadata as text.
+The .NET SDK attaches `grpc-trace-bin` to every gRPC call since 1.18.5, and the Java SDK has long done the same, so upgrading the .NET SDK made this failure appear in previously working deployments.
+Because the offending bytes come from the random trace and span IDs, the failures were intermittent and depended on the individual trace.
+With Blob Storage, authentication methods not based on request signing (such as Managed Identity) did not fail the request; the corrupted value was instead silently written into the stored blob metadata.
+
+### Root Cause
+
+The gRPC `InvokeBinding` handler merged all incoming gRPC metadata into the binding request so that text tracing headers (`traceparent`, `tracestate`, `baggage`) and custom metadata propagate to components.
+The merge did not distinguish binary metadata: `grpc-trace-bin` was renamed to `dapr-grpc-trace-bin` and its raw decoded bytes were stored in the string metadata map, then passed verbatim to the component.
+The HTTP binding API takes metadata exclusively from the request body and was not affected.
+
+### Solution
+
+Binary gRPC metadata (any key ending in `-bin`) is no longer copied from the incoming gRPC call into output binding component metadata.
+Metadata set explicitly on the `InvokeBinding` request itself is not filtered, and text tracing metadata (`traceparent`, `tracestate`, `baggage`) continues to propagate to components unchanged.
+Distributed tracing is unaffected: the runtime consumes `grpc-trace-bin` directly from the gRPC call for span propagation, never from binding metadata, which no component reads.

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -546,6 +546,10 @@ func (a *api) InvokeBinding(ctx context.Context, in *runtimev1pb.InvokeBindingRe
 		}
 
 		for key, val := range incomingMD {
+			// Binary gRPC metadata cannot be represented in string component metadata
+			if strings.HasSuffix(key, "-bin") {
+				continue
+			}
 			sanitizedKey := invokev1.ReservedGRPCMetadataToDaprPrefixHeader(key)
 			// Not to overwrite the existing metadata
 			// But if the key is traceparent or tracestate, we allow overwrite the existing metadata.

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -2673,16 +2673,31 @@ func TestInvokeBinding(t *testing.T) {
 	_, err = client.InvokeBinding(t.Context(), &runtimev1pb.InvokeBindingRequest{Name: "error-binding"})
 	assert.Equal(t, codes.Internal, status.Code(err))
 
-	ctx := grpcMetadata.AppendToOutgoingContext(t.Context(), "traceparent", "Test", "userMetadata", "overwrited", "additional", "val2")
+	binVal := string([]byte{0x00, 0x09, 0xde, 0xad})
+	ctx := grpcMetadata.AppendToOutgoingContext(t.Context(),
+		"traceparent", "Test",
+		"tracestate", "key=value",
+		"baggage", "k1=v1",
+		"userMetadata", "overwrited",
+		"additional", "val2",
+		"grpc-trace-bin", binVal,
+		"foo-bin", binVal,
+	)
 	resp, err := client.InvokeBinding(ctx, &runtimev1pb.InvokeBindingRequest{Metadata: map[string]string{"userMetadata": "val1"}})
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 	assert.Contains(t, resp.GetMetadata(), "traceparent")
 	assert.Equal(t, "Test", resp.GetMetadata()["traceparent"])
+	assert.Equal(t, "key=value", resp.GetMetadata()["tracestate"])
+	assert.Equal(t, "k1=v1", resp.GetMetadata()["baggage"])
 	assert.Contains(t, resp.GetMetadata(), "userMetadata")
 	assert.Equal(t, "val1", resp.GetMetadata()["userMetadata"])
 	assert.Contains(t, resp.GetMetadata(), "additional")
 	assert.Equal(t, "val2", resp.GetMetadata()["additional"])
+	// Binary gRPC metadata must not be forwarded to output binding metadata
+	assert.NotContains(t, resp.GetMetadata(), "grpc-trace-bin")
+	assert.NotContains(t, resp.GetMetadata(), "dapr-grpc-trace-bin")
+	assert.NotContains(t, resp.GetMetadata(), "foo-bin")
 }
 
 func TestTransactionStateStoreNotConfigured(t *testing.T) {

--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -50,6 +50,11 @@ var buildTags = []string{
 	// secretKeyRef entries are resolved on. Never set for released daprd
 	// flavors.
 	"secretstores_spiffeprobe",
+	// bindings_metadataprobe compiles in an integration-test-only output
+	// binding that echoes the request metadata it receives, letting a test
+	// assert which metadata daprd forwards to a component. Never set for
+	// released daprd flavors.
+	"bindings_metadataprobe",
 }
 
 func BuildAll(t *testing.T) {

--- a/tests/integration/suite/daprd/binding/output/binarymetadata.go
+++ b/tests/integration/suite/daprd/binding/output/binarymetadata.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package output
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	grpcMetadata "google.golang.org/grpc/metadata"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(binarymetadata))
+}
+
+// binarymetadata asserts that binary gRPC metadata (keys ending in "-bin") is
+// not forwarded to output binding component metadata, while text tracing and
+// custom metadata still is. The bindings.metadataprobe component echoes the
+// metadata it receives as JSON in the response data.
+type binarymetadata struct {
+	daprd *daprd.Daprd
+}
+
+func (b *binarymetadata) Setup(t *testing.T) []framework.Option {
+	b.daprd = daprd.New(t,
+		daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: probe
+spec:
+  type: bindings.metadataprobe
+  version: v1
+`))
+
+	return []framework.Option{
+		framework.WithProcesses(b.daprd),
+	}
+}
+
+func (b *binarymetadata) Run(t *testing.T, ctx context.Context) {
+	b.daprd.WaitUntilRunning(t, ctx)
+
+	client := b.daprd.GRPCClient(t, ctx)
+
+	// Valid OpenCensus binary trace context, 29 bytes. The trace ID contains
+	// a horizontal TAB byte (0x09), which is what breaks components that
+	// sanitize or validate string metadata.
+	traceBin := []byte{
+		0x00,
+		0x00, 0x4b, 0xf9, 0x2f, 0x35, 0x77, 0xb3, 0x4d, 0xa6, 0xa3, 0xce, 0x92, 0x9d, 0x0e, 0x09, 0x47, 0x36,
+		0x01, 0x00, 0xf0, 0x67, 0xaa, 0x0b, 0xa9, 0x02, 0xb7,
+		0x02, 0x01,
+	}
+
+	tp := "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01"
+	ctx = grpcMetadata.AppendToOutgoingContext(ctx,
+		"grpc-trace-bin", string(traceBin),
+		"foo-bin", string([]byte{0x00, 0x09, 0xff}),
+		"traceparent", tp,
+		"custom-key", "custom-value",
+	)
+
+	resp, err := client.InvokeBinding(ctx, &rtv1.InvokeBindingRequest{
+		Name:      "probe",
+		Operation: "get",
+	})
+	require.NoError(t, err)
+
+	var got map[string]string
+	require.NoError(t, json.Unmarshal(resp.GetData(), &got))
+
+	assert.NotContains(t, got, "grpc-trace-bin")
+	assert.NotContains(t, got, "dapr-grpc-trace-bin")
+	assert.NotContains(t, got, "foo-bin")
+	assert.Equal(t, tp, got["traceparent"])
+	assert.Equal(t, "custom-value", got["custom-key"])
+}


### PR DESCRIPTION
The gRPC InvokeBinding handler copied every incoming gRPC metadata entry into the output binding request metadata, a map[string]string. Binary transport metadata (keys ending in -bin, notably grpc-trace-bin) is already base64-decoded by grpc-go, so raw bytes ended up in string component metadata as dapr-grpc-trace-bin. This broke components that require text metadata, for example Azure Service Bus (AMQP application properties must be valid UTF-8) and Azure Blob Storage Shared Key signing (a TAB byte in the trace ID survives the sanitizer and breaks the signature).

Skip -bin suffixed keys when copying incoming gRPC metadata. Metadata set explicitly on the request proto is not filtered. Tracing is unaffected: the runtime reads grpc-trace-bin from the incoming gRPC context, never from binding metadata, and text tracing metadata (traceparent, tracestate, baggage) keeps propagating.

Fixes dapr/dapr#10387