### PR TITLE
workflow: close fastpath fold gaps

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -126,6 +126,12 @@ func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent
 		meta[todo.MetadataActivityLocalDrive] = []string{"true"}
 	}
 
+	if o.fastPath {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, redispatchCallTimeout)
+		defer cancel()
+	}
+
 	_, err = o.router.Call(ctx, internalsv1pb.
 		NewInternalInvokeRequest(todo.ExecuteActivityMethod).
 		WithActor(activityActorType, targetActorID).

--- a/pkg/actors/targets/workflow/orchestrator/fold.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold.go
@@ -53,7 +53,11 @@ const maxFoldPerTurn = 128
 // that found the entry already pending all wait on the same resolution; a
 // retry acked before the commit would stop the only durable re-driver.
 type foldEntry struct {
-	event     *backend.HistoryEvent
+	event *backend.HistoryEvent
+	// gen is state.Generation at submit time; foldTake drops-and-acks
+	// entries from a previous generation (ContinueAsNew resets event ids,
+	// so kind+id matching across generations is invalid).
+	gen       uint64
 	err       error
 	committed chan struct{}
 }
@@ -138,13 +142,20 @@ func (o *orchestrator) addWorkflowEventMaybeFold(ctx context.Context, e *backend
 		return nil, err
 	}
 
-	// Fold only sender-retried completions against a healthy, running
-	// instance; every other shape takes today's durable inbox path, which
-	// also owns all rejection semantics (purged, tombstoned, stalled,
-	// duplicates).
-	isCompletion := e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil ||
-		e.GetChildWorkflowInstanceCompleted() != nil || e.GetChildWorkflowInstanceFailed() != nil
-	if state == nil || !isCompletion || state.HasTamperMarker() || o.rstate.GetStalled() != nil {
+	// Fold only sender-retried ACTIVITY completions against a healthy,
+	// running instance; everything else takes the durable inbox path, which
+	// owns all rejection semantics. Child completions must not fold: the
+	// child publishes while holding its own turn lock, which can deadlock
+	// against a parent turn dispatching back into the same child.
+	foldable := e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil
+	if state == nil || !foldable || state.HasTamperMarker() || o.rstate.GetStalled() != nil {
+		return nil, o.addWorkflowEvent(ctx, e)
+	}
+
+	// A TaskExecutionId mismatch marks a straggler from a previous execution
+	// (ids reset on ContinueAsNew); the inbox path owns straggler semantics.
+	if !o.foldExecutionMatches(e, state) {
+		log.Debugf("Workflow actor '%s': completion's task execution id does not match current history; taking the durable inbox path", o.actorID)
 		return nil, o.addWorkflowEvent(ctx, e)
 	}
 
@@ -180,7 +191,7 @@ func (o *orchestrator) addWorkflowEventMaybeFold(ctx context.Context, e *backend
 // the actor lock held. The caller must wait on the returned entry after
 // releasing the lock.
 func (o *orchestrator) foldSubmit(ctx context.Context, e *backend.HistoryEvent, state *wfenginestate.State) *foldEntry {
-	entry := &foldEntry{event: e, committed: make(chan struct{})}
+	entry := &foldEntry{event: e, gen: state.Generation, committed: make(chan struct{})}
 	o.foldPending = append(o.foldPending, entry)
 
 	if e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil {
@@ -254,8 +265,26 @@ func (o *orchestrator) foldPendingEntry(e *backend.HistoryEvent) *foldEntry {
 }
 
 // foldTake removes and returns up to maxFoldPerTurn held completions for the
-// running turn. Lock held by caller (the turn).
-func (o *orchestrator) foldTake() []*foldEntry {
+// running turn, dropping-and-acking stale-generation entries on the way
+// (acceptance-and-drop, like the stale durable-timer drop). Lock held by
+// caller (the turn).
+func (o *orchestrator) foldTake(currentGen uint64) []*foldEntry {
+	if len(o.foldPending) == 0 {
+		return nil
+	}
+
+	kept := o.foldPending[:0]
+	for _, p := range o.foldPending {
+		if p.gen != currentGen {
+			log.Infof("Workflow actor '%s': dropping held completion from previous generation %d (current %d)", o.actorID, p.gen, currentGen)
+			close(p.committed)
+			diag.DefaultWorkflowMonitoring.WorkflowCompletionsFold(context.Background(), diag.StatusFolded)
+			continue
+		}
+		kept = append(kept, p)
+	}
+	o.foldPending = kept
+
 	n := len(o.foldPending)
 	if n == 0 {
 		return nil
@@ -266,6 +295,45 @@ func (o *orchestrator) foldTake() []*foldEntry {
 	taken := o.foldPending[:n:n]
 	o.foldPending = o.foldPending[n:]
 	return taken
+}
+
+// foldedEvents projects taken entries onto their events, for the payload
+// guard's merged-size accounting.
+func foldedEvents(taken []*foldEntry) []*backend.HistoryEvent {
+	if len(taken) == 0 {
+		return nil
+	}
+	events := make([]*backend.HistoryEvent, len(taken))
+	for i, p := range taken {
+		events[i] = p.event
+	}
+	return events
+}
+
+// foldExecutionMatches reports whether a completion's TaskExecutionId agrees
+// with the scheduling event at its task id; empty ids on either side are
+// tolerated (older SDKs, synthetic events).
+func (o *orchestrator) foldExecutionMatches(e *backend.HistoryEvent, state *wfenginestate.State) bool {
+	var taskID int32
+	var execID string
+	switch {
+	case e.GetTaskCompleted() != nil:
+		taskID = e.GetTaskCompleted().GetTaskScheduledId()
+		execID = e.GetTaskCompleted().GetTaskExecutionId()
+	case e.GetTaskFailed() != nil:
+		taskID = e.GetTaskFailed().GetTaskScheduledId()
+		execID = e.GetTaskFailed().GetTaskExecutionId()
+	default:
+		return true
+	}
+	if execID == "" {
+		return true
+	}
+	scheduled := state.FindHistoryEventByID(taskID).GetTaskScheduled()
+	if scheduled == nil || scheduled.GetTaskExecutionId() == "" {
+		return true
+	}
+	return scheduled.GetTaskExecutionId() == execID
 }
 
 // foldEvents returns the held events (for merging into a work item or for

--- a/pkg/actors/targets/workflow/orchestrator/fold.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold.go
@@ -330,7 +330,10 @@ func (o *orchestrator) foldExecutionMatches(e *backend.HistoryEvent, state *wfen
 		return true
 	}
 	scheduled := state.FindHistoryEventByID(taskID).GetTaskScheduled()
-	if scheduled == nil || scheduled.GetTaskExecutionId() == "" {
+	if scheduled == nil {
+		return false
+	}
+	if scheduled.GetTaskExecutionId() == "" {
 		return true
 	}
 	return scheduled.GetTaskExecutionId() == execID

--- a/pkg/actors/targets/workflow/orchestrator/fold_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold_test.go
@@ -15,12 +15,14 @@ package orchestrator
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -99,18 +101,19 @@ func Test_fold_takeCapAndOrder(t *testing.T) {
 	for i := range total {
 		h.orch.foldPending = append(h.orch.foldPending, &foldEntry{
 			event:     taskCompletedEvent(int32(i + 10)),
+			gen:       1,
 			committed: make(chan struct{}),
 		})
 	}
 
-	taken := h.orch.foldTake()
+	taken := h.orch.foldTake(1)
 	assert.Len(t, taken, maxFoldPerTurn, "one turn folds at most maxFoldPerTurn completions")
 	assert.Len(t, h.orch.foldPending, 5, "overflow stays pending")
 	assert.Equal(t, int32(10), taken[0].event.GetTaskCompleted().GetTaskScheduledId(), "arrival order preserved")
 
-	rest := h.orch.foldTake()
+	rest := h.orch.foldTake(1)
 	assert.Len(t, rest, 5)
-	assert.Empty(t, h.orch.foldTake())
+	assert.Empty(t, h.orch.foldTake(1))
 }
 
 func Test_fold_ackNackFlush(t *testing.T) {
@@ -177,4 +180,102 @@ func Test_fold_unresolvedTreatsPendingAsResolved(t *testing.T) {
 	require.Len(t, unresolved, 1)
 	assert.Equal(t, int32(2), unresolved[0].GetEventId(),
 		"a completion held for folding must suppress janitor re-dispatch of its task")
+}
+
+func childCompletedEvent(scheduled int32) *backend.HistoryEvent {
+	return &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId: scheduled,
+				Result:          wrapperspb.String(`"done"`),
+			},
+		},
+	}
+}
+
+// Child completions must not fold (lock-cycle risk); they take the durable
+// inbox path.
+func Test_fold_childCompletionKeepsInboxPath(t *testing.T) {
+	const instanceID = "test-fold-child"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+
+	entry, err := h.orch.addWorkflowEventMaybeFold(t.Context(), childCompletedEvent(7))
+	require.NoError(t, err)
+	assert.Nil(t, entry, "child completions must not be held for folding")
+	assert.Contains(t, h.snapshotOps(), "save", "the inbox path must commit")
+	assert.Empty(t, h.orch.foldPending)
+}
+
+// Stale-generation entries are dropped-and-acked at take.
+func Test_fold_takeDropsStaleGeneration(t *testing.T) {
+	const instanceID = "test-fold-stalegen"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+
+	stale := &foldEntry{event: taskCompletedEvent(10), gen: 1, committed: make(chan struct{})}
+	fresh := &foldEntry{event: taskCompletedEvent(11), gen: 2, committed: make(chan struct{})}
+	h.orch.foldPending = []*foldEntry{stale, fresh}
+
+	taken := h.orch.foldTake(2)
+	require.Len(t, taken, 1)
+	assert.Same(t, fresh, taken[0], "only current-generation entries may be taken")
+
+	select {
+	case <-stale.committed:
+		require.NoError(t, stale.err, "the stale entry is acked (acceptance-and-drop), not nacked into a retry loop")
+	default:
+		t.Fatal("the stale entry must be resolved at take")
+	}
+	assert.Empty(t, h.orch.foldPending)
+}
+
+// A TaskExecutionId mismatch marks a straggler; it must not fold.
+func Test_fold_executionIDMismatchKeepsInboxPath(t *testing.T) {
+	const instanceID = "test-fold-execid"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+	h.orch.state.History[1].GetTaskScheduled().TaskExecutionId = "exec-A"
+	h.orch.state.AddToHistory(&protos.HistoryEvent{
+		EventId:   8,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskScheduled{
+			TaskScheduled: &protos.TaskScheduledEvent{Name: "act", TaskExecutionId: "exec-A"},
+		},
+	})
+
+	mismatch := taskCompletedEvent(7)
+	mismatch.GetTaskCompleted().TaskExecutionId = "exec-B"
+	entry, err := h.orch.addWorkflowEventMaybeFold(t.Context(), mismatch)
+	require.NoError(t, err)
+	assert.Nil(t, entry, "a mismatched execution id must not fold")
+	assert.Empty(t, h.orch.foldPending)
+
+	match := taskCompletedEvent(8)
+	match.GetTaskCompleted().TaskExecutionId = "exec-A"
+	entry, err = h.orch.addWorkflowEventMaybeFold(t.Context(), match)
+	require.NoError(t, err)
+	assert.NotNil(t, entry, "a matching execution id folds as usual")
+}
+
+// The payload stall guard must count folded completions.
+func Test_workflowPayloadOversize_includesFoldedBytes(t *testing.T) {
+	const instanceID = "test-fold-payload"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+	h.orch.maxRequestBodySize = 2048
+
+	_, _, oversize := h.orch.workflowPayloadOversize(t.Context(), h.orch.state, nil, "wf")
+	require.False(t, oversize, "the primed state alone is well under the threshold")
+
+	big := taskCompletedEvent(7)
+	big.GetTaskCompleted().Result = wrapperspb.String(strings.Repeat("x", 4096))
+	_, _, oversize = h.orch.workflowPayloadOversize(t.Context(), h.orch.state, []*backend.HistoryEvent{big}, "wf")
+	assert.True(t, oversize, "folded completions must count toward the stall threshold")
 }

--- a/pkg/actors/targets/workflow/orchestrator/fold_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold_test.go
@@ -261,6 +261,12 @@ func Test_fold_executionIDMismatchKeepsInboxPath(t *testing.T) {
 	entry, err = h.orch.addWorkflowEventMaybeFold(t.Context(), match)
 	require.NoError(t, err)
 	assert.NotNil(t, entry, "a matching execution id folds as usual")
+
+	absent := taskCompletedEvent(42)
+	absent.GetTaskCompleted().TaskExecutionId = "exec-A"
+	entry, err = h.orch.addWorkflowEventMaybeFold(t.Context(), absent)
+	require.NoError(t, err)
+	assert.Nil(t, entry, "an execution-id-carrying completion with no scheduling event is unmatched and must not fold")
 }
 
 // The payload stall guard must count folded completions.

--- a/pkg/actors/targets/workflow/orchestrator/payloadsize.go
+++ b/pkg/actors/targets/workflow/orchestrator/payloadsize.go
@@ -42,10 +42,12 @@ const (
 
 // workflowPayloadOversize reports whether the WorkflowRequest the executor
 // will build for this run would exceed the gRPC stream's send threshold.
+// folded carries the fold-held completions taken into this turn: they ride
+// the request but never live in state.Inbox, so they must be counted here.
 // A non-positive maxRequestBodySize signals "no limit" (matching the dapr
 // HTTP server's convention) and disables both the stall check and the
 // size-ratio metric (the ratio is undefined without a limit).
-func (o *orchestrator) workflowPayloadOversize(ctx context.Context, state *wfenginestate.State, workflowName string) (protos.StalledReason, string, bool) {
+func (o *orchestrator) workflowPayloadOversize(ctx context.Context, state *wfenginestate.State, folded []*backend.HistoryEvent, workflowName string) (protos.StalledReason, string, bool) {
 	if o.maxRequestBodySize <= 0 {
 		return 0, "", false
 	}
@@ -55,6 +57,9 @@ func (o *orchestrator) workflowPayloadOversize(ctx context.Context, state *wfeng
 		size += proto.Size(e)
 	}
 	for _, e := range state.Inbox {
+		size += proto.Size(e)
+	}
+	for _, e := range folded {
 		size += proto.Size(e)
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -175,7 +175,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// them nacks the senders back into their retry chains. Overflow beyond
 	// the per-turn cap (and anything submitted after this take) re-arms a
 	// drive so it is folded by a follow-up turn.
-	folded := o.foldTake()
+	folded := o.foldTake(state.Generation)
 	foldedCommitted := false
 	defer func() {
 		if foldedCommitted {
@@ -209,7 +209,9 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	wi.IncomingHistory = state.IncomingHistory
 
 	workflowName := o.getExecutionStartedEvent(state).GetName()
-	if reason, description, oversize := o.workflowPayloadOversize(ctx, state, workflowName); oversize {
+	if reason, description, oversize := o.workflowPayloadOversize(ctx, state, foldedEvents(folded), workflowName); oversize {
+		// foldedCommitted stays false: the deferred handler nacks the folded
+		// senders back into their retry chains.
 		return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs, reason, description)
 	}
 	// Executing workflow code is a one-way operation. We must wait for the app code to report its completion, which

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/canchild.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/canchild.go
@@ -1,0 +1,131 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fold
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(canchild))
+}
+
+// canchild pins child completions against folding around ContinueAsNew
+// under the fast path: each generation derives the same deterministic child
+// instance ID, and folding the child's lock-holding completion publish can
+// deadlock against the CAN successor dispatching back into the same child.
+type canchild struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (c *canchild) Setup(t *testing.T) []framework.Option {
+	c.place = placement.New(t)
+	c.scheduler = procscheduler.New(t)
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	c.daprd = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(c.place.Address()),
+		daprd.WithSchedulerAddresses(c.scheduler.Address()),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_WORKFLOW_JANITOR_PERIOD", "2s")),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.place, c.scheduler, db, c.daprd),
+	}
+}
+
+func (c *canchild) Run(t *testing.T, ctx context.Context) {
+	c.scheduler.WaitUntilRunning(t, ctx)
+	c.place.WaitUntilRunning(t, ctx)
+	c.daprd.WaitUntilRunning(t, ctx)
+
+	registry := task.NewTaskRegistry()
+
+	var childCalls atomic.Int32
+	require.NoError(t, registry.AddWorkflowN("agent", func(octx *task.WorkflowContext) (any, error) {
+		var input int
+		if err := octx.GetInput(&input); err != nil {
+			return nil, err
+		}
+		childCalls.Add(1)
+		return input * 10, nil
+	}))
+
+	// No explicit child instance ID: each generation derives the child's
+	// instance ID from the parent's instance ID and the task counter, which
+	// ContinueAsNew resets, so every generation targets the same child
+	// actor.
+	require.NoError(t, registry.AddWorkflowN("loop", func(octx *task.WorkflowContext) (any, error) {
+		var inc int
+		if err := octx.GetInput(&inc); err != nil {
+			return nil, err
+		}
+
+		var childResult int
+		if err := octx.CallChildWorkflow("agent",
+			task.WithChildWorkflowInput(inc)).Await(&childResult); err != nil {
+			return nil, err
+		}
+
+		if inc < 2 {
+			octx.ContinueAsNew(inc + 1)
+			return nil, nil
+		}
+		return childResult, nil
+	}))
+
+	cl := client.NewTaskHubGrpcClient(c.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
+
+	id, err := cl.ScheduleNewWorkflow(ctx, "loop",
+		api.WithInstanceID("fold-canchild-parent"),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(cancel)
+	meta, err := cl.WaitForWorkflowCompletion(waitCtx, id)
+	require.NoError(t, err,
+		"parent did not complete: a folded child completion deadlocked against the CAN successor's child dispatch")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"failure details: %v", meta.GetFailureDetails())
+	require.Equal(t, `20`, meta.GetOutput().GetValue())
+	require.Equal(t, int32(3), childCalls.Load())
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/fold/payloadfanin.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/fold/payloadfanin.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package fold
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(payloadfanin))
+}
+
+// payloadfanin pins the payload stall guard against fold-held completions:
+// a fan-in of large results taken by one folding turn must stall gracefully,
+// not blow the hard gRPC limit. Fold drives are dropped via the test
+// injection so the results accumulate into a single recovery turn.
+type payloadfanin struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (p *payloadfanin) Setup(t *testing.T) []framework.Option {
+	p.place = placement.New(t)
+	p.scheduler = procscheduler.New(t)
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	p.daprd = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(p.place.Address()),
+		daprd.WithSchedulerAddresses(p.scheduler.Address()),
+		daprd.WithMaxBodySize("1Mi"),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithExecOptions(exec.WithEnvVars(t,
+			"DAPR_WORKFLOW_JANITOR_PERIOD", "2s",
+			"DAPR_WORKFLOW_TEST_DROP_FOLD_DRIVES", "100",
+		)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(p.place, p.scheduler, db, p.daprd),
+	}
+}
+
+func (p *payloadfanin) Run(t *testing.T, ctx context.Context) {
+	p.scheduler.WaitUntilRunning(t, ctx)
+	p.place.WaitUntilRunning(t, ctx)
+	p.daprd.WaitUntilRunning(t, ctx)
+
+	// 4 x 300 KiB: the total exceeds the 1 MiB hard limit, but any strict
+	// subset fits under the 95% stall threshold, so no split of the fan-in
+	// can stall via durable history alone. Only a guard that counts the
+	// fold-held results can stall this workflow.
+	const chunkSize = 300 * 1024
+	const numActivities = 4
+	chunk := strings.Repeat("x", chunkSize)
+
+	registry := task.NewTaskRegistry()
+	require.NoError(t, registry.AddWorkflowN("fanin", func(wctx *task.WorkflowContext) (any, error) {
+		tasks := make([]task.Task, numActivities)
+		for i := range tasks {
+			tasks[i] = wctx.CallActivity("emit-chunk")
+		}
+		for _, tk := range tasks {
+			var out string
+			if err := tk.Await(&out); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}))
+	require.NoError(t, registry.AddActivityN("emit-chunk", func(task.ActivityContext) (any, error) {
+		return chunk, nil
+	}))
+
+	cl := client.NewTaskHubGrpcClient(p.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
+
+	id, err := cl.ScheduleNewWorkflow(ctx, "fanin")
+	require.NoError(t, err)
+
+	wf.WaitForRuntimeStatus(t, ctx, cl, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+	lastEvent := wf.GetLastHistoryEventOfType[protos.HistoryEvent_ExecutionStalled](t, ctx, cl, id)
+	require.NotNil(t, lastEvent)
+	require.Equal(t, protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, lastEvent.GetExecutionStalled().GetReason())
+	require.Contains(t, lastEvent.GetExecutionStalled().GetDescription(), "exceeds")
+}


### PR DESCRIPTION
The WorkflowsFastPath completion fold held any completion kind and never re-examined what it held, which opened three gaps.

Child completions must not fold. A child publishes its completion while holding its own turn lock; parking that publish on the parent's fold commit while the parent's turn (or its ContinueAsNew successor, which re-derives the same deterministic child instance ID) dispatches back into that child creates a cross-actor lock cycle that only breaks on timeouts. Child completions now always take the durable inbox path, and the inline fastpath activity dispatch is bounded by the janitor re-dispatch timeout so the activity-side cycle breaks into the recoverable retry path.

Held entries leaked across generations. ContinueAsNew resets event IDs, so a completion held before the CAN could match the new generation's operations by kind and ID. Fold entries now record their generation and foldTake drops-and-acks stale ones, mirroring the stale durable-timer drop; a TaskExecutionId mismatch routes the completion to the durable inbox path, whose stripUnmatchedResolutions owns straggler semantics.

The payload stall guard undercounted. Folded completions ride the turn's WorkflowRequest but never live in state.Inbox, so a fan-in of large activity results slipped past the 95% stall threshold and the GetWorkItems send failed forever with ResourceExhausted instead of stalling gracefully. The guard now counts the turn's folded events; a stall on that path nacks the uncommitted senders back into their retry chains.