### PR TITLE
workflow: suppress stale reminder escalations for completed instances

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/invoke.go
+++ b/pkg/actors/targets/workflow/orchestrator/invoke.go
@@ -175,7 +175,17 @@ func (o *orchestrator) runJanitor(ctx context.Context, reminder *actorapi.Remind
 		return err
 	}
 
-	if state == nil || runtimestate.IsCompleted(o.rstate) {
+	if state == nil {
+		o.deleteJanitor(ctx)
+		return nil
+	}
+
+	if runtimestate.IsCompleted(o.rstate) {
+		// Re-assert retention before self-deleting: the janitor owns
+		// recovery of a retention create lost after a terminal commit.
+		if rerr := o.handleRetention(ctx, runtimestate.RuntimeStatus(o.rstate)); rerr != nil {
+			return fmt.Errorf("failed to (re)create retention reminder on janitor terminal path: %w", rerr)
+		}
 		o.deleteJanitor(ctx)
 		return nil
 	}

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -74,6 +74,11 @@ type orchestrator struct {
 	// traffic; it distinguishes "alive and progressing" from "being polled".
 	lastProgress atomic.Int64
 	driveInfo    atomic.Pointer[driveInfo]
+	// wakeEpoch counts durable turn commits; escalate suppresses wakes armed
+	// before the latest commit (their durable reminder would be a stray).
+	// Bumped only at the turn-commit sites in runWorkflow; never reset
+	// (monotonic avoids ABA with a pre-halt escalation).
+	wakeEpoch atomic.Uint64
 	// foldPending holds sender-retried completions awaiting their folding
 	// turn (WorkflowsFastPath; see fold.go). INVARIANT: only touched
 	// while holding the per-actor turn lock (submit, turn, janitor,

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -169,6 +169,15 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		}
 	}
 
+	// A terminal rstate with a pending ExecutionStarted (or empty history)
+	// means the cache trails a purge/recreate; running the turn would
+	// resurrect the instance as PENDING with no name. Reload and retry.
+	if runtimestate.IsCompleted(o.rstate) && (esHistoryEvent != nil || len(state.History) == 0) {
+		log.Warnf("Workflow actor '%s': cached runtime state is terminal but the durable view holds a pending start (history len %d); reloading before running", o.actorID, len(state.History))
+		o.invalidateCachedState()
+		return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("workflow actor '%s': inconsistent cached state (terminal runtime state with pending start), reloaded", o.actorID))
+	}
+
 	// Take any held completions into this turn (WorkflowsFastPath):
 	// they ride the turn's single Multi into history and their senders are
 	// acked only if that commit happens. Any outcome that does not commit
@@ -331,6 +340,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 				// The CAN save persisted the effect of every consumed event,
 				// including folded completions: their senders are acked.
 				foldedCommitted = true
+
+				// Bump before the elide so a stale escalation cannot
+				// recreate the reminder.
+				o.wakeEpoch.Add(1)
 
 				// The save above durably committed the consumed
 				// ExecutionStarted, so the pending start one-shot is a no-op
@@ -585,6 +598,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// The turn's single Multi is durable: folded completions are now in
 	// history and their senders are acked (see the deferred fold handling).
 	foldedCommitted = true
+
+	// Bump before the elide so a stale escalation cannot recreate the
+	// reminder.
+	o.wakeEpoch.Add(1)
 
 	// This turn consumed the ExecutionStarted event and its commit above is
 	// durable, so the pending start one-shot can only ever fire as a no-op:

--- a/pkg/actors/targets/workflow/orchestrator/wake.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake.go
@@ -17,6 +17,9 @@ import (
 	"context"
 	"time"
 
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
@@ -98,6 +101,8 @@ type driveInfo struct {
 	reminderName string
 	dueTime      time.Time
 	wfName       string
+	// epoch is o.wakeEpoch at arming time (see wakeEpoch).
+	epoch uint64
 }
 
 // localDrive eagerly drives a wake-up on this host instead of creating a
@@ -143,7 +148,7 @@ func (o *orchestrator) localDrive(reminderName string, dueTime time.Time, wfName
 		return
 	}
 
-	o.driveInfo.Store(&driveInfo{reminderName: reminderName, dueTime: dueTime, wfName: wfName})
+	o.driveInfo.Store(&driveInfo{reminderName: reminderName, dueTime: dueTime, wfName: wfName, epoch: o.wakeEpoch.Load()})
 
 	// Post the wake. A full buffer means a notification is already pending
 	// and this wake coalesces into it: the pending drive's turn runs after
@@ -291,6 +296,14 @@ func (o *orchestrator) escalate(info *driveInfo) {
 		diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusEscalateSkipped)
 		return
 	}
