### PR TITLE
workflow: disable fast path when scheduler concurrency limits are configured

### DIFF
--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -81,8 +81,10 @@ const (
 	// sender's retry as the durability (external raised events keep the
 	// durable inbox path). Each leg removes scheduler job commits and
 	// trigger round trips from the workflow hot path. At-least-once
-	// execution is unchanged throughout. Preview feature; disabled by
-	// default.
+	// execution is unchanged throughout. With scheduler-enforced workflow
+	// concurrency limits configured the fast path disables itself: the
+	// limits gate per job delivery, which local drives bypass. Preview
+	// feature; disabled by default.
 	WorkflowsFastPath Feature = "WorkflowsFastPath"
 )
 
@@ -276,6 +278,19 @@ func (w *WorkflowSpec) GetGlobalMaxConcurrentActivityInvocations() *int32 {
 		return nil
 	}
 	return w.GlobalMaxConcurrentActivityInvocations
+}
+
+// HasSchedulerConcurrencyLimits reports whether any scheduler-enforced
+// concurrency limit is configured (global caps or per-name lists); the
+// worker-enforced per-host caps are excluded.
+func (w *WorkflowSpec) HasSchedulerConcurrencyLimits() bool {
+	if w == nil {
+		return false
+	}
+	return w.GetGlobalMaxConcurrentWorkflowInvocations() != nil ||
+		w.GetGlobalMaxConcurrentActivityInvocations() != nil ||
+		len(w.WorkflowConcurrencyLimits) > 0 ||
+		len(w.ActivityConcurrencyLimits) > 0
 }
 
 type SecretsSpec struct {

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -287,10 +287,21 @@ func (w *WorkflowSpec) HasSchedulerConcurrencyLimits() bool {
 	if w == nil {
 		return false
 	}
-	return w.GetGlobalMaxConcurrentWorkflowInvocations() != nil ||
-		w.GetGlobalMaxConcurrentActivityInvocations() != nil ||
-		len(w.WorkflowConcurrencyLimits) > 0 ||
-		len(w.ActivityConcurrencyLimits) > 0
+	if w.GetGlobalMaxConcurrentWorkflowInvocations() != nil ||
+		w.GetGlobalMaxConcurrentActivityInvocations() != nil {
+		return true
+	}
+	// Only entries the scheduler actually enforces count (mirrors
+	// cluster.buildConcurrencyLimits).
+	enforced := func(ls []NamedConcurrencyLimit) bool {
+		for _, l := range ls {
+			if l.Name != nil && l.MaxConcurrent != nil && *l.MaxConcurrent > 0 {
+				return true
+			}
+		}
+		return false
+	}
+	return enforced(w.WorkflowConcurrencyLimits) || enforced(w.ActivityConcurrencyLimits)
 }
 
 type SecretsSpec struct {

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -972,4 +972,18 @@ func TestHasSchedulerConcurrencyLimits(t *testing.T) {
 	require.True(t, (&WorkflowSpec{
 		ActivityConcurrencyLimits: []NamedConcurrencyLimit{{Name: &name, MaxConcurrent: i32(1)}},
 	}).HasSchedulerConcurrencyLimits())
+
+	// Entries the scheduler ignores must not disable the fast path.
+	require.False(t, (&WorkflowSpec{
+		WorkflowConcurrencyLimits: []NamedConcurrencyLimit{{MaxConcurrent: i32(1)}},
+	}).HasSchedulerConcurrencyLimits(), "nil name is not enforced")
+	require.False(t, (&WorkflowSpec{
+		WorkflowConcurrencyLimits: []NamedConcurrencyLimit{{Name: &name}},
+	}).HasSchedulerConcurrencyLimits(), "nil max is not enforced")
+	require.False(t, (&WorkflowSpec{
+		ActivityConcurrencyLimits: []NamedConcurrencyLimit{{Name: &name, MaxConcurrent: i32(0)}},
+	}).HasSchedulerConcurrencyLimits(), "non-positive max is not enforced")
+	require.True(t, (&WorkflowSpec{
+		WorkflowConcurrencyLimits: []NamedConcurrencyLimit{{MaxConcurrent: i32(1)}, {Name: &name, MaxConcurrent: i32(1)}},
+	}).HasSchedulerConcurrencyLimits(), "one enforced entry among ignored ones counts")
 }

--- a/pkg/config/configuration_test.go
+++ b/pkg/config/configuration_test.go
@@ -948,3 +948,28 @@ func TestWorkflowStateRetentionPolicyUnmarshalJSON(t *testing.T) {
 		assert.Error(t, json.Unmarshal([]byte(data), &p))
 	})
 }
