### PR TITLE
workflow: fix parent deadlock on child instance ID collision after ContinueAsNew

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [Workflow left permanently PENDING when its start reminder fails during a scheduler restart](#workflow-left-permanently-pending-when-its-start-reminder-fails-during-a-scheduler-restart)
+- [Parent workflow deadlocked forever when a child workflow created after ContinueAsNew collided with a still-running child's instance ID](#parent-workflow-deadlocked-forever-when-a-child-workflow-created-after-continueasnew-collided-with-a-still-running-childs-instance-id)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -30,3 +31,33 @@ Workflow reminder creation now retries every error with bounded exponential back
 Previously only `Unavailable` and `DeadlineExceeded` were retried, so any other transient error, including the Scheduler's shutdown and etcd errors that cross the wire as `Unknown`, was dropped on the first attempt.
 This applies to all workflow-related reminder creates (start, timer, activity, and termination reminders), and a genuinely permanent error still surfaces within the bounded retry budget.
 The reminder scheduling error log now also includes the actor type and ID, so any failure can be attributed to the affected workflow instance.
+
+## Parent workflow deadlocked forever when a child workflow created after ContinueAsNew collided with a still-running child's instance ID
+
+### Problem
+
+A parent workflow that called ContinueAsNew and then created a child workflow whose instance ID was still held by a running child from a previous execution of the same parent hung forever.
+The child was never started, the parent's child workflow task never completed or faulted, and the workflow status stayed `RUNNING` indefinitely.
+The only trace was a debug-level log line: `ignoring duplicate child workflow creation from parent '<id>'`.
+
+Auto-generated child instance IDs are derived from the parent instance ID and a per-execution action counter, and that counter restarts at zero on every ContinueAsNew, so the first auto-generated child ID of each generation is identical.
+Similarly, deterministic SDK APIs such as the .NET SDK's `WorkflowContext.NewGuid()` return the same value again after ContinueAsNew, so code that pins child instance IDs from such values re-issues an ID that is already in use.
+
+### Impact
+
+You were affected if a workflow used ContinueAsNew and created child workflows whose previous-generation counterparts could still be running, for example a fire-and-forget child started before the ContinueAsNew.
+
+### Root Cause
+
+Creating a child workflow whose instance ID already exists is deliberately deduplicated in the case when the parent crashed after successfully creating the child but before persisting its own state, its re-execution re-issues the same creation, which must be ignored for replay safety.
+That dedup check compared only the parent's instance ID and the creating task's ID.
+ContinueAsNew keeps the parent's instance ID and resets its history, so task IDs restart from zero, and a genuinely new child creation from a later execution was indistinguishable from a crash-replay duplicate.
+The creation was dropped, the drop was reported as success, and nothing ever completed or faulted the parent's pending child workflow task.
+
+### Solution
+
+Every workflow execution already carries a unique execution ID, minted fresh on each ContinueAsNew and on instance recreation, and it is already included in child creation requests.
+The dedup check now compares it as well: when the stored child's parent execution ID and the incoming creation's parent execution ID are both present and differ, the creation is a genuinely new one, not a crash-replay, and it now fails with an `already exists` error instead of being silently dropped.
+That error faults the parent's child workflow task, so the parent either handles it or transitions to `FAILED` with a clear message, matching the existing behavior for creating a child under an instance ID occupied by an unrelated running workflow.
+
+Reusing a child instance ID whose previous holder has completed also works exactly as before.

--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -27,7 +27,8 @@ The bounded retry around actor reminder creation classified only `Unavailable` a
 
 ### Solution
 
-Workflow reminder creation now retries every error with bounded exponential backoff, except clearly-permanent request errors (`InvalidArgument`, `PermissionDenied`, `Unauthenticated`, `FailedPrecondition`, `Unimplemented`, `NotFound`).
+Workflow reminder creation now retries every error with bounded exponential backoff, except clearly-permanent request errors (`InvalidArgument`, `PermissionDenied`, `Unauthenticated`, `FailedPrecondition`, `Unimplemented`, `NotFound`) and Scheduler storage exhaustion (`ResourceExhausted`), which requires operator intervention and is surfaced to the caller immediately.
+The Scheduler now returns etcd space-quota exhaustion with gRPC code `ResourceExhausted` instead of `Unknown`, so clients can distinguish it from transient failures.
 Previously only `Unavailable` and `DeadlineExceeded` were retried, so any other transient error, including the Scheduler's shutdown and etcd errors that cross the wire as `Unknown`, was dropped on the first attempt.
 This applies to all workflow-related reminder creates (start, timer, activity, and termination reminders), and a genuinely permanent error still surfaces within the bounded retry budget.
 The reminder scheduling error log now also includes the actor type and ID, so any failure can be attributed to the affected workflow instance.

--- a/pkg/actors/targets/workflow/common/retry.go
+++ b/pkg/actors/targets/workflow/common/retry.go
@@ -36,15 +36,23 @@ type reminderCreator interface {
 const reminderCreateMaxElapsedTime = time.Minute
 
 // CreateReminderWithRetry calls reminders.Create with bounded exponential
-// backoff. Every error is retried except a context error or a
-// clearly-permanent request error (see isPermanentCreateError). The create is
-// often the only signal that will ever advance durable state committed just
-// before it (a workflow's start, timer, or activity reminder), so dropping an
-// unrecognised-but-transient error strands that state forever: the scheduler
-// surfaces its shutdown errors ("cron is closed") and etcd errors as plain
-// errors that cross the wire as Unknown, and no allowlist of codes can
-// anticipate every such case. A genuinely permanent error outside the
-// denylist costs at most the bounded budget before surfacing.
+// backoff. Every error is retried except a context error, a clearly-permanent
+// request error (see isPermanentCreateError), or scheduler storage exhaustion
+// (ResourceExhausted). The create is often the only signal that will ever
+// advance durable state committed just before it (a workflow's start, timer,
+// or activity reminder), so dropping an unrecognised-but-transient error
+// strands that state forever: the scheduler surfaces its shutdown errors
+// ("cron is closed") as plain errors that cross the wire as Unknown, and no
+// allowlist of codes can anticipate every such case. A genuinely permanent
+// error outside the denylist costs at most the bounded budget before
+// surfacing.
+//
+// ResourceExhausted is permanent here, unlike in
+// CreateReminderWithRetryForever: etcd surfaces a full storage quota
+// (NOSPACE) as ResourceExhausted, which only clears with compaction or
+// operator intervention, and this bounded create sits on a synchronous caller
+// path where burning the budget replaces the actionable "database space
+// exceeded" with the caller's own deadline error.
 func CreateReminderWithRetry(ctx context.Context, r reminderCreator, req *actorapi.CreateReminderRequest) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 100 * time.Millisecond
@@ -56,7 +64,7 @@ func CreateReminderWithRetry(ctx context.Context, r reminderCreator, req *actora
 			return backoff.Permanent(err)
 		}
 		err := r.Create(ctx, req)
-		if err != nil && isPermanentCreateError(err) {
+		if err != nil && (isPermanentCreateError(err) || status.Code(err) == codes.ResourceExhausted) {
 			return backoff.Permanent(err)
 		}
 		return err
@@ -88,10 +96,12 @@ func CreateReminderWithRetryForever(ctx context.Context, r reminderCreator, req 
 // isPermanentCreateError reports whether a reminder Create error is a
 // client-side mistake that retrying can never fix (malformed request, missing
 // auth, unimplemented method). Everything else: Unavailable, DeadlineExceeded,
-// Internal, Aborted, ResourceExhausted, and notably Unknown (the code carried
-// by the scheduler's plain-error returns, including cron shutdown and etcd
-// errors), is treated as retryable by both retry helpers, because the
-// scheduler may recover and the create is an idempotent overwrite-by-name.
+// Internal, Aborted, and notably Unknown (the code carried by the scheduler's
+// plain-error returns, including cron shutdown), is treated as retryable by
+// both retry helpers, because the scheduler may recover and the create is an
+// idempotent overwrite-by-name. ResourceExhausted (transient etcd pressure)
+// is also retryable for the forever helper; the bounded helper additionally
+// treats it as permanent, see CreateReminderWithRetry.
 func isPermanentCreateError(err error) bool {
 	s, ok := status.FromError(err)
 	if !ok {

--- a/pkg/actors/targets/workflow/common/retry_test.go
+++ b/pkg/actors/targets/workflow/common/retry_test.go
@@ -76,10 +76,15 @@ func Test_CreateReminderWithRetry(t *testing.T) {
 			wantErr:   false,
 			wantCalls: 3,
 		},
-		"resource exhausted is retried": {
+		// etcd surfaces a full storage quota (NOSPACE) as ResourceExhausted;
+		// it only clears with operator intervention, so the bounded helper
+		// surfaces it immediately rather than masking it behind the caller's
+		// deadline (the forever helper still retries it as transient etcd
+		// pressure).
+		"resource exhausted is permanent": {
 			err:       status.Error(codes.ResourceExhausted, "quota"),
-			wantErr:   false,
-			wantCalls: 3,
+			wantErr:   true,
+			wantCalls: 1,
 		},
 		"invalid argument is permanent": {
 			err:       status.Error(codes.InvalidArgument, "bad request"),
@@ -117,4 +122,13 @@ func Test_CreateReminderWithRetry(t *testing.T) {
 			assert.Equal(t, test.wantCalls, creator.calls)
 		})
 	}
+}
+
+func Test_CreateReminderWithRetryForever_ResourceExhausted(t *testing.T) {
+	t.Parallel()
+
+	req := &actorapi.CreateReminderRequest{Name: "start-es-1", ActorType: "wf", ActorID: "id"}
+	creator := &failNCreator{n: 2, err: status.Error(codes.ResourceExhausted, "quota")}
+	require.NoError(t, CreateReminderWithRetryForever(t.Context(), creator, req))
+	assert.Equal(t, 3, creator.calls)
 }

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -101,7 +101,8 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 		// This happens when the parent's runWorkflow created the child workflow
 		// successfully but crashed before persisting its own state, causing it to
 		// re-execute and attempt the child creation again.
-		if o.isSameParentCreation(state, startEvent) {
+		sameParent, parentExecMismatch := o.isSameParentCreation(state, startEvent)
+		if sameParent {
 			log.Debugf("Workflow actor '%s': ignoring duplicate child workflow creation from parent '%s'",
 				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetWorkflowInstance().GetInstanceId())
 			// If the child saved its state but its start reminder was never
@@ -140,6 +141,12 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 				log.Infof("Workflow actor '%s': re-driving pending start for saved-but-never-run workflow", o.actorID)
 				return o.assertStartReminder(ctx, pending)
 			}
+		}
+
+		if parentExecMismatch {
+			return status.Errorf(codes.AlreadyExists,
+				"an active workflow with ID '%s' already exists: it was created by a previous execution of parent workflow '%s' (e.g. before a ContinueAsNew); child workflow instance IDs must be unique across parent executions",
+				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetWorkflowInstance().GetInstanceId())
 		}
 
 		return status.Errorf(codes.AlreadyExists, "an active workflow with ID '%s' already exists", o.actorID)
@@ -252,8 +259,11 @@ func (o *orchestrator) startReminderMissing(ctx context.Context, saved *backend.
 
 // isSameLogicalStart reports whether an incoming ExecutionStarted event
 // describes the same logical creation as the saved pending one. Per-attempt
-// volatile fields (Timestamp, WorkflowInstance.ExecutionId, trace context)
-// are ignored: a client retry of the same logical create regenerates them. A
+// volatile fields (Timestamp, the child's own WorkflowInstance.ExecutionId,
+// trace context) are ignored: a client retry of the same logical create
+// regenerates them. The parent's ExecutionId inside ParentInstanceInfo is NOT
+// volatile (it is persisted in the parent's own history and changes only on
+// ContinueAsNew or recreate), so it is compared when present on both sides. A
 // mismatch means a genuinely conflicting create, which keeps today's
 // AlreadyExists behavior.
 func isSameLogicalStart(saved, incoming *protos.ExecutionStartedEvent) bool {
@@ -283,7 +293,8 @@ func isSameLogicalStart(saved, incoming *protos.ExecutionStartedEvent) bool {
 	}
 	if savedParent != nil {
 		if savedParent.GetWorkflowInstance().GetInstanceId() != incomingParent.GetWorkflowInstance().GetInstanceId() ||
-			savedParent.GetTaskScheduledId() != incomingParent.GetTaskScheduledId() {
+			savedParent.GetTaskScheduledId() != incomingParent.GetTaskScheduledId() ||
+			!sameParentExecution(savedParent, incomingParent) {
 			return false
 		}
 	}
@@ -291,17 +302,43 @@ func isSameLogicalStart(saved, incoming *protos.ExecutionStartedEvent) bool {
 	return true
 }
 
-func (o *orchestrator) isSameParentCreation(state *wfenginestate.State, startEvent *backend.HistoryEvent) bool {
+// isSameParentCreation reports whether the incoming child creation is a
+// crash-replay duplicate of the creation that produced the existing state.
+// parentExecMismatch is true when the parent lineage and task slot match but
+// the parent's ExecutionId differs: the parent continued-as-new (or was
+// recreated) and scheduled a child whose instance ID collides with a live
+// child of a previous execution. That is a genuinely new creation, not a
+// replay, and must not be silently deduplicated.
+func (o *orchestrator) isSameParentCreation(state *wfenginestate.State, startEvent *backend.HistoryEvent) (sameCreation bool, parentExecMismatch bool) {
 	newParent := startEvent.GetExecutionStarted().GetParentInstance()
 	if newParent == nil {
-		return false
+		return false, false
 	}
 
 	existingParent := o.getExecutionStartedEvent(state).GetParentInstance()
 	if existingParent == nil {
-		return false
+		return false, false
 	}
 
-	return existingParent.GetWorkflowInstance().GetInstanceId() == newParent.GetWorkflowInstance().GetInstanceId() &&
-		existingParent.GetTaskScheduledId() == newParent.GetTaskScheduledId()
+	if existingParent.GetWorkflowInstance().GetInstanceId() != newParent.GetWorkflowInstance().GetInstanceId() ||
+		existingParent.GetTaskScheduledId() != newParent.GetTaskScheduledId() {
+		return false, false
+	}
+
+	if !sameParentExecution(existingParent, newParent) {
+		return false, true
+	}
+
+	return true, false
+}
+
+// sameParentExecution reports whether two parent references could belong to
+// the same parent execution. A nil ExecutionId on EITHER side (older
+// persisted state, rerun-path creations that omit it) conservatively returns
+// true, preserving crash-replay dedup. Only both-set-and-different returns
+// false.
+func sameParentExecution(existing, incoming *protos.ParentInstanceInfo) bool {
+	a := existing.GetWorkflowInstance().GetExecutionId()
+	b := incoming.GetWorkflowInstance().GetExecutionId()
+	return a == nil || b == nil || a.GetValue() == b.GetValue()
 }

--- a/pkg/actors/targets/workflow/orchestrator/create_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/create_test.go
@@ -334,6 +334,124 @@ func Test_createWorkflowInstance_pendingStartSameParentReasserts(t *testing.T) {
 	require.Equal(t, []string{"create:" + wantName}, h.ops)
 }
 
+// parentWithExec returns a startEventFor mutate hook attaching a
+// ParentInstanceInfo whose WorkflowInstance carries the given ExecutionId, or
+// none when execID is empty.
+func parentWithExec(execID string) func(*protos.ExecutionStartedEvent) {
+	return func(es *protos.ExecutionStartedEvent) {
+		pi := &protos.ParentInstanceInfo{
+			TaskScheduledId:  3,
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "parent-1"},
+		}
+		if execID != "" {
+			pi.WorkflowInstance.ExecutionId = wrapperspb.String(execID)
+		}
+		es.ParentInstance = pi
+	}
+}
+
+func Test_createWorkflowInstance_sameParentSameExecutionDedups(t *testing.T) {
+	const instanceID = "test-parent-same-exec"
+
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+	h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
+
+	// A crash-replay duplicate carries the same parent ExecutionId and is
+	// ignored exactly as when no ExecutionId is present at all.
+	incoming := startEventFor(instanceID, time.Now(), parentWithExec("exec-a"))
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	assert.Empty(t, h.ops)
+}
+
+func Test_createWorkflowInstance_parentExecutionMismatchAlreadyExists(t *testing.T) {
+	const instanceID = "test-parent-exec-mismatch"
+
+	// A differing parent ExecutionId means the parent continued-as-new (or was
+	// recreated) and scheduled a genuinely new child colliding with a live
+	// child of a previous execution. It must fail with AlreadyExists so the
+	// parent's child task is faulted, never silently deduplicated. The
+	// reminder-missing variant proves the pending-start re-drive gate does not
+	// resurrect the OLD execution's start either.
+	for name, armed := range map[string]*actorapi.Reminder{
+		"reminder armed":   {Name: "start-es-1"},
+		"reminder missing": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newCreateHarness(t, instanceID)
+			h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+			h.armedReminder = armed
+
+			incoming := startEventFor(instanceID, time.Now(), parentWithExec("exec-b"))
+			err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming))
+			require.Error(t, err)
+			assert.Equal(t, codes.AlreadyExists, status.Code(err))
+			assert.Contains(t, err.Error(), "already exists")
+			assert.Contains(t, err.Error(), "previous execution")
+
+			h.lock.Lock()
+			defer h.lock.Unlock()
+			assert.Empty(t, h.ops, "a colliding create from a new parent execution must not save or re-arm the old execution's start")
+		})
+	}
+}
+
+func Test_createWorkflowInstance_parentExecutionNilEitherSideDedups(t *testing.T) {
+	const instanceID = "test-parent-exec-nil"
+
+	// A missing ExecutionId on either side (older persisted state, rerun-path
+	// creations that omit it) must keep today's conservative dedup.
+	for name, execs := range map[string]struct{ saved, incoming string }{
+		"saved set, incoming nil": {saved: "exec-a", incoming: ""},
+		"saved nil, incoming set": {saved: "", incoming: "exec-b"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newCreateHarness(t, instanceID)
+			h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec(execs.saved)))
+			h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
+
+			incoming := startEventFor(instanceID, time.Now(), parentWithExec(execs.incoming))
+			require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+			h.lock.Lock()
+			defer h.lock.Unlock()
+			assert.Empty(t, h.ops)
+		})
+	}
+}
+
+func Test_sameParentExecution(t *testing.T) {
+	pi := func(execID string) *protos.ParentInstanceInfo {
+		p := &protos.ParentInstanceInfo{
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "parent-1"},
+		}
+		if execID != "" {
+			p.WorkflowInstance.ExecutionId = wrapperspb.String(execID)
+		}
+		return p
+	}
+
+	tests := map[string]struct {
+		existing *protos.ParentInstanceInfo
+		incoming *protos.ParentInstanceInfo
+		want     bool
+	}{
+		"both nil":  {existing: pi(""), incoming: pi(""), want: true},
+		"a nil":     {existing: pi(""), incoming: pi("x"), want: true},
+		"b nil":     {existing: pi("x"), incoming: pi(""), want: true},
+		"equal":     {existing: pi("x"), incoming: pi("x"), want: true},
+		"different": {existing: pi("x"), incoming: pi("y"), want: false},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			assert.Equal(t, tc.want, sameParentExecution(tc.existing, tc.incoming))
+		})
+	}
+}
+
 func Test_createWorkflowInstance_pendingStartWithRaisedEventStillReasserts(t *testing.T) {
 	const instanceID = "test-pending-raised"
 

--- a/pkg/scheduler/server/api.go
+++ b/pkg/scheduler/server/api.go
@@ -22,6 +22,7 @@ import (
 	apierrors "github.com/diagridio/go-etcd-cron/api/errors"
 
 	"github.com/diagridio/go-etcd-cron/api"
+	"go.etcd.io/etcd/api/v3/v3rpc/rpctypes"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
@@ -67,6 +68,13 @@ func (s *Server) ScheduleJob(ctx context.Context, req *schedulerv1pb.ScheduleJob
 		monitoring.RecordJobsCreatedFailedCount(req.GetMetadata())
 		if apierrors.IsJobAlreadyExists(err) {
 			return nil, status.Errorf(codes.AlreadyExists, "%s", err.Error())
+		}
+		// The etcd client's NOSPACE error does not implement GRPCStatus, so
+		// returning it as-is crosses the wire as Unknown, indistinguishable
+		// from transient failures like cron shutdown. Restore the code etcd
+		// itself uses so clients can classify quota exhaustion as permanent.
+		if errors.Is(err, rpctypes.ErrNoSpace) || errors.Is(err, rpctypes.ErrGRPCNoSpace) {
+			return nil, status.Errorf(codes.ResourceExhausted, "%s", err.Error())
 		}
 
 		return nil, err

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/auto.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/auto.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(auto))
+}
+
+type auto struct {
+	workflow *workflow.Workflow
+}
+
+func (a *auto) Setup(t *testing.T) []framework.Option {
+	a.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *auto) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-auto"
+
+	var inActivity atomic.Bool
+	var blockerID atomic.Value
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := a.workflow.Registry()
+
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		blockerID.Store(string(ctx.ID))
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("quick", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			ctx.CallChildWorkflow("blocker")
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+		var out string
+		if err := ctx.CallChildWorkflow("quick").Await(nil); err != nil {
+			out = err.Error()
+		}
+		return out, nil
+	})
+
+	client := a.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent deadlocked: colliding auto-generated child ID across ContinueAsNew generations was silently deduplicated")
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetOutput().GetValue(), "already exists")
+
+	close(releaseCh)
+	childID, ok := blockerID.Load().(string)
+	require.True(t, ok)
+	ometa, err := client.WaitForWorkflowCompletion(ctx, api.InstanceID(childID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "blocker", ometa.GetName())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/basic.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/basic.go
@@ -1,0 +1,121 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+type basic struct {
+	workflow *workflow.Workflow
+}
+
+func (b *basic) Setup(t *testing.T) []framework.Option {
+	b.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(b.workflow),
+	}
+}
+
+func (b *basic) Run(t *testing.T, ctx context.Context) {
+	b.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-basic"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := b.workflow.Registry()
+
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinnedID))
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+		return nil, ctx.CallChildWorkflow("blocker",
+			task.WithChildWorkflowInstanceID(pinnedID),
+		).Await(nil)
+	})
+
+	client := b.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent deadlocked: post-ContinueAsNew child ID collision was silently deduplicated")
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "already exists")
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "blocker", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, pinnedID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/completed.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/completed.go
@@ -1,0 +1,100 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(completed))
+}
+
+type completed struct {
+	workflow *workflow.Workflow
+}
+
+func (c *completed) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *completed) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-completed"
+	const pinnedID = parentID + "-pinned"
+
+	reg := c.workflow.Registry()
+
+	reg.AddWorkflowN("quick", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		return gen, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		var out int
+		if err := ctx.CallChildWorkflow("quick",
+			task.WithChildWorkflowInstanceID(pinnedID),
+			task.WithChildWorkflowInput(gen),
+		).Await(&out); err != nil {
+			return nil, err
+		}
+		if gen < 2 {
+			ctx.ContinueAsNew(gen + 1)
+			return nil, nil
+		}
+		return out, nil
+	})
+
+	client := c.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "reuse of a completed child's instance ID across generations must keep working")
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Equal(t, "2", meta.GetOutput().GetValue())
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "quick", ometa.GetName())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/crossapp.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/crossapp.go
@@ -1,0 +1,130 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(crossapp))
+}
+
+type crossapp struct {
+	workflow *workflow.Workflow
+}
+
+func (c *crossapp) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t,
+		workflow.WithDaprds(2),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *crossapp) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-crossapp"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	app1AppID := c.workflow.DaprN(1).AppID()
+
+	c.workflow.Registry().AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			ctx.CallChildWorkflow("blocker",
+				task.WithChildWorkflowAppID(app1AppID),
+				task.WithChildWorkflowInstanceID(pinnedID),
+			)
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+		return nil, ctx.CallChildWorkflow("blocker",
+			task.WithChildWorkflowAppID(app1AppID),
+			task.WithChildWorkflowInstanceID(pinnedID),
+		).Await(nil)
+	})
+
+	app1Reg := c.workflow.RegistryN(1)
+	app1Reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	app1Reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	client0 := c.workflow.BackendClient(t, ctx)
+	client1 := c.workflow.BackendClientN(t, ctx, 1)
+
+	_, err := client0.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client0.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client0.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent deadlocked: cross-app post-ContinueAsNew child ID collision was silently deduplicated")
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED.String(), meta.GetRuntimeStatus().String())
+	assert.Contains(t, meta.GetFailureDetails().GetErrorMessage(), "already exists")
+
+	ometa, err := client1.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "blocker", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client1.WaitForWorkflowCompletion(ctx, pinnedID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/fanout.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/fanout.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fanout))
+}
+
+type fanout struct {
+	workflow *workflow.Workflow
+}
+
+func (f *fanout) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *fanout) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-fanout"
+	const children = 3
+
+	pinned := func(i int) string {
+		return fmt.Sprintf("%s-pinned-%d", parentID, i)
+	}
+
+	var inActivity atomic.Int64
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := f.workflow.Registry()
+
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Add(1)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			for i := range children {
+				ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinned(i)))
+			}
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+		tasks := make([]task.Task, children)
+		for i := range children {
+			tasks[i] = ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinned(i)))
+		}
+		faulted := 0
+		for _, tk := range tasks {
+			if err := tk.Await(nil); err != nil {
+				faulted++
+			}
+		}
+		return faulted, nil
+	})
+
+	client := f.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, func() bool {
+		return inActivity.Load() == children
+	}, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent deadlocked: at least one colliding creation in the batch was silently deduplicated")
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Equal(t, strconv.Itoa(children), meta.GetOutput().GetValue(),
+		"every colliding child creation must fault its own task")
+
+	for i := range children {
+		ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinned(i)))
+		require.NoError(t, err)
+		assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	}
+
+	close(releaseCh)
+	for i := range children {
+		ometa, err := client.WaitForWorkflowCompletion(ctx, api.InstanceID(pinned(i)))
+		require.NoError(t, err)
+		assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	}
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/multigen.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/multigen.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(multigen))
+}
+
+type multigen struct {
+	workflow *workflow.Workflow
+}
+
+func (m *multigen) Setup(t *testing.T) []framework.Option {
+	m.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(m.workflow),
+	}
+}
+
+func (m *multigen) Run(t *testing.T, ctx context.Context) {
+	m.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-multigen"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := m.workflow.Registry()
+
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+
+	type state struct {
+		Gen  int
+		Errs []string
+	}
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var s state
+		if err := ctx.GetInput(&s); err != nil {
+			return nil, err
+		}
+		if s.Gen == 0 {
+			ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinnedID))
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(state{Gen: 1})
+			return nil, nil
+		}
+		err := ctx.CallChildWorkflow("blocker",
+			task.WithChildWorkflowInstanceID(pinnedID),
+		).Await(nil)
+		if err == nil {
+			return nil, nil
+		}
+		s.Errs = append(s.Errs, err.Error())
+		if s.Gen < 2 {
+			ctx.ContinueAsNew(state{Gen: s.Gen + 1, Errs: s.Errs})
+			return nil, nil
+		}
+		return s.Errs, nil
+	})
+
+	client := m.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(state{Gen: 0}),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err, "parent deadlocked: a repeated collision in a later generation was silently deduplicated")
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+
+	output := meta.GetOutput().GetValue()
+	assert.Equal(t, 2, strings.Count(output, "already exists"),
+		"generations 1 and 2 must each observe their own collision failure: %s", output)
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "blocker", ometa.GetName())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, pinnedID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/childid/retry.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/childid/retry.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package childid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(retry))
+}
+
+type retry struct {
+	workflow *workflow.Workflow
+}
+
+func (r *retry) Setup(t *testing.T) []framework.Option {
+	r.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *retry) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "childid-retry"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	var childFailed atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := r.workflow.Registry()
+
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("quick", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, nil
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinnedID))
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+		return nil, ctx.CallChildWorkflow("quick",
+			task.WithChildWorkflowInstanceID(pinnedID),
+			task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+				MaxAttempts:          20,
+				InitialRetryInterval: time.Millisecond * 500,
+				Handle: func(err error) bool {
+					childFailed.Store(true)
+					return true
+				},
+			}),
+		).Await(nil)
+	})
+
+	client := r.workflow.BackendClient(t, ctx)
+
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	require.Eventually(t, childFailed.Load, time.Second*10, time.Millisecond*10,
+		"the colliding creation must fault the retry attempt, not silently deduplicate it")
+	close(releaseCh)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+	assert.Equal(t, "quick", ometa.GetName())
+}

--- a/tests/integration/suite/daprd/workflow/continueasnew/workflow.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/workflow.go
@@ -1,0 +1,18 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package continueasnew
+
+import (
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/continueasnew/childid"
+)


### PR DESCRIPTION
A parent workflow that called ContinueAsNew and then created a child workflow whose instance ID was still held by a running child from a previous execution of the same parent hung forever. The creation was silently dropped with only a debug log ("ignoring duplicate child workflow creation from parent"), the drop was reported as success, and nothing ever completed or faulted the parent's pending child task.

The drop exists to deduplicate crash-replay: a parent that crashed after creating a child but before persisting its own state re-issues the same creation on re-execution. That check compared only the parent's instance ID and the creating task's ID. ContinueAsNew keeps the instance ID and restarts task IDs from zero, so a genuinely new creation from a later execution was indistinguishable from a crash-replay duplicate.

The dedup check now also compares the parent's execution ID (already carried on child creation requests and minted fresh on every ContinueAsNew and recreate). When both sides carry one and they differ, the creation is genuinely new rather than a crash-replay, and it fails with AlreadyExists to fault the parent's child task instead of being silently dropped.