+	if o.wakeEpoch.Load() != info.epoch {
+		o.escLock.Unlock()
+		// A turn committed since this wake was armed: a reminder for it
+		// would be a stray.
+		log.Debugf("Workflow actor '%s': suppressing stale escalation of wake '%s' (a turn committed since it was armed)", o.actorID, info.reminderName)
+		diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusEscalateSuppressed)
+		return
+	}
 	o.escWG.Add(1)
 	o.escLock.Unlock()
 
@@ -308,6 +321,20 @@ func (o *orchestrator) escalate(info *driveInfo) {
 			return
 		}
 		diag.DefaultWorkflowMonitoring.WorkflowLocalWake(context.Background(), diag.StatusEscalated)
+
+		// A commit raced the create: delete the stray, best effort.
+		// NotFound is the normal case.
+		if o.wakeEpoch.Load() != info.epoch {
+			if err := o.reminders.Delete(ctx, &actorapi.DeleteReminderRequest{
+				Name:      info.reminderName,
+				ActorType: o.actorTypeBuilder.Workflow(o.appID),
+				ActorID:   o.actorID,
+			}); err != nil {
+				if s, ok := grpcstatus.FromError(err); !ok || s.Code() != codes.NotFound {
+					log.Debugf("Workflow actor '%s': failed to delete stray escalated wake '%s' (it will fire as a no-op): %v", o.actorID, info.reminderName, err)
+				}
+			}
+		}
 	}()
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/wake_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/wake_test.go
@@ -39,7 +39,10 @@ import (
 	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/dapr/pkg/config"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
@@ -55,7 +58,8 @@ type wakeHarness struct {
 	callReminderErr error
 	deleteErr       error
 	createErrFor    map[string]error
-	reminderGate    chan struct{} // when non-nil, CallReminder blocks on it (or ctx)
+	createGateFor   map[string]chan struct{} // when set, Create for that name blocks on the gate
+	reminderGate    chan struct{}            // when non-nil, CallReminder blocks on it (or ctx)
 
 	attempts atomic.Int64 // CallReminder invocations, successful or not
 	calls    []*actorapi.Reminder
@@ -78,6 +82,11 @@ func newWakeHarness(t *testing.T, instanceID string, fastPath bool) *wakeHarness
 	fakeRems := remindersfake.New().
 		WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
 			h.lock.Lock()
+			if gate, ok := h.createGateFor[req.Name]; ok {
+				h.lock.Unlock()
+				<-gate
+				h.lock.Lock()
+			}
 			defer h.lock.Unlock()
 			if err, ok := h.createErrFor[req.Name]; ok {
 				return err
@@ -557,4 +566,143 @@ func Test_localWake_driveLoopLosslessUnderConcurrency(t *testing.T) {
 	}, time.Second*5, time.Millisecond*5)
 
 	require.NoError(t, h.fact.HaltAll(t.Context()))
+}
+
+// A wake whose turn has already durably committed (epoch advanced) must not
+// escalate: the commit drained the inbox, so the durable reminder would be a
+// stray one-shot with a past dueTime firing against a committed instance.
+func Test_escalate_staleEpochSuppressed(t *testing.T) {
+	const instanceID = "test-wake-stale-epoch"
+
+	h := newWakeHarness(t, instanceID, true)
+	h.callReminderErr = errors.New("wake failed")
+	h.reminderGate = make(chan struct{})
+	h.primeRunning(t, instanceID, 7)
+
+	require.NoError(t, h.orch.addWorkflowEvent(t.Context(), taskCompletedEvent(7)))
+
+	// A turn commits while the drive is parked on the gate.
+	h.orch.wakeEpoch.Add(1)
+
+	// Age both life signals so the failure resolves as stalled, which is the
+	// path that would have escalated before the epoch check.
+	stale := time.Now().Add(-time.Minute).UnixNano()
+	h.orch.lastActive.Store(stale)
+	h.orch.lastProgress.Store(stale)
+	close(h.reminderGate)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.False(c, h.orch.driveRunning.Load(), "the drive loop must wind down")
+	}, time.Second*5, time.Millisecond*5)
+
+	time.Sleep(time.Millisecond * 100)
+	assert.Equal(t, []string{"save", "create:new-event-janitor"}, h.snapshotOps(),
+		"a stale-epoch escalation must not create the durable per-event reminder")
+}
+
+// If the escalation's create is already in flight when the turn commits, the
+// created reminder is a stray: the escalation goroutine must notice the epoch
+// advance after its create succeeds and delete the reminder again.
+func Test_escalate_createAfterCommitCompensated(t *testing.T) {
+	const instanceID = "test-wake-compensate"
+
+	h := newWakeHarness(t, instanceID, true)
+	h.primeRunning(t, instanceID, 7)
+
+	// The escalation's pre-check passes (epoch matches at entry), then a turn
+	// commits while the create is still in flight: gate the create so the
+	// epoch bump deterministically lands before the create succeeds.
+	createGate := make(chan struct{})
+	h.lock.Lock()
+	h.createGateFor = map[string]chan struct{}{"new-event-tc-7": createGate}
+	h.lock.Unlock()
+
+	h.orch.escalate(&driveInfo{
+		reminderName: "new-event-tc-7",
+		dueTime:      time.Now(),
+		wfName:       "TestWorkflow",
+		epoch:        h.orch.wakeEpoch.Load(),
+	})
+
+	h.orch.wakeEpoch.Add(1)
+	close(createGate)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		ops := h.snapshotOps()
+		createIdx, deleteIdx := -1, -1
+		for i, op := range ops {
+			switch op {
+			case "create:new-event-tc-7":
+				createIdx = i
+			case "delete:new-event-tc-7":
+				deleteIdx = i
+			}
+		}
+		if assert.GreaterOrEqual(c, createIdx, 0, "the in-flight escalation create must land") {
+			assert.Greater(c, deleteIdx, createIdx,
+				"the stray reminder must be deleted after the epoch advance is observed")
+		}
+	}, time.Second*10, time.Millisecond*5)
+}
+
+// A terminal cached runtime state paired with a pending ExecutionStarted in
+// the durable view is an impossible pairing in any consistent snapshot; the
+// turn must not run from it (the engine would drop the work item and the
+// follow-up save would resurrect the instance as PENDING with no name).
+func Test_runWorkflow_terminalRstateWithPendingStartRecoverable(t *testing.T) {
+	const instanceID = "test-inconsistent-pairing"
+
+	h := newWakeHarness(t, instanceID, true)
+	h.primeRunning(t, instanceID, 7)
+
+	// Rebuild the cached pairing: state holds ONLY a pending start in the
+	// inbox (empty history), while rstate claims the instance completed.
+	wfState := wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "testapp",
+		Namespace:         "default",
+		WorkflowActorType: "dapr.internal.default.testapp.workflow",
+		ActivityActorType: "dapr.internal.default.testapp.activity",
+	})
+	wfState.AddToInbox(&protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name:             "TestWorkflow",
+				WorkflowInstance: &protos.WorkflowInstance{InstanceId: instanceID},
+			},
+		},
+	})
+	h.orch.state = wfState
+	h.orch.rstate.CompletedEvent = &protos.ExecutionCompletedEvent{
+		WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+	}
+
+	completed, runErr := h.orch.runWorkflow(t.Context(), &actorapi.Reminder{Name: "start-es-1"})
+	require.Error(t, runErr)
+	assert.True(t, wferrors.IsRecoverable(runErr), "the guard must hand recovery to the re-fire")
+	assert.Equal(t, todo.RunCompletedFalse, completed)
+	assert.Nil(t, h.orch.state, "the stale cache must be invalidated")
+	assert.NotContains(t, h.snapshotOps(), "save",
+		"the inconsistent pairing must not produce any state save")
+}
+
+// With stale escalations suppressed by the wake epoch, the janitor's terminal
+// self-delete is the recovery path for a lost retention create: it must
+// re-assert retention (idempotent, deterministic name) before self-deleting.
+func Test_janitor_terminalReassertsRetention(t *testing.T) {
+	const instanceID = "test-janitor-retention"
+
+	h := newWakeHarness(t, instanceID, true)
+	h.primeRunning(t, instanceID, 7)
+	ttl := time.Hour
+	h.orch.retentionPolicy = &config.WorkflowStateRetentionPolicy{AnyTerminal: &ttl}
+	h.orch.rstate.CompletedEvent = &protos.ExecutionCompletedEvent{
+		WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+	}
+
+	require.NoError(t, h.orch.runJanitor(t.Context(), &actorapi.Reminder{Name: janitorReminderName}))
+	ops := h.snapshotOps()
+	assert.Contains(t, ops, "create:retention")
+	assert.Contains(t, ops, "delete:new-event-janitor")
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/reuseidstray.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/reuseidstray.go
@@ -1,0 +1,152 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wakev2
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(reuseidstray))
+}
+
+type reuseidstray struct {
+	daprd     *daprd.Daprd
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+}
+
+func (r *reuseidstray) Setup(t *testing.T) []framework.Option {
+	r.place = placement.New(t)
+	r.scheduler = procscheduler.New(t)
+	db := sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	r.daprd = daprd.New(t,
+		daprd.WithResourceFiles(db.GetComponent(t)),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithSchedulerAddresses(r.scheduler.Address()),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithExecOptions(exec.WithEnvVars(t, "DAPR_WORKFLOW_JANITOR_PERIOD", "2s")),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.place, r.scheduler, db, r.daprd),
+	}
+}
+
+func (r *reuseidstray) Run(t *testing.T, ctx context.Context) {
+	r.scheduler.WaitUntilRunning(t, ctx)
+	r.place.WaitUntilRunning(t, ctx)
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	const parentID = "wakev2-reuseidstray"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	var childFailed atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	registry := task.NewTaskRegistry()
+
+	require.NoError(t, registry.AddWorkflowN("occupant", func(octx *task.WorkflowContext) (any, error) {
+		return nil, octx.CallActivity("block").Await(nil)
+	}))
+	require.NoError(t, registry.AddActivityN("block", func(task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	}))
+	require.NoError(t, registry.AddWorkflowN("quick", func(*task.WorkflowContext) (any, error) {
+		return nil, nil
+	}))
+	require.NoError(t, registry.AddWorkflowN("parent", func(octx *task.WorkflowContext) (any, error) {
+		return nil, octx.CallChildWorkflow("quick",
+			task.WithChildWorkflowInstanceID(pinnedID),
+			task.WithChildWorkflowRetryPolicy(&task.RetryPolicy{
+				MaxAttempts:          20,
+				InitialRetryInterval: time.Millisecond * 500,
+				Handle: func(err error) bool {
+					childFailed.Store(true)
+					return true
+				},
+			}),
+		).Await(nil)
+	}))
+
+	cl := client.NewTaskHubGrpcClient(r.daprd.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, cl.StartWorkItemListener(ctx, registry))
+
+	_, err := cl.ScheduleNewWorkflow(ctx, "occupant", api.WithInstanceID(pinnedID))
+	require.NoError(t, err)
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+
+	_, err = cl.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	require.Eventually(t, childFailed.Load, time.Second*10, time.Millisecond*10,
+		"the occupied-ID creation must fault the retry attempt")
+	close(releaseCh)
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*90)
+	t.Cleanup(cancel)
+	meta, err := cl.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+
+	deadline := time.Now().Add(time.Second * 8)
+	for time.Now().Before(deadline) {
+		ometa, oerr := cl.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+		require.NoError(t, oerr)
+		assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String(),
+			"the reused instance's terminal state was reset (stray start reminder)")
+		assert.Equal(t, "quick", ometa.GetName())
+		if t.Failed() {
+			return
+		}
+		time.Sleep(time.Millisecond * 250)
+	}
+}


### PR DESCRIPTION
Under WorkflowsFastPath a failed local wake escalates to a durable
one-shot start reminder, and the escalation raced the turn it covered: a
turn could commit (draining the inbox and eliding the pending start
one-shot) while the create was still in flight. The stray reminder fired
immediately with its past dueTime, the turn ran against a cached
terminal state paired with an inconsistent durable view, and the save
wrote an empty metadata row, resetting a completed instance (for example
a recreated child under a reused instance ID) to PENDING with no name.

The fix is a wake-epoch interlock: a monotonic wakeEpoch counts durable
turn commits, wakes snapshot it when armed, and escalation suppresses
the create when a turn has committed since; a post-create re-check
best-effort deletes a reminder resurrected by the remaining race. As a
backstop, runWorkflow refuses to run a turn whose cached state is
terminal while the durable view holds a pending start (or empty
history), invalidating the cache and retrying instead of destroying the
terminal metadata. The janitor terminal path now re-asserts retention
before self-deleting, covering a retention create lost after a terminal
commit.

Branched from https://github.com/dapr/dapr/pull/10404
