### PR TITLE
fix(http): join streaming goroutine before handler return on resiliency timeout

### DIFF
--- a/pkg/api/http/directmessaging.go
+++ b/pkg/api/http/directmessaging.go
@@ -23,6 +23,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	"github.com/cenkalti/backoff/v4"
@@ -159,8 +160,26 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 		},
 	)
 	success := atomic.Bool{}
+	// opDone is closed when the policy operation closure below completes.
+	// When a timeout policy is active, the resiliency runner runs the
+	// operation on its own goroutine and returns ctx.Err() as soon as the
+	// deadline expires, WITHOUT waiting for the operation goroutine to
+	// finish. If we returned from onDirectMessage at that point, the
+	// goroutine could still be streaming the response body into `w`
+	// (http.ResponseWriter) after the handler has returned — the framework
+	// may then reuse or close the writer, causing a panic like
+	// "invalid memory address or nil pointer dereference" in flushWriter
+	// (dapr#10371). Waiting on opDone before returning guarantees the
+	// handler outlives every write to `w`. The operation's context is
+	// already canceled when we get here on the timeout path, so it exits
+	// promptly and this wait is bounded. Without a timeout policy the
+	// operation runs on this same goroutine and opDone is already closed,
+	// making the wait a no-op.
+	opDone := make(chan struct{})
+	var opDoneOnce sync.Once
 	// Since we don't want to return the actual error, we have to extract several things in order to construct our response.
 	resp, err := policyRunner(func(ctx context.Context) (*invokev1.InvokeMethodResponse, error) {
+		defer opDoneOnce.Do(func() { close(opDone) })
 		rResp, rErr := a.directMessaging.Invoke(ctx, targetID, req)
 		if rErr != nil {
 			// Allowlist policies that are applied on the callee side can return a Permission Denied error.
@@ -301,6 +320,12 @@ func (a *api) onDirectMessage(w http.ResponseWriter, r *http.Request) {
 	// If success is true, it means that headers have already been sent, so we can't send the error to the user, because:
 	// headers cannot be re-sent, and adding to response body may cause corrupted data to be sent
 	if success.Load() {
+		// The operation has started writing to `w`, and on a timeout the
+		// resiliency runner may have returned while the operation goroutine
+		// is still streaming the body into `w`. Join it so the handler never
+		// returns before every write to `w` has finished (dapr#10371).
+		<-opDone
+
 		// For streaming requests with non-2xx responses, a CodeError is
 		// returned solely for circuit breaker accounting after the
 		// response was already successfully forwarded. Use debug level

--- a/pkg/api/http/directmessaging_streamtimeout_test.go
+++ b/pkg/api/http/directmessaging_streamtimeout_test.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package http
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/dapr/dapr/pkg/api/universal"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/kit/logger"
+
+	v1alpha1 "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestOnDirectMessageJoinsStreamingGoroutineAfterTimeout is a regression test
+// for dapr#10371: when a resiliency timeout fires while the policy operation
+// goroutine is still streaming the app's response body into the
+// http.ResponseWriter (io.Copy inside the operation), the HTTP handler must
+// not return until that streaming has finished. Before the fix,
+// onDirectMessage returned as soon as the runner returned ctx.Err(), leaving
+// the goroutine writing into `w` after the handler returned — which panics
+// once the net/http framework reclaims the writer.
+func TestOnDirectMessageJoinsStreamingGoroutineAfterTimeout(t *testing.T) {
+	// drained is set when the slow response body has been fully read by the
+	// handler-side io.Copy. If the handler returns before this, the streaming
+	// was still in flight after the handler returned - the bug.
+	var drained atomic.Bool
+
+	slow := &slowReader{
+		chunkEvery: 20 * time.Millisecond,
+		chunks:     25, // ~500ms total, far beyond the 100ms timeout
+		onEOF:      func() { drained.Store(true) },
+	}
+
+	dm := &slowResponseDirectMessaging{body: slow}
+
+	res := &v1alpha1.Resiliency{
+		ObjectMeta: metav1.ObjectMeta{Name: "res"},
+		Spec: v1alpha1.ResiliencySpec{
+			Policies: v1alpha1.Policies{
+				Timeouts: map[string]string{"fast": "100ms"},
+			},
+			Targets: v1alpha1.Targets{
+				Apps: map[string]v1alpha1.EndpointPolicyNames{
+					"streamApp": {Timeout: "fast"},
+				},
+			},
+		},
+	}
+
+	compStore := compstore.New()
+	testAPI := &api{
+		directMessaging: dm,
+		universal: universal.New(universal.Options{
+			CompStore:  compStore,
+			Resiliency: resiliency.FromConfigurations(logger.NewLogger("messaging.test"), res),
+		}),
+	}
+
+	fakeServer := newFakeHTTPServer()
+	fakeServer.StartServer(testAPI.constructDirectMessagingEndpoints(), nil)
+
+	fakeServer.DoRequest("POST", "v1.0/invoke/streamApp/method/stream", []byte("x"), nil)
+	fakeServer.Shutdown()
+
+	if !drained.Load() {
+		t.Fatal("HTTP handler returned while the response body was still being streamed into the ResponseWriter (dapr#10371 regression)")
+	}
+}
+
+// slowResponseDirectMessaging returns a 200 response whose body streams slowly,
+// mirroring an app that produces a chunked/streamed response.
+type slowResponseDirectMessaging struct {
+	body *slowReader
+}
+
+func (d *slowResponseDirectMessaging) Invoke(ctx context.Context, targetAppID string, req *invokev1.InvokeMethodRequest) (*invokev1.InvokeMethodResponse, error) {
+	resp := invokev1.NewInvokeMethodResponse(int32(http.StatusOK), "OK", nil)
+	resp.WithRawData(d.body) // the handler-side io.Copy drains this
+	return resp, nil
+}
+
+// slowReader emits a chunk every chunkEvery until chunks are exhausted,
+// ignoring context cancellation — like a socket feed that keeps producing
+// regardless of the caller going away. This is what kept the operation
+// goroutine busy past the resiliency timeout in dapr#10371.
+type slowReader struct {
+	chunkEvery time.Duration
+	chunks     int
+	onEOF      func()
+	i          int
+}
+
+func (s *slowReader) Read(p []byte) (int, error) {
+	if s.i >= s.chunks {
+		if s.onEOF != nil {
+			s.onEOF()
+		}
+		return 0, io.EOF
+	}
+	time.Sleep(s.chunkEvery)
+	n := copy(p, "chunk")
+	s.i++
+	return n, nil
+}


### PR DESCRIPTION
# Description

Fixes a panic (`nil pointer dereference` in `flushWriter`) that crashes daprd when an HTTP service invocation is cancelled (context canceled / resiliency timeout) while the response body is still being streamed to the client.

Root cause: when a timeout policy is active, the resiliency runner executes the operation on its own goroutine and returns `ctx.Err()` as soon as the deadline expires, without waiting for the operation goroutine to finish. In `onDirectMessage` (HTTP), the operation streams the app response into the `http.ResponseWriter` via `io.Copy`. On timeout, the handler returned while those writes were still in flight; net/http then reclaims the writer and `flushWriter.Write` dereferences it after return → panic.

Fix: track operation completion with an `opDone` channel (closed via `sync.Once`, since retries invoke the closure multiple times) and, on the `success.Load()` path — the only path where the operation has started writing to `w` — wait for it before returning. Other paths keep their previous timing so timeouts are not extended for operations that never touched the writer.

## Issue reference

Please reference the issue this PR will close: #10371

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