+
+func TestHasSchedulerConcurrencyLimits(t *testing.T) {
+	i32 := func(v int32) *int32 { return &v }
+
+	var nilSpec *WorkflowSpec
+	require.False(t, nilSpec.HasSchedulerConcurrencyLimits())
+	require.False(t, (&WorkflowSpec{}).HasSchedulerConcurrencyLimits())
+	require.False(t, (&WorkflowSpec{
+		MaxConcurrentWorkflowInvocations: 5,
+		MaxConcurrentActivityInvocations: 5,
+	}).HasSchedulerConcurrencyLimits(), "per-host caps are worker-enforced and must not disable the fast path")
+	require.False(t, (&WorkflowSpec{
+		GlobalMaxConcurrentWorkflowInvocations: i32(0),
+	}).HasSchedulerConcurrencyLimits(), "a non-positive global cap means unset")
+
+	require.True(t, (&WorkflowSpec{GlobalMaxConcurrentWorkflowInvocations: i32(2)}).HasSchedulerConcurrencyLimits())
+	require.True(t, (&WorkflowSpec{GlobalMaxConcurrentActivityInvocations: i32(2)}).HasSchedulerConcurrencyLimits())
+	name := "wf"
+	require.True(t, (&WorkflowSpec{
+		WorkflowConcurrencyLimits: []NamedConcurrencyLimit{{Name: &name, MaxConcurrent: i32(1)}},
+	}).HasSchedulerConcurrencyLimits())
+	require.True(t, (&WorkflowSpec{
+		ActivityConcurrencyLimits: []NamedConcurrencyLimit{{Name: &name, MaxConcurrent: i32(1)}},
+	}).HasSchedulerConcurrencyLimits())
+}

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -144,6 +144,15 @@ func New(opts Options) (Interface, error) {
 		return nil, errors.New("WorkflowHistorySigning feature flag is enabled but mTLS is not configured; workflow history signing requires mTLS to be active")
 	}
 
+	// Scheduler-enforced concurrency limits gate per job delivery, which
+	// the fast path's local drives bypass: fall back to durable reminders
+	// when limits are configured.
+	fastPath := opts.WorkflowsFastPath
+	if fastPath && opts.Spec.HasSchedulerConcurrencyLimits() {
+		log.Info("WorkflowsFastPath is enabled but scheduler-enforced workflow concurrency limits are configured; disabling the fast path so the limits are enforced")
+		fastPath = false
+	}
+
 	// If no backend was initialized by the manager, create a backend backed by actors
 	abackend, err := backendactors.New(backendactors.Options{
 		AppID:                  opts.AppID,
@@ -159,7 +168,7 @@ func New(opts Options) (Interface, error) {
 
 		EnableClusteredDeployment:       opts.EnableClusteredDeployment,
 		WorkflowsRemoteActivityReminder: opts.WorkflowsRemoteActivityReminder,
-		WorkflowsFastPath:               opts.WorkflowsFastPath,
+		WorkflowsFastPath:               fastPath,
 	})
 	if err != nil {
 		return nil, err

--- a/tests/integration/suite/daprd/workflow/globalmaxconcurrent/fastpath.go
+++ b/tests/integration/suite/daprd/workflow/globalmaxconcurrent/fastpath.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package globalmaxconcurrent
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fastpath))
+}
+
+type fastpath struct {
+	workflow *workflow.Workflow
+}
+
+func (f *fastpath) Setup(t *testing.T) []framework.Option {
+	configManifest := `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: globalmax
+spec:
+  features:
+  - name: WorkflowsFastPath
+    enabled: true
+  workflow:
+    globalMaxConcurrentWorkflowInvocations: 2
+`
+	const appID = "globalmax-fastpath"
+	f.workflow = workflow.New(t,
+		workflow.WithDaprds(3),
+		workflow.WithDaprdOptions(0, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
+		workflow.WithDaprdOptions(1, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
+		workflow.WithDaprdOptions(2, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *fastpath) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	var inside atomic.Int64
+	doneCh := make(chan struct{})
+	defer close(doneCh)
+
+	for idx := range 3 {
+		f.workflow.RegistryN(idx).AddWorkflowN("globalmax", func(ctx *task.WorkflowContext) (any, error) {
+			inside.Add(1)
+			<-doneCh
+			return nil, nil
+		})
+	}
+
+	client0 := f.workflow.BackendClientN(t, ctx, 0)
+	client1 := f.workflow.BackendClientN(t, ctx, 1)
+	client2 := f.workflow.BackendClientN(t, ctx, 2)
+
+	_, err := client0.ScheduleNewWorkflow(ctx, "globalmax", api.WithStartTime(time.Now()))
+	require.NoError(t, err)
+	_, err = client1.ScheduleNewWorkflow(ctx, "globalmax", api.WithStartTime(time.Now()))
+	require.NoError(t, err)
+	_, err = client2.ScheduleNewWorkflow(ctx, "globalmax", api.WithStartTime(time.Now()))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), inside.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	time.Sleep(time.Second * 2)
+	assert.Equal(t, int64(2), inside.Load(), "the concurrency cap must hold with WorkflowsFastPath enabled")
+
+	doneCh <- struct{}{}
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(3), inside.Load())
+	}, time.Second*10, time.Millisecond*10)
+}


### PR DESCRIPTION
The scheduler enforces the global and per-name workflow concurrency limits by gating each job delivery. WorkflowsFastPath local drives execute work items directly on the sidecar and elide the reminders that would round-trip through the scheduler, so those executions never pass the gate and the configured limits are silently bypassed.

The workflow engine now refuses to activate the fast path when any scheduler-enforced limit is configured, logging why. A new helper, WorkflowSpec.HasSchedulerConcurrencyLimits, reports whether one is set; the worker-enforced per-host caps do not disable the fast path.