### PR TITLE
workflow: prevent activity double-execution across placement handoff

### DIFF
--- a/pkg/actors/targets/workflow/activity/claim/check.go
+++ b/pkg/actors/targets/workflow/activity/claim/check.go
@@ -1,0 +1,105 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package claim
+
+import (
+	"context"
+	"time"
+)
+
+// Check classifies the record for a fresh-owner recovery arrival about to
+// execute taskKey.
+func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, error) {
+	rec, etag, err := g.read(ctx, actorID)
+	if err != nil {
+		return Defer, err
+	}
+	if rec == nil {
+		g.forget(actorID)
+		return Proceed, nil
+	}
+	stale := g.observeStale(actorID, rec)
+	if rec.TaskKey != taskKey {
+		// Another scheduling's record: ignore it, and reap it once its
+		// guard host reads dead so an old run's row cannot leak forever.
+		if stale && g.delete(ctx, actorID, etag) != nil {
+			// The row changed under the read (a guard heartbeat won the
+			// race): defer so the retry re-observes it. Not an error, a
+			// classification.
+			return Defer, nil //nolint:nilerr
+		}
+		if stale {
+			g.forget(actorID)
+		}
+		return Proceed, nil
+	}
+	if rec.Completed {
+		g.forget(actorID)
+		return Completed, nil
+	}
+	if !stale {
+		return Defer, nil
+	}
+	// The guarding host stopped heartbeating: it is dead, reclaim. The
+	// ETag-conditional delete closes the read/delete race: a heartbeat
+	// landing in between fails the delete, and the arrival defers instead
+	// of duplicating the revived execution.
+	if g.delete(ctx, actorID, etag) != nil {
+		// Reclaim lost the race; classify as live rather than error.
+		return Defer, nil //nolint:nilerr
+	}
+	g.forget(actorID)
+	return Proceed, nil
+}
+
+// observeStale reports whether rec's heartbeat has been observed unchanged
+// for StaleAfter on this reader's clock. HeartbeatMs is another host's wall
+// clock, so it is never compared against local time (skew of the grace or
+// more would insta-reclaim a live execution); the first sight of a value
+// only opens the window and a changed value reopens it. Recovery arrivals
+// recur (janitor re-dispatch, deferral retry), so the multi-read watch
+// converges within roughly one extra grace.
+func (g *Guards) observeStale(actorID string, rec *Record) bool {
+	now := time.Now()
+	g.obsLock.Lock()
+	defer g.obsLock.Unlock()
+	for id, o := range g.observed {
+		if now.Sub(o.lastSeen) > 2*g.opts.StaleAfter {
+			delete(g.observed, id)
+		}
+	}
+	o, ok := g.observed[actorID]
+	if !ok || o.taskKey != rec.TaskKey || o.heartbeatMs != rec.HeartbeatMs {
+		if g.observed == nil {
+			g.observed = make(map[string]*observation)
+		}
+		g.observed[actorID] = &observation{
+			taskKey:     rec.TaskKey,
+			heartbeatMs: rec.HeartbeatMs,
+			firstSeen:   now,
+			lastSeen:    now,
+		}
+		return false
+	}
+	o.lastSeen = now
+	return now.Sub(o.firstSeen) >= g.opts.StaleAfter
+}
+
+// forget drops the staleness watch once the record resolved (reclaimed,
+// completed, or gone).
+func (g *Guards) forget(actorID string) {
+	g.obsLock.Lock()
+	delete(g.observed, actorID)
+	g.obsLock.Unlock()
+}

--- a/pkg/actors/targets/workflow/activity/claim/check.go
+++ b/pkg/actors/targets/workflow/activity/claim/check.go
@@ -45,7 +45,15 @@ func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, e
 		return Proceed, nil
 	}
 	if rec.Completed {
-		g.forget(actorID)
+		// Ack without executing; the result was already published. Reap the
+		// row once it reads stale (a restart inside the retention window
+		// leaves it behind: the guard's retention delete cannot run again),
+		// best effort, so it does not linger for good.
+		if stale {
+			if g.delete(ctx, actorID, etag) == nil {
+				g.forget(actorID)
+			}
+		}
 		return Completed, nil
 	}
 	if !stale {

--- a/pkg/actors/targets/workflow/activity/claim/claim.go
+++ b/pkg/actors/targets/workflow/activity/claim/claim.go
@@ -19,15 +19,11 @@ limitations under the License.
 package claim
 
 import (
-	"context"
-	"encoding/json"
 	"errors"
 	"sync"
 	"time"
 
-	actorsapi "github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/state"
-	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	"github.com/dapr/kit/logger"
 )
@@ -66,6 +62,10 @@ const (
 )
 
 // Record is the persisted shape of the execution-claim state row.
+// HeartbeatMs is the writer's clock and readers never compare it against
+// their own: staleness is judged by observing the value unchanged for
+// StaleAfter on the reader's clock (see observeStale), so cross-host clock
+// skew cannot reclaim a live execution.
 type Record struct {
 	TaskKey     string `json:"taskKey"`
 	HeartbeatMs int64  `json:"heartbeatMs"`
@@ -82,8 +82,8 @@ type Options struct {
 	// Retention keeps a Completed record readable before deletion, the
 	// durable analogue of the in-memory inflight cache TTL.
 	Retention time.Duration
-	// StaleAfter is the grace after the last heartbeat before a record
-	// reads as dead and the new owner reclaims.
+	// StaleAfter is how long a reader must observe an unchanged heartbeat
+	// value before the record reads as dead and the new owner reclaims.
 	StaleAfter time.Duration
 }
 
@@ -94,206 +94,23 @@ type Guards struct {
 	lock   sync.Mutex
 	active map[string]struct{}
 	wg     sync.WaitGroup
+
+	// observed tracks, per actor, when this reader first saw the record's
+	// current heartbeat value; see observeStale.
+	obsLock  sync.Mutex
+	observed map[string]*observation
+}
+
+// observation is one reader-side staleness watch: firstSeen anchors the
+// StaleAfter window for the recorded heartbeat value, lastSeen bounds the
+// map (entries not refreshed within twice the grace are pruned).
+type observation struct {
+	taskKey     string
+	heartbeatMs int64
+	firstSeen   time.Time
+	lastSeen    time.Time
 }
 
 func New(opts Options) *Guards {
 	return &Guards{opts: opts}
-}
-
-// Spawn writes the record synchronously and starts one heartbeat goroutine
-// per task key (deduped; rootCtx-bounded, waitgroup-accounted). The
-// synchronous write runs within HaltNonHosted's UPDATE phase, so the record
-// is durable before UNLOCK admits the first recovery arrival.
-func (g *Guards) Spawn(ctx, rootCtx context.Context, actorID, taskKey string, call *inflight.Call) {
-	g.lock.Lock()
-	if rootCtx.Err() != nil {
-		g.lock.Unlock()
-		return
-	}
-	if g.active == nil {
-		g.active = make(map[string]struct{})
-	}
-	if _, ok := g.active[taskKey]; ok {
-		g.lock.Unlock()
-		return
-	}
-	g.active[taskKey] = struct{}{}
-	g.wg.Add(1)
-	g.lock.Unlock()
-
-	log.Infof("Activity actor '%s': guarding its in-flight execution claim across placement churn", actorID)
-
-	g.write(ctx, actorID, taskKey, false)
-
-	go func() {
-		defer func() {
-			g.lock.Lock()
-			delete(g.active, taskKey)
-			g.lock.Unlock()
-			g.wg.Done()
-		}()
-		g.guard(rootCtx, actorID, taskKey, call)
-	}()
-}
-
-// Wait blocks until all guard goroutines have exited.
-func (g *Guards) Wait() {
-	g.wg.Wait()
-}
-
-// Active returns the number of running guards.
-func (g *Guards) Active() int {
-	g.lock.Lock()
-	defer g.lock.Unlock()
-	return len(g.active)
-}
-
-// guard heartbeats the already-written record every HeartbeatEvery until the
-// local execution settles: clean finish marks Completed and retains the
-// record for Retention before deleting; a failed finish deletes immediately;
-// a dead host goes stale. Stale and deleted both mean the new owner
-// re-executes.
-func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *inflight.Call) {
-	ticker := time.NewTicker(g.opts.HeartbeatEvery)
-	defer ticker.Stop()
-	for {
-		select {
-		case <-ctx.Done():
-			// Process shutdown: the execution dies with this host, so the
-			// record only stalls the new owner. Best-effort delete; a lost
-			// delete goes stale within the grace anyway.
-			g.deleteOwned(context.WithoutCancel(ctx), actorID, taskKey)
-			return
-		case <-call.Done():
-			if call.Err() != nil {
-				g.deleteOwned(ctx, actorID, taskKey)
-				return
-			}
-			g.write(ctx, actorID, taskKey, true)
-			select {
-			case <-ctx.Done():
-			case <-time.After(g.opts.Retention):
-				g.deleteOwned(ctx, actorID, taskKey)
-			}
-			return
-		case <-ticker.C:
-			g.write(ctx, actorID, taskKey, false)
-		}
-	}
-}
-
-// deleteOwned deletes the record only while it still carries taskKey: a
-// newer scheduling's guard may have overwritten the shared row, and deleting
-// that would unprotect a live execution. The delete is ETag-conditional so a
-// write landing between the read and the delete also keeps the newer row.
-func (g *Guards) deleteOwned(ctx context.Context, actorID, taskKey string) {
-	rec, etag, err := g.read(ctx, actorID)
-	if err != nil {
-		log.Warnf("Activity actor '%s': failed to read the execution-claim record before deleting; leaving it to go stale: %v", actorID, err)
-		return
-	}
-	if rec == nil || rec.TaskKey != taskKey {
-		return
-	}
-	g.delete(ctx, actorID, etag)
-}
-
-// Check classifies the record for a fresh-owner recovery arrival about to
-// execute taskKey.
-func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, error) {
-	rec, etag, err := g.read(ctx, actorID)
-	if err != nil {
-		return Defer, err
-	}
-	if rec == nil {
-		return Proceed, nil
-	}
-	stale := time.Since(time.UnixMilli(rec.HeartbeatMs)) >= g.opts.StaleAfter
-	if rec.TaskKey != taskKey {
-		// Another scheduling's record: ignore it, and reap it when its
-		// guard host is dead so an old run's row cannot leak forever.
-		if stale && g.delete(ctx, actorID, etag) != nil {
-			// The row changed under the read (a guard heartbeat won the
-			// race): defer so the retry re-observes it. Not an error, a
-			// classification.
-			return Defer, nil //nolint:nilerr
-		}
-		return Proceed, nil
-	}
-	if rec.Completed {
-		return Completed, nil
-	}
-	if !stale {
-		return Defer, nil
-	}
-	// The guarding host stopped heartbeating: it is dead, reclaim. The
-	// ETag-conditional delete closes the read/delete race: a heartbeat
-	// landing in between fails the delete, and the arrival defers instead
-	// of duplicating the revived execution.
-	if g.delete(ctx, actorID, etag) != nil {
-		// Reclaim lost the race; classify as live rather than error.
-		return Defer, nil //nolint:nilerr
-	}
-	return Proceed, nil
-}
-
-func (g *Guards) write(ctx context.Context, actorID, taskKey string, completed bool) {
-	octx, cancel := context.WithTimeout(ctx, opTimeout)
-	defer cancel()
-	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
-		ActorType: g.opts.ActorType,
-		ActorID:   actorID,
-		Operations: []actorsapi.TransactionalOperation{{
-			Operation: actorsapi.Upsert,
-			Request: actorsapi.TransactionalUpsert{
-				Key: recordStateKey,
-				Value: Record{
-					TaskKey:     taskKey,
-					HeartbeatMs: time.Now().UnixMilli(),
-					Completed:   completed,
-				},
-			},
-		}},
-	}, false)
-	if err != nil {
-		log.Warnf("Activity actor '%s': failed to write the execution-claim record; recovery degrades to at-least-once for this handoff: %v", actorID, err)
-	}
-}
-
-// delete removes the record, conditional on etag when the read that observed
-// it returned one, so a concurrent overwrite is kept rather than destroyed.
-func (g *Guards) delete(ctx context.Context, actorID string, etag *string) error {
-	octx, cancel := context.WithTimeout(ctx, opTimeout)
-	defer cancel()
-	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
-		ActorType: g.opts.ActorType,
-		ActorID:   actorID,
-		Operations: []actorsapi.TransactionalOperation{{
-			Operation: actorsapi.Delete,
-			Request:   actorsapi.TransactionalDelete{Key: recordStateKey, ETag: etag},
-		}},
-	}, false)
-	if err != nil {
-		log.Warnf("Activity actor '%s': failed to delete the execution-claim record: %v", actorID, err)
-	}
-	return err
-}
-
-func (g *Guards) read(ctx context.Context, actorID string) (*Record, *string, error) {
-	res, err := g.opts.State.Get(ctx, &actorsapi.GetStateRequest{
-		ActorType: g.opts.ActorType,
-		ActorID:   actorID,
-		Key:       recordStateKey,
-	}, false)
-	if err != nil {
-		return nil, nil, err
-	}
-	if res == nil || len(res.Data) == 0 {
-		return nil, nil, nil
-	}
-	var rec Record
-	if err := json.Unmarshal(res.Data, &rec); err != nil {
-		return nil, nil, err
-	}
-	return &rec, res.ETag, nil
 }

--- a/pkg/actors/targets/workflow/activity/claim/claim.go
+++ b/pkg/actors/targets/workflow/activity/claim/claim.go
@@ -1,0 +1,271 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package claim implements the durable execution-claim record for activity
+// actors under the WorkflowsFastPath preview: a lease written only around
+// placement churn, so a recovery arrival on a new placement owner can tell a
+// live cross-host execution, or its published result, from one that died
+// with its host.
+package claim
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"time"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/state"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	"github.com/dapr/kit/logger"
+)
+
+var log = logger.NewLogger("dapr.runtime.actors.targets.activity.claim")
+
+const (
+	// recordStateKey keys the record under the activity actor's state
+	// prefix; TaskKey tells scheduling generations apart.
+	recordStateKey = "execution-claim"
+
+	// opTimeout bounds each guard state operation so a slow store cannot
+	// park a guard goroutine indefinitely.
+	opTimeout = 10 * time.Second
+)
+
+// ErrHeldElsewhere defers a recovery arrival whose body is still executing
+// on the previous owner (live heartbeat). Recoverable: retries land after
+// the record resolves to Completed, deleted, or stale.
+var ErrHeldElsewhere = wferrors.NewRecoverable(errors.New(
+	"activity execution claim is held live by another host; deferring re-execution"))
+
+// Outcome classifies the record for a fresh-owner recovery arrival.
+type Outcome int
+
+const (
+	// Proceed: no record, a different scheduling's record, or a stale one
+	// (its guard host died); execute as a fresh owner.
+	Proceed Outcome = iota
+	// Defer: a live heartbeat proves the body is still executing on another
+	// host; surface a recoverable error so the arrival retries.
+	Defer
+	// Completed: the guarded execution finished cleanly and its result is
+	// published; ack success without executing.
+	Completed
+)
+
+// Record is the persisted shape of the execution-claim state row.
+type Record struct {
+	TaskKey     string `json:"taskKey"`
+	HeartbeatMs int64  `json:"heartbeatMs"`
+	Completed   bool   `json:"completed"`
+}
+
+// Options configures Guards. HeartbeatEvery, Retention and StaleAfter are
+// options only so tests can compress them.
+type Options struct {
+	ActorType string
+	State     state.Interface
+	// HeartbeatEvery paces the guard's record refresh.
+	HeartbeatEvery time.Duration
+	// Retention keeps a Completed record readable before deletion, the
+	// durable analogue of the in-memory inflight cache TTL.
+	Retention time.Duration
+	// StaleAfter is the grace after the last heartbeat before a record
+	// reads as dead and the new owner reclaims.
+	StaleAfter time.Duration
+}
+
+// Guards owns the guard goroutines and the record gate.
+type Guards struct {
+	opts Options
+
+	lock   sync.Mutex
+	active map[string]struct{}
+	wg     sync.WaitGroup
+}
+
+func New(opts Options) *Guards {
+	return &Guards{opts: opts}
+}
+
+// Spawn writes the record synchronously and starts one heartbeat goroutine
+// per task key (deduped; rootCtx-bounded, waitgroup-accounted). The
+// synchronous write runs within HaltNonHosted's UPDATE phase, so the record
+// is durable before UNLOCK admits the first recovery arrival.
+func (g *Guards) Spawn(ctx, rootCtx context.Context, actorID, taskKey string, call *inflight.Call) {
+	g.lock.Lock()
+	if rootCtx.Err() != nil {
+		g.lock.Unlock()
+		return
+	}
+	if g.active == nil {
+		g.active = make(map[string]struct{})
+	}
+	if _, ok := g.active[taskKey]; ok {
+		g.lock.Unlock()
+		return
+	}
+	g.active[taskKey] = struct{}{}
+	g.wg.Add(1)
+	g.lock.Unlock()
+
+	log.Infof("Activity actor '%s': guarding its in-flight execution claim across placement churn", actorID)
+
+	g.write(ctx, actorID, taskKey, false)
+
+	go func() {
+		defer func() {
+			g.lock.Lock()
+			delete(g.active, taskKey)
+			g.lock.Unlock()
+			g.wg.Done()
+		}()
+		g.guard(rootCtx, actorID, taskKey, call)
+	}()
+}
+
+// Wait blocks until all guard goroutines have exited.
+func (g *Guards) Wait() {
+	g.wg.Wait()
+}
+
+// Active returns the number of running guards.
+func (g *Guards) Active() int {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	return len(g.active)
+}
+
+// guard heartbeats the already-written record every HeartbeatEvery until the
+// local execution settles: clean finish marks Completed and retains the
+// record for Retention before deleting; a failed finish deletes immediately;
+// a dead host goes stale. Stale and deleted both mean the new owner
+// re-executes.
+func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *inflight.Call) {
+	ticker := time.NewTicker(g.opts.HeartbeatEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Process shutdown: the execution dies with this host, so the
+			// record only stalls the new owner. Best-effort delete; a lost
+			// delete goes stale within the grace anyway.
+			g.delete(context.WithoutCancel(ctx), actorID)
+			return
+		case <-call.Done():
+			if call.Err() != nil {
+				g.delete(ctx, actorID)
+				return
+			}
+			g.write(ctx, actorID, taskKey, true)
+			select {
+			case <-ctx.Done():
+			case <-time.After(g.opts.Retention):
+				g.delete(ctx, actorID)
+			}
+			return
+		case <-ticker.C:
+			g.write(ctx, actorID, taskKey, false)
+		}
+	}
+}
+
+// Check classifies the record for a fresh-owner recovery arrival about to
+// execute taskKey.
+func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, error) {
+	rec, err := g.read(ctx, actorID)
+	if err != nil {
+		return Defer, err
+	}
+	if rec == nil {
+		return Proceed, nil
+	}
+	stale := time.Since(time.UnixMilli(rec.HeartbeatMs)) >= g.opts.StaleAfter
+	if rec.TaskKey != taskKey {
+		// Another scheduling's record: ignore it, and reap it when its
+		// guard host is dead so an old run's row cannot leak forever.
+		if stale {
+			g.delete(ctx, actorID)
+		}
+		return Proceed, nil
+	}
+	if rec.Completed {
+		return Completed, nil
+	}
+	if !stale {
+		return Defer, nil
+	}
+	// The guarding host stopped heartbeating: it is dead, reclaim.
+	g.delete(ctx, actorID)
+	return Proceed, nil
+}
+
+func (g *Guards) write(ctx context.Context, actorID, taskKey string, completed bool) {
+	octx, cancel := context.WithTimeout(ctx, opTimeout)
+	defer cancel()
+	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Operations: []actorsapi.TransactionalOperation{{
+			Operation: actorsapi.Upsert,
+			Request: actorsapi.TransactionalUpsert{
+				Key: recordStateKey,
+				Value: Record{
+					TaskKey:     taskKey,
+					HeartbeatMs: time.Now().UnixMilli(),
+					Completed:   completed,
+				},
+			},
+		}},
+	}, false)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to write the execution-claim record; recovery degrades to at-least-once for this handoff: %v", actorID, err)
+	}
+}
+
+func (g *Guards) delete(ctx context.Context, actorID string) {
+	octx, cancel := context.WithTimeout(ctx, opTimeout)
+	defer cancel()
+	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Operations: []actorsapi.TransactionalOperation{{
+			Operation: actorsapi.Delete,
+			Request:   actorsapi.TransactionalDelete{Key: recordStateKey},
+		}},
+	}, false)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to delete the execution-claim record: %v", actorID, err)
+	}
+}
+
+func (g *Guards) read(ctx context.Context, actorID string) (*Record, error) {
+	res, err := g.opts.State.Get(ctx, &actorsapi.GetStateRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Key:       recordStateKey,
+	}, false)
+	if err != nil {
+		return nil, err
+	}
+	if res == nil || len(res.Data) == 0 {
+		return nil, nil
+	}
+	var rec Record
+	if err := json.Unmarshal(res.Data, &rec); err != nil {
+		return nil, err
+	}
+	return &rec, nil
+}

--- a/pkg/actors/targets/workflow/activity/claim/claim.go
+++ b/pkg/actors/targets/workflow/activity/claim/claim.go
@@ -162,18 +162,18 @@ func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *infli
 			// Process shutdown: the execution dies with this host, so the
 			// record only stalls the new owner. Best-effort delete; a lost
 			// delete goes stale within the grace anyway.
-			g.delete(context.WithoutCancel(ctx), actorID)
+			g.deleteOwned(context.WithoutCancel(ctx), actorID, taskKey)
 			return
 		case <-call.Done():
 			if call.Err() != nil {
-				g.delete(ctx, actorID)
+				g.deleteOwned(ctx, actorID, taskKey)
 				return
 			}
 			g.write(ctx, actorID, taskKey, true)
 			select {
 			case <-ctx.Done():
 			case <-time.After(g.opts.Retention):
-				g.delete(ctx, actorID)
+				g.deleteOwned(ctx, actorID, taskKey)
 			}
 			return
 		case <-ticker.C:
@@ -182,10 +182,26 @@ func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *infli
 	}
 }
 
+// deleteOwned deletes the record only while it still carries taskKey: a
+// newer scheduling's guard may have overwritten the shared row, and deleting
+// that would unprotect a live execution. The delete is ETag-conditional so a
+// write landing between the read and the delete also keeps the newer row.
+func (g *Guards) deleteOwned(ctx context.Context, actorID, taskKey string) {
+	rec, etag, err := g.read(ctx, actorID)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to read the execution-claim record before deleting; leaving it to go stale: %v", actorID, err)
+		return
+	}
+	if rec == nil || rec.TaskKey != taskKey {
+		return
+	}
+	g.delete(ctx, actorID, etag)
+}
+
 // Check classifies the record for a fresh-owner recovery arrival about to
 // execute taskKey.
 func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, error) {
-	rec, err := g.read(ctx, actorID)
+	rec, etag, err := g.read(ctx, actorID)
 	if err != nil {
 		return Defer, err
 	}
@@ -196,8 +212,11 @@ func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, e
 	if rec.TaskKey != taskKey {
 		// Another scheduling's record: ignore it, and reap it when its
 		// guard host is dead so an old run's row cannot leak forever.
-		if stale {
-			g.delete(ctx, actorID)
+		if stale && g.delete(ctx, actorID, etag) != nil {
+			// The row changed under the read (a guard heartbeat won the
+			// race): defer so the retry re-observes it. Not an error, a
+			// classification.
+			return Defer, nil //nolint:nilerr
 		}
 		return Proceed, nil
 	}
@@ -207,8 +226,14 @@ func (g *Guards) Check(ctx context.Context, actorID, taskKey string) (Outcome, e
 	if !stale {
 		return Defer, nil
 	}
-	// The guarding host stopped heartbeating: it is dead, reclaim.
-	g.delete(ctx, actorID)
+	// The guarding host stopped heartbeating: it is dead, reclaim. The
+	// ETag-conditional delete closes the read/delete race: a heartbeat
+	// landing in between fails the delete, and the arrival defers instead
+	// of duplicating the revived execution.
+	if g.delete(ctx, actorID, etag) != nil {
+		// Reclaim lost the race; classify as live rather than error.
+		return Defer, nil //nolint:nilerr
+	}
 	return Proceed, nil
 }
 
@@ -235,7 +260,9 @@ func (g *Guards) write(ctx context.Context, actorID, taskKey string, completed b
 	}
 }
 
-func (g *Guards) delete(ctx context.Context, actorID string) {
+// delete removes the record, conditional on etag when the read that observed
+// it returned one, so a concurrent overwrite is kept rather than destroyed.
+func (g *Guards) delete(ctx context.Context, actorID string, etag *string) error {
 	octx, cancel := context.WithTimeout(ctx, opTimeout)
 	defer cancel()
 	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
@@ -243,29 +270,30 @@ func (g *Guards) delete(ctx context.Context, actorID string) {
 		ActorID:   actorID,
 		Operations: []actorsapi.TransactionalOperation{{
 			Operation: actorsapi.Delete,
-			Request:   actorsapi.TransactionalDelete{Key: recordStateKey},
+			Request:   actorsapi.TransactionalDelete{Key: recordStateKey, ETag: etag},
 		}},
 	}, false)
 	if err != nil {
 		log.Warnf("Activity actor '%s': failed to delete the execution-claim record: %v", actorID, err)
 	}
+	return err
 }
 
-func (g *Guards) read(ctx context.Context, actorID string) (*Record, error) {
+func (g *Guards) read(ctx context.Context, actorID string) (*Record, *string, error) {
 	res, err := g.opts.State.Get(ctx, &actorsapi.GetStateRequest{
 		ActorType: g.opts.ActorType,
 		ActorID:   actorID,
 		Key:       recordStateKey,
 	}, false)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	if res == nil || len(res.Data) == 0 {
-		return nil, nil
+		return nil, nil, nil
 	}
 	var rec Record
 	if err := json.Unmarshal(res.Data, &rec); err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	return &rec, nil
+	return &rec, res.ETag, nil
 }

--- a/pkg/actors/targets/workflow/activity/claim/guard.go
+++ b/pkg/actors/targets/workflow/activity/claim/guard.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package claim
+
+import (
+	"context"
+	"time"
+
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
+)
+
+// Spawn writes the record synchronously and starts one heartbeat goroutine
+// per task key (deduped; rootCtx-bounded, waitgroup-accounted). The
+// synchronous write runs within HaltNonHosted's UPDATE phase, so the record
+// is durable before UNLOCK admits the first recovery arrival.
+func (g *Guards) Spawn(ctx, rootCtx context.Context, actorID, taskKey string, call *inflight.Call) {
+	g.lock.Lock()
+	if rootCtx.Err() != nil {
+		g.lock.Unlock()
+		return
+	}
+	if g.active == nil {
+		g.active = make(map[string]struct{})
+	}
+	if _, ok := g.active[taskKey]; ok {
+		g.lock.Unlock()
+		return
+	}
+	g.active[taskKey] = struct{}{}
+	g.wg.Add(1)
+	g.lock.Unlock()
+
+	log.Infof("Activity actor '%s': guarding its in-flight execution claim across placement churn", actorID)
+
+	g.write(ctx, actorID, taskKey, false)
+
+	go func() {
+		defer func() {
+			g.lock.Lock()
+			delete(g.active, taskKey)
+			g.lock.Unlock()
+			g.wg.Done()
+		}()
+		g.guard(rootCtx, actorID, taskKey, call)
+	}()
+}
+
+// Wait blocks until all guard goroutines have exited.
+func (g *Guards) Wait() {
+	g.wg.Wait()
+}
+
+// Active returns the number of running guards.
+func (g *Guards) Active() int {
+	g.lock.Lock()
+	defer g.lock.Unlock()
+	return len(g.active)
+}
+
+// guard heartbeats the already-written record every HeartbeatEvery until the
+// local execution settles: clean finish marks Completed and retains the
+// record for Retention before deleting; a failed finish deletes immediately;
+// a dead host goes stale. Stale and deleted both mean the new owner
+// re-executes.
+func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *inflight.Call) {
+	ticker := time.NewTicker(g.opts.HeartbeatEvery)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			// Process shutdown: the execution dies with this host, so the
+			// record only stalls the new owner. Best-effort delete; a lost
+			// delete goes stale within the grace anyway.
+			g.deleteOwned(context.WithoutCancel(ctx), actorID, taskKey)
+			return
+		case <-call.Done():
+			if call.Err() != nil {
+				g.deleteOwned(ctx, actorID, taskKey)
+				return
+			}
+			g.write(ctx, actorID, taskKey, true)
+			select {
+			case <-ctx.Done():
+			case <-time.After(g.opts.Retention):
+				g.deleteOwned(ctx, actorID, taskKey)
+			}
+			return
+		case <-ticker.C:
+			g.write(ctx, actorID, taskKey, false)
+		}
+	}
+}
+
+// deleteOwned deletes the record only while it still carries taskKey: a
+// newer scheduling's guard may have overwritten the shared row, and deleting
+// that would unprotect a live execution. The delete is ETag-conditional so a
+// write landing between the read and the delete also keeps the newer row.
+func (g *Guards) deleteOwned(ctx context.Context, actorID, taskKey string) {
+	rec, etag, err := g.read(ctx, actorID)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to read the execution-claim record before deleting; leaving it to go stale: %v", actorID, err)
+		return
+	}
+	if rec == nil || rec.TaskKey != taskKey {
+		return
+	}
+	g.delete(ctx, actorID, etag)
+}

--- a/pkg/actors/targets/workflow/activity/claim/guard.go
+++ b/pkg/actors/targets/workflow/activity/claim/guard.go
@@ -92,6 +92,9 @@ func (g *Guards) guard(ctx context.Context, actorID, taskKey string, call *infli
 			g.write(ctx, actorID, taskKey, true)
 			select {
 			case <-ctx.Done():
+				// Shutdown mid-retention: keep the Completed row so recovery
+				// arrivals on the new owner ack instead of re-executing the
+				// published body; gate reads reap it once it goes stale.
 			case <-time.After(g.opts.Retention):
 				g.deleteOwned(ctx, actorID, taskKey)
 			}

--- a/pkg/actors/targets/workflow/activity/claim/store.go
+++ b/pkg/actors/targets/workflow/activity/claim/store.go
@@ -1,0 +1,85 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package claim
+
+import (
+	"context"
+	"encoding/json"
+	"time"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+)
+
+func (g *Guards) write(ctx context.Context, actorID, taskKey string, completed bool) {
+	octx, cancel := context.WithTimeout(ctx, opTimeout)
+	defer cancel()
+	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Operations: []actorsapi.TransactionalOperation{{
+			Operation: actorsapi.Upsert,
+			Request: actorsapi.TransactionalUpsert{
+				Key: recordStateKey,
+				Value: Record{
+					TaskKey:     taskKey,
+					HeartbeatMs: time.Now().UnixMilli(),
+					Completed:   completed,
+				},
+			},
+		}},
+	}, false)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to write the execution-claim record; recovery degrades to at-least-once for this handoff: %v", actorID, err)
+	}
+}
+
+// delete removes the record, conditional on etag when the read that observed
+// it returned one, so a concurrent overwrite is kept rather than destroyed.
+func (g *Guards) delete(ctx context.Context, actorID string, etag *string) error {
+	octx, cancel := context.WithTimeout(ctx, opTimeout)
+	defer cancel()
+	err := g.opts.State.TransactionalStateOperation(octx, true, &actorsapi.TransactionalRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Operations: []actorsapi.TransactionalOperation{{
+			Operation: actorsapi.Delete,
+			Request:   actorsapi.TransactionalDelete{Key: recordStateKey, ETag: etag},
+		}},
+	}, false)
+	if err != nil {
+		log.Warnf("Activity actor '%s': failed to delete the execution-claim record: %v", actorID, err)
+	}
+	return err
+}
+
+func (g *Guards) read(ctx context.Context, actorID string) (*Record, *string, error) {
+	octx, cancel := context.WithTimeout(ctx, opTimeout)
+	defer cancel()
+	res, err := g.opts.State.Get(octx, &actorsapi.GetStateRequest{
+		ActorType: g.opts.ActorType,
+		ActorID:   actorID,
+		Key:       recordStateKey,
+	}, false)
+	if err != nil {
+		return nil, nil, err
+	}
+	if res == nil || len(res.Data) == 0 {
+		return nil, nil, nil
+	}
+	var rec Record
+	if err := json.Unmarshal(res.Data, &rec); err != nil {
+		return nil, nil, err
+	}
+	return &rec, res.ETag, nil
+}

--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -714,6 +714,36 @@ func Test_gateJanitorRedispatch(t *testing.T) {
 		require.NoError(t, err)
 	})
 
+	t.Run("stale completed record is reaped while acking", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond,
+		})
+		// A restart inside the retention window leaves this row behind; the
+		// guard cannot delete it again.
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: 12345, Completed: true})
+
+		a := f.GetOrCreate(actorID).(*activity)
+
+		// First read opens the reader-side observation window and acks.
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		assert.True(t, handled)
+		require.NoError(t, err)
+		_, ok := store.get(t, actorID)
+		assert.True(t, ok, "a fresh completed row is retained for in-flight recovery arrivals")
+
+		// A later read past the grace still acks and reaps the row.
+		time.Sleep(5 * time.Millisecond)
+		handled, err = a.gateJanitorRedispatch(t.Context(), testInvocation())
+		assert.True(t, handled)
+		require.NoError(t, err)
+		_, ok = store.get(t, actorID)
+		assert.False(t, ok, "a stale completed row must not linger forever")
+	})
+
 	t.Run("missing record proceeds", func(t *testing.T) {
 		t.Parallel()
 		f, _, _ := newClaimHarness(t)

--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -1,0 +1,609 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package activity
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/claim"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// recordStore backs the state fake with an in-memory execution-claim record
+// table keyed by activity actor ID.
+type recordStore struct {
+	lock sync.Mutex
+	data map[string][]byte
+}
+
+func newRecordStore() *recordStore {
+	return &recordStore{data: make(map[string][]byte)}
+}
+
+func (s *recordStore) fake() *statefake.Fake {
+	return statefake.New().
+		WithGetFn(func(_ context.Context, req *actorsapi.GetStateRequest, _ bool) (*actorsapi.StateResponse, error) {
+			s.lock.Lock()
+			defer s.lock.Unlock()
+			b, ok := s.data[req.ActorID]
+			if !ok {
+				return &actorsapi.StateResponse{}, nil
+			}
+			return &actorsapi.StateResponse{Data: b}, nil
+		}).
+		WithTransactionalStateOperationFn(func(_ context.Context, _ bool, req *actorsapi.TransactionalRequest, _ bool) error {
+			s.lock.Lock()
+			defer s.lock.Unlock()
+			for _, op := range req.Operations {
+				switch r := op.Request.(type) {
+				case actorsapi.TransactionalUpsert:
+					b, err := json.Marshal(r.Value)
+					if err != nil {
+						return err
+					}
+					s.data[req.ActorID] = b
+				case actorsapi.TransactionalDelete:
+					delete(s.data, req.ActorID)
+				}
+			}
+			return nil
+		})
+}
+
+func (s *recordStore) get(t *testing.T, actorID string) (*claim.Record, bool) {
+	t.Helper()
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	b, ok := s.data[actorID]
+	if !ok {
+		return nil, false
+	}
+	var rec claim.Record
+	require.NoError(t, json.Unmarshal(b, &rec))
+	return &rec, true
+}
+
+func (s *recordStore) set(t *testing.T, actorID string, rec claim.Record) {
+	t.Helper()
+	b, err := json.Marshal(rec)
+	require.NoError(t, err)
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.data[actorID] = b
+}
+
+func newClaimHarness(t *testing.T) (*factory, *recordStore, chan *backend.ActivityWorkItem) {
+	t.Helper()
+	store := newRecordStore()
+	scheduled := make(chan *backend.ActivityWorkItem, 2)
+	driveCtx, driveCancel := context.WithCancel(t.Context())
+	f := &factory{
+		driveCtx:          driveCtx,
+		driveCancel:       driveCancel,
+		appID:             "testapp",
+		actorType:         "dapr.internal.default.testapp.activity",
+		workflowActorType: "dapr.internal.default.testapp.workflow",
+		router:            routerfake.New(),
+		signing:           &signing.Signing{Namespace: "default"},
+		state:             store.fake(),
+		fastPath:          true,
+		rootCtx:           t.Context(),
+		staleClaimAfter:   time.Hour,
+		claims: claim.New(claim.Options{
+			ActorType:      "dapr.internal.default.testapp.activity",
+			State:          store.fake(),
+			HeartbeatEvery: time.Millisecond * 10,
+			Retention:      time.Millisecond * 50,
+			StaleAfter:     time.Hour,
+		}),
+		scheduler: func(_ context.Context, wi *backend.ActivityWorkItem) error {
+			scheduled <- wi
+			return nil
+		},
+	}
+	return f, store, scheduled
+}
+
+func haltNothingHosted(t *testing.T, f *factory) {
+	t.Helper()
+	require.NoError(t, f.HaltNonHosted(t.Context(), func(*actorsapi.LookupActorRequest) bool {
+		return false
+	}))
+}
+
+// Test_claimGuard_lifecycle: written on churn halt, heartbeat advances,
+// Completed on clean finish, deleted after retention or on error.
+func Test_claimGuard_lifecycle(t *testing.T) {
+	t.Parallel()
+
+	const actorID = "wf::3"
+	key := actorID + "::gen1"
+
+	t.Run("churn halt writes, heartbeats, completes and deletes the record", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+
+		rec, ok := store.get(t, actorID)
+		require.True(t, ok, "the record must be durable before the churn halt returns (pre-unlock)")
+		assert.Equal(t, key, rec.TaskKey)
+		assert.False(t, rec.Completed)
+		hb1 := rec.HeartbeatMs
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			rec, ok := store.get(t, actorID)
+			if assert.True(c, ok) {
+				assert.Greater(c, rec.HeartbeatMs, hb1, "the heartbeat must advance every period")
+			}
+		}, time.Second*5, time.Millisecond*5)
+
+		call.Finish(nil)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			rec, ok := store.get(t, actorID)
+			if assert.True(c, ok, "the record must be marked Completed before deletion") {
+				assert.True(c, rec.Completed)
+			}
+		}, time.Second*5, time.Millisecond*5)
+
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return !ok
+		}, time.Second*5, time.Millisecond*5, "the completed record must self-delete after retention")
+		f.claims.Wait()
+	})
+
+	t.Run("execution error deletes the record without completing it", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return ok
+		}, time.Second*5, time.Millisecond*5)
+
+		call.Finish(errors.New("app crashed"))
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return !ok
+		}, time.Second*5, time.Millisecond*5, "a failed execution must delete the record so the new owner re-executes")
+		f.claims.Wait()
+
+		rec, ok := store.get(t, actorID)
+		assert.False(t, ok, "no Completed marker may survive an execution error: %+v", rec)
+	})
+
+	t.Run("halt-all spawns no guard", func(t *testing.T) {
+		// HaltAll is disconnection or shutdown; a record there would only
+		// stall the next owner.
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		require.NoError(t, f.HaltAll(t.Context()))
+		f.claims.Wait()
+
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok)
+		call.Finish(nil)
+	})
+
+	t.Run("shutdown deletes the record best effort", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		rootCtx, rootCancel := context.WithCancel(t.Context())
+		f.rootCtx = rootCtx
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return ok
+		}, time.Second*5, time.Millisecond*5)
+
+		rootCancel()
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return !ok
+		}, time.Second*5, time.Millisecond*5, "a guard stopped by shutdown must not leave a record stalling the new owner")
+		f.claims.Wait()
+		call.Finish(nil)
+	})
+
+	t.Run("no guard for a settled claim", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		call.Finish(nil)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+		f.claims.Wait()
+
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok, "a settled claim needs no guard: its outcome is already delivered")
+	})
+
+	t.Run("no guard without a claim", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+		f.claims.Wait()
+
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok)
+	})
+
+	t.Run("no guard when the fast path is disabled", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.fastPath = false
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+		f.claims.Wait()
+
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok)
+		call.Finish(nil)
+	})
+
+	t.Run("repeated halts spawn a single guard per task key", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+
+		assert.Equal(t, 1, f.claims.Active())
+
+		call.Finish(nil)
+		require.Eventually(t, func() bool {
+			_, ok := store.get(t, actorID)
+			return !ok
+		}, time.Second*5, time.Millisecond*5)
+		f.claims.Wait()
+	})
+}
+
+func Test_checkClaimRecord(t *testing.T) {
+	t.Parallel()
+
+	const actorID = "wf::3"
+	key := actorID + "::gen1"
+
+	t.Run("missing record proceeds", func(t *testing.T) {
+		t.Parallel()
+		f, _, _ := newClaimHarness(t)
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+	})
+
+	t.Run("record for another scheduling proceeds", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID + "::gen0", HeartbeatMs: time.Now().UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+	})
+
+	t.Run("live heartbeat defers", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome)
+	})
+
+	t.Run("completed acks", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(-time.Hour).UnixMilli(), Completed: true})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Completed, outcome)
+	})
+
+	t.Run("stale record from another scheduling is reaped on read", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond,
+		})
+		store.set(t, actorID, claim.Record{TaskKey: actorID + "::oldrun", HeartbeatMs: time.Now().Add(-time.Second).UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok, "a dead old-run record must not leak")
+	})
+
+	t.Run("live record from another scheduling is ignored but kept", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID + "::otherrun", HeartbeatMs: time.Now().UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+		_, ok := store.get(t, actorID)
+		assert.True(t, ok, "a live record may guard a newer generation and must not be deleted")
+	})
+
+	t.Run("stale heartbeat proceeds and deletes the record", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond,
+		})
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(-time.Second).UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+		_, ok := store.get(t, actorID)
+		assert.False(t, ok, "a stale record is dead weight and must be reclaimed")
+	})
+
+	t.Run("read error surfaces", func(t *testing.T) {
+		t.Parallel()
+		f, _, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType: f.actorType,
+			State: statefake.New().WithGetFn(func(context.Context, *actorsapi.GetStateRequest, bool) (*actorsapi.StateResponse, error) {
+				return nil, errors.New("store down")
+			}),
+		})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.Error(t, err)
+		assert.Equal(t, claim.Defer, outcome)
+	})
+}
+
+// Test_executeActivity_recoveryGate: live defers, completed acks, stale
+// executes.
+func Test_executeActivity_recoveryGate(t *testing.T) {
+	t.Parallel()
+
+	// testInvocation carries no TaskExecutionId and no timestamp, so the
+	// inflight key for actor wf::3 is the actor ID itself.
+	const actorID = "wf::3"
+
+	t.Run("live record defers with a recoverable error", func(t *testing.T) {
+		t.Parallel()
+		f, store, scheduled := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().UnixMilli()})
+
+		a := f.GetOrCreate(actorID).(*activity)
+		err := a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
+		require.ErrorIs(t, err, claim.ErrHeldElsewhere)
+		assert.True(t, wferrors.IsRecoverable(err), "the deferral must be retried, not failed terminally")
+		select {
+		case <-scheduled:
+			t.Fatal("a deferred arrival must not dispatch a WorkItem")
+		default:
+		}
+	})
+
+	t.Run("completed record acks success without executing", func(t *testing.T) {
+		t.Parallel()
+		f, store, scheduled := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().Add(-time.Hour).UnixMilli(), Completed: true})
+
+		a := f.GetOrCreate(actorID).(*activity)
+		require.NoError(t, a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true))
+		select {
+		case <-scheduled:
+			t.Fatal("a completed execution must not be re-run")
+		default:
+		}
+	})
+
+	t.Run("stale record executes as a fresh owner", func(t *testing.T) {
+		t.Parallel()
+		f, store, scheduled := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType: f.actorType,
+			State:     store.fake(),
+		})
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().Add(-time.Hour).UnixMilli()})
+
+		a := f.GetOrCreate(actorID).(*activity)
+		ownerErr := make(chan error, 1)
+		go func() {
+			ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
+		}()
+
+		var wi *backend.ActivityWorkItem
+		select {
+		case wi = <-scheduled:
+		case <-time.After(time.Second * 5):
+			t.Fatal("a stale record must not block re-execution")
+		}
+		wi.Result = &protos.HistoryEvent{
+			EventId: -1,
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 3},
+			},
+		}
+		callback, ok := wi.Properties[todo.CallbackChannelProperty].(chan bool)
+		require.True(t, ok)
+		callback <- true
+
+		select {
+		case err := <-ownerErr:
+			require.NoError(t, err)
+		case <-time.After(time.Second * 5):
+			t.Fatal("timed out waiting for the owner to finish")
+		}
+	})
+}
+
+func Test_gateJanitorRedispatch(t *testing.T) {
+	t.Parallel()
+
+	const actorID = "wf::3"
+
+	t.Run("local inflight entry acks without arming a drive", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().UnixMilli()})
+		call, owner := f.inflight.Acquire(actorID)
+		require.True(t, owner)
+		t.Cleanup(func() { call.Finish(nil) })
+
+		a := f.GetOrCreate(actorID).(*activity)
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		require.NoError(t, err)
+		assert.True(t, handled, "a local claim owns delivery; the re-dispatch must ack, not spawn a drive that could retry ungated")
+	})
+
+	t.Run("stranded local entry falls through to the rescue path", func(t *testing.T) {
+		t.Parallel()
+		f, _, _ := newClaimHarness(t)
+		// Stale immediately: unsettled, not held, past the (zeroed) grace.
+		f.staleClaimAfter = time.Nanosecond
+		f.executionHeld = func(string, int32) bool { return false }
+		call, owner := f.inflight.Acquire(actorID)
+		require.True(t, owner)
+		t.Cleanup(func() { call.Finish(nil) })
+		time.Sleep(time.Millisecond)
+
+		a := f.GetOrCreate(actorID).(*activity)
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		require.NoError(t, err)
+		assert.False(t, handled,
+			"a stranded entry must not ack: acking swallows both the re-dispatch and the escalation (janitor-livelock)")
+	})
+
+	t.Run("live record defers", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().UnixMilli()})
+
+		a := f.GetOrCreate(actorID).(*activity)
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		assert.True(t, handled)
+		require.ErrorIs(t, err, claim.ErrHeldElsewhere)
+	})
+
+	t.Run("completed record acks", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: 0, Completed: true})
+
+		a := f.GetOrCreate(actorID).(*activity)
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		assert.True(t, handled)
+		require.NoError(t, err)
+	})
+
+	t.Run("missing record proceeds", func(t *testing.T) {
+		t.Parallel()
+		f, _, _ := newClaimHarness(t)
+
+		a := f.GetOrCreate(actorID).(*activity)
+		handled, err := a.gateJanitorRedispatch(t.Context(), testInvocation())
+		require.NoError(t, err)
+		assert.False(t, handled)
+	})
+}
+
+// Test_driveActivity_escalationSuppressedByLiveClaim: a churn-aborted drive
+// with a live claim must not plant a reminder on the new owner.
+func Test_driveActivity_escalationSuppressedByLiveClaim(t *testing.T) {
+	t.Parallel()
+
+	t.Run("live claim suppresses the escalation", func(t *testing.T) {
+		t.Parallel()
+		h := newDriveHarness(t)
+		h.cancelOn1 = true
+
+		key := inflight.Key("wf::3", testInvocation().GetHistoryEvent())
+		call, owner := h.fact.inflight.Acquire(key)
+		require.True(t, owner)
+		t.Cleanup(func() { call.Finish(nil) })
+
+		a := h.fact.GetOrCreate("wf::3").(*activity)
+		name := testActivityName
+		require.True(t, a.localDrive(testInvocation(), time.Now().Add(-time.Second), &name))
+		h.fact.driveWG.Wait()
+		h.fact.escWG.Wait()
+
+		assert.Empty(t, h.sched.snapshotCreates(), "a live claim owns delivery; no durable reminder may be planted")
+	})
+
+	t.Run("settled claim still escalates", func(t *testing.T) {
+		t.Parallel()
+		h := newDriveHarness(t)
+		h.cancelOn1 = true
+
+		key := inflight.Key("wf::3", testInvocation().GetHistoryEvent())
+		call, owner := h.fact.inflight.Acquire(key)
+		require.True(t, owner)
+		call.Finish(errStaleClaimEvicted)
+
+		a := h.fact.GetOrCreate("wf::3").(*activity)
+		name := testActivityName
+		require.True(t, a.localDrive(testInvocation(), time.Now().Add(-time.Second), &name))
+		assert.Eventually(t, func() bool {
+			return len(h.sched.snapshotCreates()) == 1
+		}, time.Second*5, time.Millisecond*10, "without a live claim the durable-reminder escalation must be restored")
+		h.fact.driveWG.Wait()
+		h.fact.escWG.Wait()
+	})
+}

--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -406,13 +406,22 @@ func Test_checkClaimRecord(t *testing.T) {
 		f.claims = claim.New(claim.Options{
 			ActorType:  f.actorType,
 			State:      store.fake(),
-			StaleAfter: time.Millisecond,
+			StaleAfter: time.Millisecond * 50,
 		})
 		store.set(t, actorID, claim.Record{TaskKey: actorID + "::oldrun", HeartbeatMs: time.Now().Add(-time.Second).UnixMilli()})
+		// First sighting only opens the observation window; the other
+		// scheduling's record does not block this taskKey.
 		outcome, err := f.claims.Check(t.Context(), actorID, key)
 		require.NoError(t, err)
 		assert.Equal(t, claim.Proceed, outcome)
 		_, ok := store.get(t, actorID)
+		assert.True(t, ok, "the record cannot read dead on a single observation")
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
+		_, ok = store.get(t, actorID)
 		assert.False(t, ok, "a dead old-run record must not leak")
 	})
 
@@ -433,14 +442,85 @@ func Test_checkClaimRecord(t *testing.T) {
 		f.claims = claim.New(claim.Options{
 			ActorType:  f.actorType,
 			State:      store.fake(),
-			StaleAfter: time.Millisecond,
+			StaleAfter: time.Millisecond * 50,
 		})
 		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(-time.Second).UnixMilli()})
 		outcome, err := f.claims.Check(t.Context(), actorID, key)
 		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome, "a single observation cannot read stale")
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
 		assert.Equal(t, claim.Proceed, outcome)
 		_, ok := store.get(t, actorID)
 		assert.False(t, ok, "a stale record is dead weight and must be reclaimed")
+	})
+
+	t.Run("skewed past heartbeat is not insta-reclaimed", func(t *testing.T) {
+		// The writer's clock ran far behind: the raw timestamp is over the
+		// grace on arrival, but only reader-side observation may declare it
+		// dead. A frozen value still reclaims after the grace.
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond * 50,
+		})
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(-time.Hour).UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome, "cross-host clock skew must not reclaim a live execution")
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome, "a value frozen past the grace is dead regardless of skew")
+	})
+
+	t.Run("skewed future heartbeat defers and later reclaims", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond * 50,
+		})
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(time.Hour).UnixMilli()})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome)
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome, "a frozen future timestamp must not shield a dead guard forever")
+	})
+
+	t.Run("heartbeat change resets the observation window", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond * 50,
+		})
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: 1})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome)
+
+		time.Sleep(time.Millisecond * 75)
+		store.set(t, actorID, claim.Record{TaskKey: key, HeartbeatMs: 2})
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome, "a changed heartbeat proves the guard lives; the window must restart")
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Proceed, outcome)
 	})
 
 	t.Run("failed reclaim delete defers instead of proceeding", func(t *testing.T) {
@@ -461,9 +541,14 @@ func Test_checkClaimRecord(t *testing.T) {
 				WithTransactionalStateOperationFn(func(context.Context, bool, *actorsapi.TransactionalRequest, bool) error {
 					return errors.New("etag mismatch")
 				}),
-			StaleAfter: time.Millisecond,
+			StaleAfter: time.Millisecond * 50,
 		})
 		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome)
+
+		time.Sleep(time.Millisecond * 75)
+		outcome, err = f.claims.Check(t.Context(), actorID, key)
 		require.NoError(t, err)
 		assert.Equal(t, claim.Defer, outcome)
 	})
@@ -526,12 +611,20 @@ func Test_executeActivity_recoveryGate(t *testing.T) {
 		t.Parallel()
 		f, store, scheduled := newClaimHarness(t)
 		f.claims = claim.New(claim.Options{
-			ActorType: f.actorType,
-			State:     store.fake(),
+			ActorType:  f.actorType,
+			State:      store.fake(),
+			StaleAfter: time.Millisecond * 50,
 		})
 		store.set(t, actorID, claim.Record{TaskKey: actorID, HeartbeatMs: time.Now().Add(-time.Hour).UnixMilli()})
 
 		a := f.GetOrCreate(actorID).(*activity)
+
+		// The first arrival opens the observation window and defers; the
+		// retry past the grace observes the frozen value and reclaims.
+		err := a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
+		require.ErrorIs(t, err, claim.ErrHeldElsewhere)
+		time.Sleep(time.Millisecond * 75)
+
 		ownerErr := make(chan error, 1)
 		go func() {
 			ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)

--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -720,7 +720,7 @@ func Test_gateJanitorRedispatch(t *testing.T) {
 		f.claims = claim.New(claim.Options{
 			ActorType:  f.actorType,
 			State:      store.fake(),
-			StaleAfter: time.Millisecond,
+			StaleAfter: time.Millisecond * 50,
 		})
 		// A restart inside the retention window leaves this row behind; the
 		// guard cannot delete it again.
@@ -735,8 +735,9 @@ func Test_gateJanitorRedispatch(t *testing.T) {
 		_, ok := store.get(t, actorID)
 		assert.True(t, ok, "a fresh completed row is retained for in-flight recovery arrivals")
 
-		// A later read past the grace still acks and reaps the row.
-		time.Sleep(5 * time.Millisecond)
+		// A later read past the grace (but inside the 2x prune window, so the
+		// observation survives) still acks and reaps the row.
+		time.Sleep(75 * time.Millisecond)
 		handled, err = a.gateJanitorRedispatch(t.Context(), testInvocation())
 		assert.True(t, handled)
 		require.NoError(t, err)

--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -37,14 +38,16 @@ import (
 )
 
 // recordStore backs the state fake with an in-memory execution-claim record
-// table keyed by activity actor ID.
+// table keyed by activity actor ID, with first-write-wins ETag semantics so
+// the conditional deletes in claim are exercised for real.
 type recordStore struct {
 	lock sync.Mutex
 	data map[string][]byte
+	etag map[string]int
 }
 
 func newRecordStore() *recordStore {
-	return &recordStore{data: make(map[string][]byte)}
+	return &recordStore{data: make(map[string][]byte), etag: make(map[string]int)}
 }
 
 func (s *recordStore) fake() *statefake.Fake {
@@ -56,7 +59,8 @@ func (s *recordStore) fake() *statefake.Fake {
 			if !ok {
 				return &actorsapi.StateResponse{}, nil
 			}
-			return &actorsapi.StateResponse{Data: b}, nil
+			etag := strconv.Itoa(s.etag[req.ActorID])
+			return &actorsapi.StateResponse{Data: b, ETag: &etag}, nil
 		}).
 		WithTransactionalStateOperationFn(func(_ context.Context, _ bool, req *actorsapi.TransactionalRequest, _ bool) error {
 			s.lock.Lock()
@@ -69,7 +73,11 @@ func (s *recordStore) fake() *statefake.Fake {
 						return err
 					}
 					s.data[req.ActorID] = b
+					s.etag[req.ActorID]++
 				case actorsapi.TransactionalDelete:
+					if r.ETag != nil && *r.ETag != strconv.Itoa(s.etag[req.ActorID]) {
+						return errors.New("etag mismatch")
+					}
 					delete(s.data, req.ActorID)
 				}
 			}
@@ -97,6 +105,7 @@ func (s *recordStore) set(t *testing.T, actorID string, rec claim.Record) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.data[actorID] = b
+	s.etag[actorID]++
 }
 
 func newClaimHarness(t *testing.T) (*factory, *recordStore, chan *backend.ActivityWorkItem) {
@@ -293,6 +302,41 @@ func Test_claimGuard_lifecycle(t *testing.T) {
 		call.Finish(nil)
 	})
 
+	t.Run("retention delete spares a newer generation's record", func(t *testing.T) {
+		t.Parallel()
+		f, store, _ := newClaimHarness(t)
+		f.claims = claim.New(claim.Options{
+			ActorType:      f.actorType,
+			State:          store.fake(),
+			HeartbeatEvery: time.Millisecond * 10,
+			// Long enough to overwrite the row before the delete leg runs.
+			Retention:  time.Second,
+			StaleAfter: time.Hour,
+		})
+
+		call, owner := f.inflight.Acquire(key)
+		require.True(t, owner)
+		f.GetOrCreate(actorID)
+		haltNothingHosted(t, f)
+
+		call.Finish(nil)
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			rec, ok := store.get(t, actorID)
+			if assert.True(c, ok) {
+				assert.True(c, rec.Completed)
+			}
+		}, time.Second*5, time.Millisecond*5)
+
+		// A newer scheduling generation of the same actor takes the row
+		// while the old guard sits out its retention.
+		store.set(t, actorID, claim.Record{TaskKey: actorID + "::gen2", HeartbeatMs: time.Now().UnixMilli()})
+		f.claims.Wait()
+
+		rec, ok := store.get(t, actorID)
+		require.True(t, ok, "the old guard's retention delete must not destroy the newer generation's live claim")
+		assert.Equal(t, actorID+"::gen2", rec.TaskKey)
+	})
+
 	t.Run("repeated halts spawn a single guard per task key", func(t *testing.T) {
 		t.Parallel()
 		f, store, _ := newClaimHarness(t)
@@ -397,6 +441,31 @@ func Test_checkClaimRecord(t *testing.T) {
 		assert.Equal(t, claim.Proceed, outcome)
 		_, ok := store.get(t, actorID)
 		assert.False(t, ok, "a stale record is dead weight and must be reclaimed")
+	})
+
+	t.Run("failed reclaim delete defers instead of proceeding", func(t *testing.T) {
+		// A heartbeat landing between the stale read and the conditional
+		// delete fails the delete: the arrival must defer, not duplicate the
+		// revived execution.
+		t.Parallel()
+		f, _, _ := newClaimHarness(t)
+		b, err := json.Marshal(claim.Record{TaskKey: key, HeartbeatMs: time.Now().Add(-time.Second).UnixMilli()})
+		require.NoError(t, err)
+		etag := "1"
+		f.claims = claim.New(claim.Options{
+			ActorType: f.actorType,
+			State: statefake.New().
+				WithGetFn(func(context.Context, *actorsapi.GetStateRequest, bool) (*actorsapi.StateResponse, error) {
+					return &actorsapi.StateResponse{Data: b, ETag: &etag}, nil
+				}).
+				WithTransactionalStateOperationFn(func(context.Context, bool, *actorsapi.TransactionalRequest, bool) error {
+					return errors.New("etag mismatch")
+				}),
+			StaleAfter: time.Millisecond,
+		})
+		outcome, err := f.claims.Check(t.Context(), actorID, key)
+		require.NoError(t, err)
+		assert.Equal(t, claim.Defer, outcome)
 	})
 
 	t.Run("read error surfaces", func(t *testing.T) {

--- a/pkg/actors/targets/workflow/activity/drive.go
+++ b/pkg/actors/targets/workflow/activity/drive.go
@@ -24,6 +24,7 @@ import (
 	"google.golang.org/protobuf/types/known/anypb"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -175,6 +176,17 @@ func (f *factory) driveActivity(driveCtx context.Context, actorID string, invoca
 			continue
 		}
 		break
+	}
+
+	// A churn-aborted drive with a live claim has not lost the work: the
+	// detached publish watcher delivers it. Escalating would plant a
+	// reminder that can duplicate the body on a new placement owner; skip,
+	// the janitor re-dispatch covers a lost delivery.
+	key := inflight.Key(actorID, invocation.GetHistoryEvent())
+	if call, ok := f.inflight.Peek(key); ok && !call.Settled() {
+		log.Infof("Activity actor '%s': local drive aborted but its execution claim is live; skipping the durable-reminder escalation", actorID)
+		diag.DefaultWorkflowMonitoring.WorkflowLocalActivity(context.Background(), diag.StatusEscalateSkipped)
+		return
 	}
 
 	log.Warnf("Activity actor '%s': local drive failed; escalating to a durable run-activity reminder: %v", actorID, err)

--- a/pkg/actors/targets/workflow/activity/execute.go
+++ b/pkg/actors/targets/workflow/activity/execute.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	actorsapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/claim"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	"github.com/dapr/dapr/pkg/messages"
@@ -34,7 +35,11 @@ import (
 var errStaleClaimEvicted = wferrors.NewRecoverable(errors.New(
 	"in-flight activity claim evicted as stale (its work item is no longer held by the engine); re-executing"))
 
-func (a *activity) executeActivity(ctx context.Context, name string, invocation *protos.ActivityInvocation, skipLock bool) error {
+// executeActivity runs one activity delivery. gated marks a recovery
+// arrival (scheduler-fired reminder under the fast path): a fresh owner
+// consults the durable execution-claim record first (see claimrecord.go) so
+// a body still live on the previous owner is deferred to, not duplicated.
+func (a *activity) executeActivity(ctx context.Context, name string, invocation *protos.ActivityInvocation, skipLock, gated bool) error {
 	taskEvent := invocation.GetHistoryEvent()
 	activityName := ""
 	if ts := taskEvent.GetTaskScheduled(); ts != nil {
@@ -67,6 +72,12 @@ func (a *activity) executeActivity(ctx context.Context, name string, invocation 
 			return err
 		}
 		if owner {
+			if gated {
+				proceed, gerr := a.gateFreshOwner(ctx, key, call)
+				if !proceed {
+					return gerr
+				}
+			}
 			return a.runOwned(ctx, key, call, name, activityName, workflowID, taskEvent, invocation)
 		}
 
@@ -187,4 +198,31 @@ func (f *factory) actorNotReachable(ctx context.Context, wfActorType, workflowID
 		cancel(nil)
 	}
 	return errors.Is(err, messages.ErrActorNoAddress)
+}
+
+// gateFreshOwner runs the claim-record gate for a fresh-owner recovery
+// arrival. False means the claim was settled and released with the surfaced
+// error (nil = completed ack).
+func (a *activity) gateFreshOwner(ctx context.Context, key string, call *inflight.Call) (bool, error) {
+	outcome, err := a.claims.Check(ctx, a.actorID, key)
+	if err != nil {
+		werr := wferrors.NewRecoverable(fmt.Errorf("failed to read the execution-claim record: %w", err))
+		call.Finish(werr)
+		a.inflight.Release(key, call)
+		return false, werr
+	}
+	switch outcome {
+	case claim.Defer:
+		log.Infof("Activity actor '%s': execution claim is live on another host; deferring", a.actorID)
+		call.Finish(claim.ErrHeldElsewhere)
+		a.inflight.Release(key, call)
+		return false, claim.ErrHeldElsewhere
+	case claim.Completed:
+		log.Infof("Activity actor '%s': execution completed on its previous host; acking without re-executing", a.actorID)
+		call.Finish(nil)
+		a.inflight.ReleaseAfter(key, call, InflightCacheTTL)
+		return false, nil
+	default:
+		return true, nil
+	}
 }

--- a/pkg/actors/targets/workflow/activity/execute_test.go
+++ b/pkg/actors/targets/workflow/activity/execute_test.go
@@ -52,7 +52,7 @@ func Test_executeActivity_lockFreeDuringExecution(t *testing.T) {
 
 	ownerErr := make(chan error, 1)
 	go func() {
-		ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false)
+		ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, false)
 	}()
 
 	var wi *backend.ActivityWorkItem
@@ -74,7 +74,7 @@ func Test_executeActivity_lockFreeDuringExecution(t *testing.T) {
 	// WorkItem.
 	followerErr := make(chan error, 1)
 	go func() {
-		followerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false)
+		followerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, false)
 	}()
 
 	wi.Result = &protos.HistoryEvent{

--- a/pkg/actors/targets/workflow/activity/factory.go
+++ b/pkg/actors/targets/workflow/activity/factory.go
@@ -15,6 +15,7 @@ package activity
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -27,6 +28,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/router"
 	"github.com/dapr/dapr/pkg/actors/state"
 	"github.com/dapr/dapr/pkg/actors/targets"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/claim"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
@@ -135,6 +137,10 @@ type factory struct {
 	rootCtx context.Context
 	escLock sync.Mutex
 	escWG   sync.WaitGroup
+
+	// claims owns the durable execution-claim guards and gate (see the
+	// claim subpackage).
+	claims *claim.Guards
 }
 
 func New(ctx context.Context, opts Options) (targets.Factory, error) {
@@ -165,13 +171,27 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 
 	driveCtx, driveCancel := context.WithCancel(context.Background())
 
+	claimRetention := common.EnvDurationOr(
+		"DAPR_WORKFLOW_ACTIVITY_CLAIM_RETENTION",
+		InflightCacheTTL,
+	)
+
 	return &factory{
-		appID:                  opts.AppID,
-		actorType:              opts.ActivityActorType,
-		fastPath:               opts.FastPath,
-		executionHeld:          opts.ExecutionHeld,
-		registerResolver:       opts.RegisterResolver,
-		staleClaimAfter:        2 * common.JanitorPeriod(),
+		appID:            opts.AppID,
+		actorType:        opts.ActivityActorType,
+		fastPath:         opts.FastPath,
+		executionHeld:    opts.ExecutionHeld,
+		registerResolver: opts.RegisterResolver,
+		staleClaimAfter:  2 * common.JanitorPeriod(),
+		claims: claim.New(claim.Options{
+			ActorType: opts.ActivityActorType,
+			State:     state,
+			// Half-period beats give a live guard three misses, not one,
+			// before its record reads stale under load.
+			HeartbeatEvery: common.JanitorPeriod() / 2,
+			Retention:      claimRetention,
+			StaleAfter:     2 * common.JanitorPeriod(),
+		}),
 		driveCtx:               driveCtx,
 		driveCancel:            driveCancel,
 		rootCtx:                ctx,
@@ -245,6 +265,7 @@ func (f *factory) HaltNonHosted(ctx context.Context, fn func(*api.LookupActorReq
 			ActorType: f.actorType,
 			ActorID:   key.(string),
 		}) {
+			f.spawnClaimGuards(ctx, key.(string))
 			val.(*activity).Deactivate(ctx)
 			f.table.Delete(key)
 		}
@@ -262,4 +283,25 @@ func (f *factory) Len() int {
 	var count int
 	f.table.Range(func(_, _ any) bool { count++; return true })
 	return count
+}
+
+// spawnClaimGuards spawns a claim guard for every unsettled in-flight claim
+// of actorID, from HaltNonHosted (placement churn). Deliberately NOT from
+// HaltAll: at shutdown the execution dies with the process and a record
+// would only delay the new owner by the staleness grace.
+func (f *factory) spawnClaimGuards(ctx context.Context, actorID string) {
+	if !f.fastPath {
+		return
+	}
+	prefix := actorID + "::"
+	f.inflight.Range(func(key string, call *inflight.Call) bool {
+		if key != actorID && !strings.HasPrefix(key, prefix) {
+			return true
+		}
+		if call.Settled() {
+			return true
+		}
+		f.claims.Spawn(ctx, f.rootCtx, actorID, key, call)
+		return true
+	})
 }

--- a/pkg/actors/targets/workflow/activity/inflight/map.go
+++ b/pkg/actors/targets/workflow/activity/inflight/map.go
@@ -37,6 +37,22 @@ func (m *Map) Acquire(key string) (call *Call, owner bool) {
 	return actual.(*Call), !loaded
 }
 
+// Peek returns the inflight call for key without creating one.
+func (m *Map) Peek(key string) (*Call, bool) {
+	v, ok := m.m.Load(key)
+	if !ok {
+		return nil, false
+	}
+	return v.(*Call), true
+}
+
+// Range calls fn for each inflight entry until fn returns false.
+func (m *Map) Range(fn func(key string, call *Call) bool) {
+	m.m.Range(func(k, v any) bool {
+		return fn(k.(string), v.(*Call))
+	})
+}
+
 // Release removes the inflight entry for key if it still matches call.
 // CompareAndDelete protects against clobbering a follow-on dispatch that
 // legitimately reused the slot.

--- a/pkg/actors/targets/workflow/activity/invoke.go
+++ b/pkg/actors/targets/workflow/activity/invoke.go
@@ -18,11 +18,14 @@ import (
 	"errors"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"google.golang.org/protobuf/proto"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/claim"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity/inflight"
 	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
@@ -66,6 +69,15 @@ func (a *activity) handleInvoke(ctx context.Context, req *internalsv1pb.Internal
 		return nil, fmt.Errorf("failed to decode activity invocation: %w", err)
 	}
 
+	// Gate a janitor re-dispatch on the durable execution-claim record: it
+	// may race a body still live on the previous placement owner. A local
+	// inflight entry acks without a state read.
+	if a.fastPath && janitorRedispatchMarked(req) {
+		if handled, gerr := a.gateJanitorRedispatch(ctx, invocation); handled {
+			return nil, gerr
+		}
+	}
+
 	// Fast path: when the dispatching orchestrator certifies its janitor
 	// backstop is armed (metadata) and this host runs the preview, drive
 	// the execution locally instead of creating the durable run-activity
@@ -83,6 +95,48 @@ func (a *activity) handleInvoke(ctx context.Context, req *internalsv1pb.Internal
 
 	// The actual execution is triggered by a reminder
 	return nil, a.createReminder(ctx, invocation, dueTime, activityName)
+}
+
+// janitorRedispatchMarked reports whether the dispatching orchestrator marked
+// this Execute call as a janitor re-dispatch of an unresolved task.
+func janitorRedispatchMarked(req *internalsv1pb.InternalInvokeRequest) bool {
+	v, ok := req.GetMetadata()[todo.MetadataActivityJanitorRedispatch]
+	return ok && len(v.GetValues()) > 0 && v.GetValues()[0] == "true"
+}
+
+// gateJanitorRedispatch consults the durable execution-claim record for a
+// janitor re-dispatch. handled=true means do not execute here: gerr nil acks
+// (a local claim owns delivery, or the guarded execution already completed
+// and published), recoverable defers (live elsewhere or unreadable record).
+func (a *activity) gateJanitorRedispatch(ctx context.Context, invocation *protos.ActivityInvocation) (handled bool, gerr error) {
+	key := inflight.Key(a.actorID, invocation.GetHistoryEvent())
+	if call, ok := a.inflight.Peek(key); ok {
+		endIndex := strings.Index(a.actorID, "::")
+		if !a.staleClaim(call, a.actorID[:max(endIndex, 0)], invocation.GetHistoryEvent().GetEventId()) {
+			// A live local entry owns delivery: ack, do not arm a drive
+			// (joining a transient gate-claim entry that settles with the
+			// defer error would re-execute via the ungated retry). The
+			// janitor re-checks next period.
+			return true, nil
+		}
+		// Stranded local entry (delivery lost, not held): fall through so
+		// the execution path's stale eviction re-executes; acking here would
+		// also swallow the escalation that creates the durable reminder.
+	}
+	outcome, err := a.claims.Check(ctx, a.actorID, key)
+	if err != nil {
+		return true, wferrors.NewRecoverable(fmt.Errorf("failed to read the execution-claim record: %w", err))
+	}
+	switch outcome {
+	case claim.Defer:
+		log.Infof("Activity actor '%s': janitor re-dispatch deferred; the execution claim is live on another host", a.actorID)
+		return true, claim.ErrHeldElsewhere
+	case claim.Completed:
+		log.Infof("Activity actor '%s': janitor re-dispatch acked; the execution completed on its previous host", a.actorID)
+		return true, nil
+	default:
+		return false, nil
+	}
 }
 
 // localDriveCertified reports whether the dispatching orchestrator attached
@@ -152,7 +206,11 @@ func (a *activity) handleReminder(ctx context.Context, reminder *actorapi.Remind
 		return errors.New("activity reminder missing history event")
 	}
 
-	err := a.executeActivity(ctx, reminder.Name, &invocation, reminder.SkipLock)
+	// Scheduler-fired reminders are the recovery deliveries that can land
+	// on a fresh placement owner mid-handoff: gate them. Local drives
+	// (SkipRetries) stay ungated; handleInvoke gates their re-dispatches.
+	gated := a.fastPath && !reminder.SkipRetries
+	err := a.executeActivity(ctx, reminder.Name, &invocation, reminder.SkipLock, gated)
 
 	// Returning nil signals that we want the execution to be retried in the next
 	// period interval

--- a/pkg/actors/targets/workflow/activity/reminder.go
+++ b/pkg/actors/targets/workflow/activity/reminder.go
@@ -42,6 +42,13 @@ func (a *activity) createReminder(ctx context.Context, invocation *protos.Activi
 // rather than the *activity because the drive-failure escalation path may
 // outlive the actor object (HaltAll recycles it).
 func (f *factory) createActivityReminder(ctx context.Context, actorID string, invocation *protos.ActivityInvocation, dueTime time.Time, activityName *string) error {
+	// Clamp a past dueTime to now: the scheduler paces failure retries from
+	// the scheduled time, so a stale dueTime replays the whole elapsed
+	// backlog as a burst on every failed trigger.
+	if now := time.Now(); dueTime.Before(now) {
+		dueTime = now
+	}
+
 	log.Debugf("Activity actor '%s||%s': creating reminder '%s' with dueTime=%s", f.actorType, actorID, activityReminderName, dueTime)
 
 	anydata, err := anypb.New(invocation)

--- a/pkg/actors/targets/workflow/activity/reminder_test.go
+++ b/pkg/actors/targets/workflow/activity/reminder_test.go
@@ -302,3 +302,43 @@ func Test_reminderRetryPoliciesAreJittered(t *testing.T) {
 	// Draws must actually decorrelate across creates.
 	assert.Greater(t, len(seen), 1)
 }
+
+// Test_createReminderClampsPastDueTime: a past dueTime would replay the
+// elapsed backlog as a retry burst on every failed trigger.
+func Test_createReminderClampsPastDueTime(t *testing.T) {
+	t.Parallel()
+
+	sched := &captureScheduler{}
+	f := &factory{
+		actorType: "dapr.internal.default.testapp.activity",
+		reminders: sched,
+	}
+
+	invocation := &protos.ActivityInvocation{
+		HistoryEvent: &protos.HistoryEvent{
+			EventId: 1,
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "act"},
+			},
+		},
+	}
+
+	start := time.Now()
+	require.NoError(t, f.createActivityReminder(t.Context(), "activity-1", invocation, start.Add(-time.Hour), nil))
+
+	future := start.Add(time.Hour)
+	require.NoError(t, f.createActivityReminder(t.Context(), "activity-1", invocation, future, nil))
+
+	sched.mu.Lock()
+	defer sched.mu.Unlock()
+	require.Len(t, sched.creates, 2)
+
+	clamped, err := time.Parse(time.RFC3339Nano, sched.creates[0].DueTime)
+	require.NoError(t, err)
+	assert.False(t, clamped.Before(start), "a past dueTime must be clamped to the create time")
+	assert.False(t, clamped.After(time.Now()))
+
+	kept, err := time.Parse(time.RFC3339Nano, sched.creates[1].DueTime)
+	require.NoError(t, err)
+	assert.True(t, kept.Equal(future), "a future dueTime must be preserved so delays are honoured")
+}

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -65,7 +65,7 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 			continue
 		}
 
-		err := o.callActivity(ctx, e, dueTime, outgoingHistory[e.GetEventId()], workflowName, elide)
+		err := o.callActivity(ctx, e, dueTime, outgoingHistory[e.GetEventId()], workflowName, elide, false)
 		if err != nil {
 			if errors.Is(err, todo.ErrDuplicateInvocation) {
 				log.Warnf("Workflow actor '%s': activity invocation '%s::%d' was flagged as a duplicate and will be skipped", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
@@ -80,7 +80,7 @@ func (o *orchestrator) callActivities(ctx context.Context, es []*backend.History
 	return result
 }
 
-func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent, dueTime time.Time, ph *protos.PropagatedHistory, workflowName string, elide bool) error {
+func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent, dueTime time.Time, ph *protos.PropagatedHistory, workflowName string, elide, redispatch bool) error {
 	ts := e.GetTaskScheduled()
 	if ts == nil {
 		log.Warnf("Workflow actor '%s': unable to process task '%v'", o.actorID, e)
@@ -124,6 +124,9 @@ func (o *orchestrator) callActivity(ctx context.Context, e *backend.HistoryEvent
 	}
 	if elide {
 		meta[todo.MetadataActivityLocalDrive] = []string{"true"}
+	}
+	if redispatch {
+		meta[todo.MetadataActivityJanitorRedispatch] = []string{"true"}
 	}
 
 	_, err = o.router.Call(ctx, internalsv1pb.

--- a/pkg/actors/targets/workflow/orchestrator/redispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/redispatch.go
@@ -159,7 +159,7 @@ func (o *orchestrator) redispatchActivities(ctx context.Context, state *wfengine
 		defer o.wakeWG.Done()
 		for _, e := range unresolved {
 			cctx, cancel := context.WithTimeout(wakeCtx, redispatchCallTimeout)
-			cerr := o.callActivity(cctx, e, dueTime, phs[e.GetEventId()], wfName, elide && !durable[e.GetEventId()])
+			cerr := o.callActivity(cctx, e, dueTime, phs[e.GetEventId()], wfName, elide && !durable[e.GetEventId()], true)
 			cancel()
 			switch {
 			case cerr == nil && durable[e.GetEventId()]:

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -40,8 +40,12 @@ const (
 	// locally (WorkflowsFastPath). Absent or unrecognised, the
 	// durable reminder path is used.
 	MetadataActivityLocalDrive = "localDrive"
-	MetadataPurgeRetentionCall = "PurgeRetentionCall"
-	MetadataPurgeForce         = "PurgeForce"
+	// MetadataActivityJanitorRedispatch marks a janitor re-dispatch, gated
+	// on the execution-claim record so a body live on the previous owner is
+	// deferred to (WorkflowsFastPath). Ignored by older hosts.
+	MetadataActivityJanitorRedispatch = "janitorRedispatch"
+	MetadataPurgeRetentionCall        = "PurgeRetentionCall"
+	MetadataPurgeForce                = "PurgeForce"
 	// Set on a WaitForRuntimeStatus call to request that a terminal workflow
 	// also verify all of its child workflows, recursively, are terminal
 	// before replying. Ignored by daprds that predate the flag.

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -573,6 +573,17 @@ func (d *Daprd) Restart(t *testing.T, ctx context.Context) {
 	d.exec.Run(t, ctx)
 }
 
+// RestartGraceful is Restart with an interrupt and exit wait instead of a hard
+// kill, for tests that need the shutdown path (actor HaltAll, drains) to run
+// before the new process starts.
+func (d *Daprd) RestartGraceful(t *testing.T, ctx context.Context) {
+	t.Helper()
+	clone := d.exec.Clone(t)
+	d.exec.Cleanup(t)
+	d.exec = clone
+	d.exec.Run(t, ctx)
+}
+
 // ReplaceArg sets `--<flag>=<value>` on the daprd command line for the next
 // Run/Restart, replacing any existing occurrence of that flag. Existing args
 // remain in place, so this is safe to call between Kill and Restart.

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -448,3 +448,15 @@ func WithPlacement(placement *placement.Placement) Option {
 		o.placementAddresses = append(o.placementAddresses, placement.Address())
 	}
 }
+
+// WithWorkflowJanitorPeriod sets the WorkflowsFastPath janitor backstop
+// period for this daprd.
+func WithWorkflowJanitorPeriod(t *testing.T, d time.Duration) Option {
+	return WithExecOptions(exec.WithEnvVars(t, "DAPR_WORKFLOW_JANITOR_PERIOD", d.String()))
+}
+
+// WithWorkflowClaimRetention sets how long a Completed execution-claim
+// record is retained before its guard deletes it.
+func WithWorkflowClaimRetention(t *testing.T, d time.Duration) Option {
+	return WithExecOptions(exec.WithEnvVars(t, "DAPR_WORKFLOW_ACTIVITY_CLAIM_RETENTION", d.String()))
+}

--- a/tests/integration/framework/workflow/claimrecords.go
+++ b/tests/integration/framework/workflow/claimrecords.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -34,6 +35,33 @@ func CountClaimRecords(t *testing.T, ctx context.Context, db *sqlite.SQLite) int
 		"%||execution-claim",
 	).Scan(&count))
 	return count
+}
+
+// EnsureClaimRecords blocks until at least one execution-claim record exists.
+// Guards only spawn when a dissemination moves an in-flight activity actor,
+// and per churn round every actor can stay put, so on an empty round the next
+// extend closure runs (schedule another batch of blocked instances, then join
+// one more daprd to churn placement again) before re-polling. The closures
+// bound the retries; running out of them fails the test.
+func EnsureClaimRecords(t *testing.T, ctx context.Context, db *sqlite.SQLite, extends []func()) {
+	t.Helper()
+	for {
+		deadline := time.Now().Add(time.Second * 10)
+		for time.Now().Before(deadline) {
+			if CountClaimRecords(t, ctx, db) >= 1 {
+				return
+			}
+			select {
+			case <-ctx.Done():
+				require.Fail(t, "context done while waiting for an execution-claim record")
+			case <-time.After(time.Millisecond * 50):
+			}
+		}
+		require.NotEmpty(t, extends,
+			"no execution-claim record appeared after every churn round: placement churn over in-flight activities must write records")
+		extends[0]()
+		extends = extends[1:]
+	}
 }
 
 // AuditClaimWrites installs sqlite triggers that append every execution-claim

--- a/tests/integration/framework/workflow/claimrecords.go
+++ b/tests/integration/framework/workflow/claimrecords.go
@@ -15,6 +15,7 @@ package workflow
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -33,4 +34,32 @@ func CountClaimRecords(t *testing.T, ctx context.Context, db *sqlite.SQLite) int
 		"%||execution-claim",
 	).Scan(&count))
 	return count
+}
+
+// AuditClaimWrites installs sqlite triggers that append every execution-claim
+// insert or update on the state table to an audit table, inside the writer's
+// own transaction: unlike polling, a record written and deleted again in any
+// window cannot go unseen. Returns a reader for the number of writes audited.
+func AuditClaimWrites(t *testing.T, ctx context.Context, db *sqlite.SQLite) func() int {
+	t.Helper()
+	conn := db.GetConnection(t)
+	_, err := conn.ExecContext(ctx,
+		"CREATE TABLE IF NOT EXISTS claim_write_audit (key TEXT NOT NULL)")
+	require.NoError(t, err)
+	for _, trig := range [...]struct{ name, event string }{
+		{"claim_write_audit_ins", "INSERT"},
+		{"claim_write_audit_upd", "UPDATE"},
+	} {
+		_, err = conn.ExecContext(ctx, fmt.Sprintf(
+			"CREATE TRIGGER IF NOT EXISTS %s AFTER %s ON %s WHEN NEW.key LIKE '%%||execution-claim' "+
+				"BEGIN INSERT INTO claim_write_audit (key) VALUES (NEW.key); END",
+			trig.name, trig.event, db.TableName()))
+		require.NoError(t, err)
+	}
+	return func() int {
+		var count int
+		require.NoError(t, conn.QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM claim_write_audit").Scan(&count))
+		return count
+	}
 }

--- a/tests/integration/framework/workflow/claimrecords.go
+++ b/tests/integration/framework/workflow/claimrecords.go
@@ -1,0 +1,36 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+)
+
+// CountClaimRecords counts execution-claim rows in the actor state store
+// (key shape: appID||actorType||actorID||execution-claim, from recordStateKey
+// in the activity/claim package).
+func CountClaimRecords(t *testing.T, ctx context.Context, db *sqlite.SQLite) int {
+	t.Helper()
+	var count int
+	require.NoError(t, db.GetConnection(t).QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM "+db.TableName()+" WHERE key LIKE ?",
+		"%||execution-claim",
+	).Scan(&count))
+	return count
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
@@ -1,0 +1,172 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handoff
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+type basic struct {
+	workflow *workflow.Workflow
+	joiners  [2]*daprd.Daprd
+}
+
+func (a *basic) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Second),
+	}
+	a.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	// The joiners trigger the mid-run placement rebalance: deliberately not
+	// in WithProcesses, Run starts them at the churn moment.
+	for i := range a.joiners {
+		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+			daprd.WithAppID(a.workflow.Dapr().AppID()),
+			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
+			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
+			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
+		}, fp...)...)
+	}
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *basic) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	// Several concurrently blocked activities so at least one actor moves
+	// when the joiners rebalance the placement.
+	const instances = 4
+
+	var executions atomic.Int64
+	started := make(chan struct{}, instances)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.CallActivity("Slow", task.WithActivityInput("Dapr")).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-release:
+			return "slow-done", nil
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, a.workflow.Registry().AddWorkflowN("Handoff", wfFn))
+	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := a.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, instances)
+	for i := range ids {
+		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "Handoff",
+		})
+		require.NoError(t, err)
+		ids[i] = resp.GetInstanceId()
+	}
+
+	for range instances {
+		select {
+		case <-started:
+		case <-time.After(time.Second * 30):
+			require.Fail(t, "timed out waiting for every activity body to start executing")
+		}
+	}
+	require.Equal(t, int64(instances), executions.Load(),
+		"every activity must be mid-execution before the joiners join")
+
+	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+
+	// Join the extra daprds so the placement rebalances the in-flight
+	// activity actors away from the first host while their bodies are still
+	// blocked.
+	for i, joiner := range a.joiners {
+		joiner.Run(t, ctx)
+		t.Cleanup(func() { joiner.Cleanup(t) })
+		joiner.WaitUntilRunning(t, ctx)
+
+		registry := task.NewTaskRegistry()
+		require.NoError(t, registry.AddWorkflowN("Handoff", wfFn))
+		require.NoError(t, registry.AddActivityN("Slow", actFn))
+		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
+			if !assert.NotNil(c, table) {
+				return
+			}
+			//nolint:gosec
+			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1),
+				"placement table version must advance for each new daprd")
+		}, time.Second*15, time.Millisecond*10)
+	}
+
+	// Hold the handoff window open across several janitor periods so the
+	// re-dispatch (and its second-fire durable-reminder escalation) lands on
+	// the new placement owners while the original bodies still execute.
+	time.Sleep(time.Second * 4)
+	close(release)
+
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+	}
+
+	assert.Equal(t, int64(instances), executions.Load(),
+		"every activity body must run exactly once even when daprds join the cluster mid-execution")
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
@@ -69,8 +70,9 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
 	// Several concurrently blocked activities so at least one actor moves
-	// when the joiners rebalance the placement.
-	const instances = 4
+	// when the joiners rebalance the placement: each of N actors stays put
+	// with probability ~1/3, and the record gate below requires movement.
+	const instances = 6
 
 	var executions atomic.Int64
 	started := make(chan struct{}, instances)
@@ -154,6 +156,13 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 				"placement table version must advance for each new daprd")
 		}, time.Second*15, time.Millisecond*10)
 	}
+
+	// The rebalance must have moved at least one in-flight actor, or the
+	// exactly-once assertion below would pass without exercising the guard.
+	require.Eventually(t, func() bool {
+		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
+	}, time.Second*15, time.Millisecond*50,
+		"placement churn over in-flight activities must write execution-claim records")
 
 	// Hold the handoff window open across several janitor periods so the
 	// re-dispatch (and its second-fire durable-reminder escalation) lands on

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
@@ -41,6 +41,10 @@ func init() {
 type basic struct {
 	workflow *workflow.Workflow
 	joiners  [2]*daprd.Daprd
+	// churners join one at a time, each after another batch of blocked
+	// instances, only when a churn round moved no in-flight actor and the
+	// record gate is still unsatisfied.
+	churners [3]*daprd.Daprd
 }
 
 func (a *basic) Setup(t *testing.T) []framework.Option {
@@ -52,13 +56,19 @@ func (a *basic) Setup(t *testing.T) []framework.Option {
 
 	// The joiners trigger the mid-run placement rebalance: deliberately not
 	// in WithProcesses, Run starts them at the churn moment.
-	for i := range a.joiners {
-		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+	newDaprd := func() *daprd.Daprd {
+		return daprd.New(t, append([]daprd.Option{
 			daprd.WithAppID(a.workflow.Dapr().AppID()),
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
 		}, fp...)...)
+	}
+	for i := range a.joiners {
+		a.joiners[i] = newDaprd()
+	}
+	for i := range a.churners {
+		a.churners[i] = newDaprd()
 	}
 
 	return []framework.Option{
@@ -69,13 +79,12 @@ func (a *basic) Setup(t *testing.T) []framework.Option {
 func (a *basic) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
-	// Several concurrently blocked activities so at least one actor moves
-	// when the joiners rebalance the placement: each of N actors stays put
-	// with probability ~1/3, and the record gate below requires movement.
-	const instances = 6
+	// Concurrently blocked activities per churn round; whether any of their
+	// actors moves is probabilistic, the record gate below retries with
+	// another batch and churner until one has.
+	const batch = 6
 
 	var executions atomic.Int64
-	started := make(chan struct{}, instances)
 	release := make(chan struct{})
 	t.Cleanup(func() {
 		select {
@@ -95,10 +104,6 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 	actFn := func(c task.ActivityContext) (any, error) {
 		executions.Add(1)
 		select {
-		case started <- struct{}{}:
-		default:
-		}
-		select {
 		case <-release:
 			return "slow-done", nil
 		case <-c.Context().Done():
@@ -110,59 +115,67 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
 	client1 := a.workflow.BackendClient(t, ctx)
 
-	ids := make([]string, instances)
-	for i := range ids {
-		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
-			WorkflowComponent: "dapr",
-			WorkflowName:      "Handoff",
-		})
-		require.NoError(t, err)
-		ids[i] = resp.GetInstanceId()
-	}
-
-	for range instances {
-		select {
-		case <-started:
-		case <-time.After(time.Second * 30):
-			require.Fail(t, "timed out waiting for every activity body to start executing")
+	var ids []string
+	start := func(n int) {
+		t.Helper()
+		for range n {
+			resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+				WorkflowComponent: "dapr",
+				WorkflowName:      "Handoff",
+			})
+			require.NoError(t, err)
+			ids = append(ids, resp.GetInstanceId())
 		}
+		require.Eventually(t, func() bool {
+			return executions.Load() >= int64(len(ids))
+		}, time.Second*30, time.Millisecond*10,
+			"every scheduled activity body must be mid-execution before the churn")
 	}
-	require.Equal(t, int64(instances), executions.Load(),
-		"every activity must be mid-execution before the joiners join")
+	start(batch)
 
-	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
-
-	// Join the extra daprds so the placement rebalances the in-flight
-	// activity actors away from the first host while their bodies are still
-	// blocked.
-	for i, joiner := range a.joiners {
-		joiner.Run(t, ctx)
-		t.Cleanup(func() { joiner.Cleanup(t) })
-		joiner.WaitUntilRunning(t, ctx)
+	version := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+	join := func(d *daprd.Daprd) {
+		t.Helper()
+		d.Run(t, ctx)
+		t.Cleanup(func() { d.Cleanup(t) })
+		d.WaitUntilRunning(t, ctx)
 
 		registry := task.NewTaskRegistry()
 		require.NoError(t, registry.AddWorkflowN("Handoff", wfFn))
 		require.NoError(t, registry.AddActivityN("Slow", actFn))
-		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		joinerClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), backend.DefaultLogger())
 		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
 
+		version++
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
 			if !assert.NotNil(c, table) {
 				return
 			}
-			//nolint:gosec
-			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1),
+			assert.GreaterOrEqual(c, table.Version, version,
 				"placement table version must advance for each new daprd")
 		}, time.Second*15, time.Millisecond*10)
 	}
 
-	// The rebalance must have moved at least one in-flight actor, or the
-	// exactly-once assertion below would pass without exercising the guard.
-	require.Eventually(t, func() bool {
-		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
-	}, time.Second*15, time.Millisecond*50,
-		"placement churn over in-flight activities must write execution-claim records")
+	// Join the extra daprds so the placement rebalances the in-flight
+	// activity actors away from the first host while their bodies are still
+	// blocked.
+	for _, joiner := range a.joiners {
+		join(joiner)
+	}
+
+	// At least one in-flight actor must have moved (its guard writes a
+	// record), or the exactly-once assertion below would pass without
+	// exercising the guard. All-stay is possible per round, so each rescue
+	// round blocks another batch and churns again.
+	extends := make([]func(), 0, len(a.churners))
+	for _, churner := range a.churners {
+		extends = append(extends, func() {
+			start(batch)
+			join(churner)
+		})
+	}
+	wf.EnsureClaimRecords(t, ctx, a.workflow.DB(), extends)
 
 	// Hold the handoff window open across several janitor periods so the
 	// re-dispatch (and its second-fire durable-reminder escalation) lands on
@@ -176,6 +189,6 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
 	}
 
-	assert.Equal(t, int64(instances), executions.Load(),
+	assert.Equal(t, int64(len(ids)), executions.Load(),
 		"every activity body must run exactly once even when daprds join the cluster mid-execution")
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
@@ -1,0 +1,180 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handoff
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(cleanup))
+}
+
+type cleanup struct {
+	workflow *workflow.Workflow
+	joiners  [2]*daprd.Daprd
+}
+
+func (a *cleanup) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Second),
+		// Compress the Completed-record retention so the delete leg fits
+		// the test window.
+		daprd.WithWorkflowClaimRetention(t, time.Second*2),
+	}
+	a.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	// The joiners trigger the mid-run placement rebalance: deliberately not
+	// in WithProcesses, Run starts them at the churn moment.
+	for i := range a.joiners {
+		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+			daprd.WithAppID(a.workflow.Dapr().AppID()),
+			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
+			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
+			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
+		}, fp...)...)
+	}
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *cleanup) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	// Higher than the other handoff tests: the record presence assertion
+	// needs at least one actor to move, and each of N actors stays put with
+	// probability ~1/3.
+	const instances = 6
+
+	var executions atomic.Int64
+	started := make(chan struct{}, instances)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.CallActivity("Slow", task.WithActivityInput("Dapr")).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-release:
+			return "slow-done", nil
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, a.workflow.Registry().AddWorkflowN("HandoffCleanup", wfFn))
+	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := a.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, instances)
+	for i := range ids {
+		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "HandoffCleanup",
+		})
+		require.NoError(t, err)
+		ids[i] = resp.GetInstanceId()
+	}
+
+	for range instances {
+		select {
+		case <-started:
+		case <-time.After(time.Second * 30):
+			require.Fail(t, "timed out waiting for every activity body to start executing")
+		}
+	}
+	require.Zero(t, wf.CountClaimRecords(t, ctx, a.workflow.DB()),
+		"no records may exist before any placement churn")
+
+	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+
+	for i, joiner := range a.joiners {
+		joiner.Run(t, ctx)
+		t.Cleanup(func() { joiner.Cleanup(t) })
+		joiner.WaitUntilRunning(t, ctx)
+
+		registry := task.NewTaskRegistry()
+		require.NoError(t, registry.AddWorkflowN("HandoffCleanup", wfFn))
+		require.NoError(t, registry.AddActivityN("Slow", actFn))
+		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
+			if !assert.NotNil(c, table) {
+				return
+			}
+			//nolint:gosec
+			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+		}, time.Second*15, time.Millisecond*10)
+	}
+
+	// The rebalance moved some in-flight actors: their guards must surface as
+	// records while the bodies still execute on the old host.
+	require.Eventually(t, func() bool {
+		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
+	}, time.Second*15, time.Millisecond*50,
+		"placement churn over in-flight activities must write execution-claim records")
+
+	close(release)
+
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+	}
+	assert.Equal(t, int64(instances), executions.Load())
+
+	// Retention (2s) then delete: no record may leak past completion.
+	assert.Eventually(t, func() bool {
+		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) == 0
+	}, time.Second*30, time.Millisecond*100,
+		"every execution-claim record must self-delete after the retention window")
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
@@ -41,6 +41,10 @@ func init() {
 type cleanup struct {
 	workflow *workflow.Workflow
 	joiners  [2]*daprd.Daprd
+	// churners join one at a time, each after another batch of blocked
+	// instances, only when a churn round moved no in-flight actor and the
+	// record gate is still unsatisfied.
+	churners [3]*daprd.Daprd
 }
 
 func (a *cleanup) Setup(t *testing.T) []framework.Option {
@@ -55,13 +59,19 @@ func (a *cleanup) Setup(t *testing.T) []framework.Option {
 
 	// The joiners trigger the mid-run placement rebalance: deliberately not
 	// in WithProcesses, Run starts them at the churn moment.
-	for i := range a.joiners {
-		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+	newDaprd := func() *daprd.Daprd {
+		return daprd.New(t, append([]daprd.Option{
 			daprd.WithAppID(a.workflow.Dapr().AppID()),
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
 		}, fp...)...)
+	}
+	for i := range a.joiners {
+		a.joiners[i] = newDaprd()
+	}
+	for i := range a.churners {
+		a.churners[i] = newDaprd()
 	}
 
 	return []framework.Option{
@@ -72,13 +82,12 @@ func (a *cleanup) Setup(t *testing.T) []framework.Option {
 func (a *cleanup) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
-	// Higher than the other handoff tests: the record presence assertion
-	// needs at least one actor to move, and each of N actors stays put with
-	// probability ~1/3.
-	const instances = 6
+	// Concurrently blocked activities per churn round; whether any of their
+	// actors moves is probabilistic, the record gate below retries with
+	// another batch and churner until one has.
+	const batch = 6
 
 	var executions atomic.Int64
-	started := make(chan struct{}, instances)
 	release := make(chan struct{})
 	t.Cleanup(func() {
 		select {
@@ -98,10 +107,6 @@ func (a *cleanup) Run(t *testing.T, ctx context.Context) {
 	actFn := func(c task.ActivityContext) (any, error) {
 		executions.Add(1)
 		select {
-		case started <- struct{}{}:
-		default:
-		}
-		select {
 		case <-release:
 			return "slow-done", nil
 		case <-c.Context().Done():
@@ -113,55 +118,66 @@ func (a *cleanup) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
 	client1 := a.workflow.BackendClient(t, ctx)
 
-	ids := make([]string, instances)
-	for i := range ids {
-		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
-			WorkflowComponent: "dapr",
-			WorkflowName:      "HandoffCleanup",
-		})
-		require.NoError(t, err)
-		ids[i] = resp.GetInstanceId()
-	}
-
-	for range instances {
-		select {
-		case <-started:
-		case <-time.After(time.Second * 30):
-			require.Fail(t, "timed out waiting for every activity body to start executing")
+	var ids []string
+	start := func(n int) {
+		t.Helper()
+		for range n {
+			resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+				WorkflowComponent: "dapr",
+				WorkflowName:      "HandoffCleanup",
+			})
+			require.NoError(t, err)
+			ids = append(ids, resp.GetInstanceId())
 		}
+		require.Eventually(t, func() bool {
+			return executions.Load() >= int64(len(ids))
+		}, time.Second*30, time.Millisecond*10,
+			"every scheduled activity body must be mid-execution before the churn")
 	}
+	start(batch)
+
 	require.Zero(t, wf.CountClaimRecords(t, ctx, a.workflow.DB()),
 		"no records may exist before any placement churn")
 
-	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
-
-	for i, joiner := range a.joiners {
-		joiner.Run(t, ctx)
-		t.Cleanup(func() { joiner.Cleanup(t) })
-		joiner.WaitUntilRunning(t, ctx)
+	version := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+	join := func(d *daprd.Daprd) {
+		t.Helper()
+		d.Run(t, ctx)
+		t.Cleanup(func() { d.Cleanup(t) })
+		d.WaitUntilRunning(t, ctx)
 
 		registry := task.NewTaskRegistry()
 		require.NoError(t, registry.AddWorkflowN("HandoffCleanup", wfFn))
 		require.NoError(t, registry.AddActivityN("Slow", actFn))
-		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		joinerClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), backend.DefaultLogger())
 		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
 
+		version++
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
 			if !assert.NotNil(c, table) {
 				return
 			}
-			//nolint:gosec
-			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+			assert.GreaterOrEqual(c, table.Version, version)
 		}, time.Second*15, time.Millisecond*10)
 	}
 
-	// The rebalance moved some in-flight actors: their guards must surface as
-	// records while the bodies still execute on the old host.
-	require.Eventually(t, func() bool {
-		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
-	}, time.Second*15, time.Millisecond*50,
-		"placement churn over in-flight activities must write execution-claim records")
+	for _, joiner := range a.joiners {
+		join(joiner)
+	}
+
+	// The rebalance must move at least one in-flight actor so its guard
+	// surfaces as a record while the body still executes on the old host.
+	// All-stay is possible per round, so each rescue round blocks another
+	// batch and churns again.
+	extends := make([]func(), 0, len(a.churners))
+	for _, churner := range a.churners {
+		extends = append(extends, func() {
+			start(batch)
+			join(churner)
+		})
+	}
+	wf.EnsureClaimRecords(t, ctx, a.workflow.DB(), extends)
 
 	close(release)
 
@@ -170,7 +186,7 @@ func (a *cleanup) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
 	}
-	assert.Equal(t, int64(instances), executions.Load())
+	assert.Equal(t, int64(len(ids)), executions.Load())
 
 	// Retention (2s) then delete: no record may leak past completion.
 	assert.Eventually(t, func() bool {

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handoff
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(completed))
+}
+
+type completed struct {
+	workflow *workflow.Workflow
+	joiners  [2]*daprd.Daprd
+}
+
+func (a *completed) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Second),
+	}
+	a.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	// The joiners trigger the mid-run placement rebalance: deliberately not
+	// in WithProcesses, Run starts them at the churn moment.
+	for i := range a.joiners {
+		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+			daprd.WithAppID(a.workflow.Dapr().AppID()),
+			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
+			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
+			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
+		}, fp...)...)
+	}
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *completed) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	const instances = 4
+
+	var executions atomic.Int64
+	started := make(chan struct{}, instances)
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.CallActivity("Slow", task.WithActivityInput("Dapr")).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		select {
+		case <-release:
+			return "slow-done", nil
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, a.workflow.Registry().AddWorkflowN("HandoffCompleted", wfFn))
+	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := a.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, instances)
+	for i := range ids {
+		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "HandoffCompleted",
+		})
+		require.NoError(t, err)
+		ids[i] = resp.GetInstanceId()
+	}
+
+	for range instances {
+		select {
+		case <-started:
+		case <-time.After(time.Second * 30):
+			require.Fail(t, "timed out waiting for every activity body to start executing")
+		}
+	}
+
+	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+
+	for i, joiner := range a.joiners {
+		joiner.Run(t, ctx)
+		t.Cleanup(func() { joiner.Cleanup(t) })
+		joiner.WaitUntilRunning(t, ctx)
+
+		registry := task.NewTaskRegistry()
+		require.NoError(t, registry.AddWorkflowN("HandoffCompleted", wfFn))
+		require.NoError(t, registry.AddActivityN("Slow", actFn))
+		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
+			if !assert.NotNil(c, table) {
+				return
+			}
+			//nolint:gosec
+			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+		}, time.Second*15, time.Millisecond*10)
+	}
+
+	// One to two janitor fires land on the new owners, then the old host
+	// finishes: the results flow through the detached watcher while the
+	// in-flight recovery arrivals resolve against the record.
+	time.Sleep(time.Millisecond * 1500)
+	close(release)
+
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+		assert.Equal(t, `"slow-done"`, metadata.GetOutput().GetValue(),
+			"the old host's result must reach the workflow across the handoff")
+	}
+
+	assert.Equal(t, int64(instances), executions.Load(),
+		"a recovery arrival racing the old host's completion must ack, not re-execute")
+
+	// Every recovery vector must settle: a deferred or escalated arrival that
+	// cannot ack the completed execution would leave its job behind.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		janitors := a.workflow.Scheduler().JobKeyCount(t, ctx, "new-event-janitor")
+		newEvents := a.workflow.Scheduler().JobKeyCount(t, ctx, "new-event") - janitors
+		assert.Zero(c, janitors)
+		assert.Zero(c, newEvents)
+		assert.Zero(c, a.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"))
+	}, time.Second*30, time.Millisecond*50)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
@@ -41,6 +41,10 @@ func init() {
 type completed struct {
 	workflow *workflow.Workflow
 	joiners  [2]*daprd.Daprd
+	// churners join one at a time, each after another batch of blocked
+	// instances, only when a churn round moved no in-flight actor and the
+	// record gate is still unsatisfied.
+	churners [3]*daprd.Daprd
 }
 
 func (a *completed) Setup(t *testing.T) []framework.Option {
@@ -52,13 +56,19 @@ func (a *completed) Setup(t *testing.T) []framework.Option {
 
 	// The joiners trigger the mid-run placement rebalance: deliberately not
 	// in WithProcesses, Run starts them at the churn moment.
-	for i := range a.joiners {
-		a.joiners[i] = daprd.New(t, append([]daprd.Option{
+	newDaprd := func() *daprd.Daprd {
+		return daprd.New(t, append([]daprd.Option{
 			daprd.WithAppID(a.workflow.Dapr().AppID()),
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
 		}, fp...)...)
+	}
+	for i := range a.joiners {
+		a.joiners[i] = newDaprd()
+	}
+	for i := range a.churners {
+		a.churners[i] = newDaprd()
 	}
 
 	return []framework.Option{
@@ -69,12 +79,12 @@ func (a *completed) Setup(t *testing.T) []framework.Option {
 func (a *completed) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
-	// Each of N actors stays put with probability ~1/3; the record gate
-	// below requires at least one to move.
-	const instances = 6
+	// Concurrently blocked activities per churn round; whether any of their
+	// actors moves is probabilistic, the record gate below retries with
+	// another batch and churner until one has.
+	const batch = 6
 
 	var executions atomic.Int64
-	started := make(chan struct{}, instances)
 	release := make(chan struct{})
 	t.Cleanup(func() {
 		select {
@@ -94,10 +104,6 @@ func (a *completed) Run(t *testing.T, ctx context.Context) {
 	actFn := func(c task.ActivityContext) (any, error) {
 		executions.Add(1)
 		select {
-		case started <- struct{}{}:
-		default:
-		}
-		select {
 		case <-release:
 			return "slow-done", nil
 		case <-c.Context().Done():
@@ -109,54 +115,63 @@ func (a *completed) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", actFn))
 	client1 := a.workflow.BackendClient(t, ctx)
 
-	ids := make([]string, instances)
-	for i := range ids {
-		resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
-			WorkflowComponent: "dapr",
-			WorkflowName:      "HandoffCompleted",
-		})
-		require.NoError(t, err)
-		ids[i] = resp.GetInstanceId()
-	}
-
-	for range instances {
-		select {
-		case <-started:
-		case <-time.After(time.Second * 30):
-			require.Fail(t, "timed out waiting for every activity body to start executing")
+	var ids []string
+	start := func(n int) {
+		t.Helper()
+		for range n {
+			resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+				WorkflowComponent: "dapr",
+				WorkflowName:      "HandoffCompleted",
+			})
+			require.NoError(t, err)
+			ids = append(ids, resp.GetInstanceId())
 		}
+		require.Eventually(t, func() bool {
+			return executions.Load() >= int64(len(ids))
+		}, time.Second*30, time.Millisecond*10,
+			"every scheduled activity body must be mid-execution before the churn")
 	}
+	start(batch)
 
-	startVersion := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
-
-	for i, joiner := range a.joiners {
-		joiner.Run(t, ctx)
-		t.Cleanup(func() { joiner.Cleanup(t) })
-		joiner.WaitUntilRunning(t, ctx)
+	version := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
+	join := func(d *daprd.Daprd) {
+		t.Helper()
+		d.Run(t, ctx)
+		t.Cleanup(func() { d.Cleanup(t) })
+		d.WaitUntilRunning(t, ctx)
 
 		registry := task.NewTaskRegistry()
 		require.NoError(t, registry.AddWorkflowN("HandoffCompleted", wfFn))
 		require.NoError(t, registry.AddActivityN("Slow", actFn))
-		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		joinerClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), backend.DefaultLogger())
 		require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
 
+		version++
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			table := a.workflow.Placement().PlacementTables(t, ctx).Tables["default"]
 			if !assert.NotNil(c, table) {
 				return
 			}
-			//nolint:gosec
-			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+			assert.GreaterOrEqual(c, table.Version, version)
 		}, time.Second*15, time.Millisecond*10)
 	}
 
-	// The rebalance must have moved at least one in-flight actor before the
-	// bodies finish, or normal same-host completion would satisfy every
-	// assertion below without a guard or recovery arrival ever existing.
-	require.Eventually(t, func() bool {
-		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
-	}, time.Second*15, time.Millisecond*50,
-		"placement churn over in-flight activities must write execution-claim records")
+	for _, joiner := range a.joiners {
+		join(joiner)
+	}
+
+	// At least one in-flight actor must move before the bodies finish, or
+	// normal same-host completion would satisfy every assertion below without
+	// a guard or recovery arrival ever existing. All-stay is possible per
+	// round, so each rescue round blocks another batch and churns again.
+	extends := make([]func(), 0, len(a.churners))
+	for _, churner := range a.churners {
+		extends = append(extends, func() {
+			start(batch)
+			join(churner)
+		})
+	}
+	wf.EnsureClaimRecords(t, ctx, a.workflow.DB(), extends)
 
 	// One to two janitor fires land on the new owners, then the old host
 	// finishes: the results flow through the detached watcher while the
@@ -172,7 +187,7 @@ func (a *completed) Run(t *testing.T, ctx context.Context) {
 			"the old host's result must reach the workflow across the handoff")
 	}
 
-	assert.Equal(t, int64(instances), executions.Load(),
+	assert.Equal(t, int64(len(ids)), executions.Load(),
 		"a recovery arrival racing the old host's completion must ack, not re-execute")
 
 	// Every recovery vector must settle: a deferred or escalated arrival that

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
@@ -26,6 +26,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
@@ -68,7 +69,9 @@ func (a *completed) Setup(t *testing.T) []framework.Option {
 func (a *completed) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
-	const instances = 4
+	// Each of N actors stays put with probability ~1/3; the record gate
+	// below requires at least one to move.
+	const instances = 6
 
 	var executions atomic.Int64
 	started := make(chan struct{}, instances)
@@ -146,6 +149,14 @@ func (a *completed) Run(t *testing.T, ctx context.Context) {
 			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
 		}, time.Second*15, time.Millisecond*10)
 	}
+
+	// The rebalance must have moved at least one in-flight actor before the
+	// bodies finish, or normal same-host completion would satisfy every
+	// assertion below without a guard or recovery arrival ever existing.
+	require.Eventually(t, func() bool {
+		return wf.CountClaimRecords(t, ctx, a.workflow.DB()) >= 1
+	}, time.Second*15, time.Millisecond*50,
+		"placement churn over in-flight activities must write execution-claim records")
 
 	// One to two janitor fires land on the new owners, then the old host
 	// finishes: the results flow through the detached watcher while the

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
@@ -50,6 +50,10 @@ type deadhost struct {
 	db        *sqlite.SQLite
 	victim    *daprd.Daprd
 	joiners   [2]*daprd.Daprd
+	// churners join one at a time, each after another batch of blocked
+	// instances, only when a churn round moved no in-flight actor and the
+	// record gate is still unsatisfied.
+	churners [3]*daprd.Daprd
 }
 
 func (a *deadhost) Setup(t *testing.T) []framework.Option {
@@ -72,11 +76,14 @@ func (a *deadhost) Setup(t *testing.T) []framework.Option {
 			daprd.WithWorkflowJanitorPeriod(t, time.Second),
 		)
 	}
-	// Victim and joiners start mid-run (the victim is killed, the joiners
-	// trigger the rebalance): deliberately not in WithProcesses.
+	// Victim, joiners and churners start mid-run (the victim is killed, the
+	// others trigger rebalances): deliberately not in WithProcesses.
 	a.victim = newDaprd()
 	for i := range a.joiners {
 		a.joiners[i] = newDaprd()
+	}
+	for i := range a.churners {
+		a.churners[i] = newDaprd()
 	}
 
 	return []framework.Option{
@@ -88,12 +95,12 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 	a.scheduler.WaitUntilRunning(t, ctx)
 	a.place.WaitUntilRunning(t, ctx)
 
-	// Each of N actors stays put with probability ~1/3; the record gate
-	// below requires at least one to move.
+	// Blocked activities per churn round; whether any of their actors moves
+	// is probabilistic, the record gate below retries with another batch and
+	// churner until one has. The initial batch all blocks on the victim.
 	const instances = 6
 
 	var executions atomic.Int64
-	started := make(chan struct{}, instances)
 
 	newWorkflow := func(r *task.TaskRegistry) {
 		require.NoError(t, r.AddWorkflowN("HandoffDeadHost", func(c *task.WorkflowContext) (any, error) {
@@ -110,10 +117,6 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 	newWorkflow(victimRegistry)
 	require.NoError(t, victimRegistry.AddActivityN("Slow", func(c task.ActivityContext) (any, error) {
 		executions.Add(1)
-		select {
-		case started <- struct{}{}:
-		default:
-		}
 		<-c.Context().Done()
 		return nil, c.Context().Err()
 	}))
@@ -136,52 +139,63 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 	victimClient := client.NewTaskHubGrpcClient(a.victim.GRPCConn(t, ctx), backend.DefaultLogger())
 	require.NoError(t, victimClient.StartWorkItemListener(ctx, victimRegistry))
 
-	ids := make([]string, instances)
-	for i := range ids {
-		resp, err := a.victim.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
-			WorkflowComponent: "dapr",
-			WorkflowName:      "HandoffDeadHost",
-		})
-		require.NoError(t, err)
-		ids[i] = resp.GetInstanceId()
-	}
-
-	for range instances {
-		select {
-		case <-started:
-		case <-time.After(time.Second * 30):
-			require.Fail(t, "timed out waiting for every activity body to start executing")
+	var ids []string
+	start := func(n int) {
+		t.Helper()
+		for range n {
+			resp, err := a.victim.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+				WorkflowComponent: "dapr",
+				WorkflowName:      "HandoffDeadHost",
+			})
+			require.NoError(t, err)
+			ids = append(ids, resp.GetInstanceId())
 		}
+		// A body dispatched to the victim counts on entry then blocks; one
+		// dispatched to a survivor counts on its immediate completion.
+		require.Eventually(t, func() bool {
+			return executions.Load() >= int64(len(ids))
+		}, time.Second*30, time.Millisecond*10,
+			"every scheduled activity body must have started executing")
 	}
-	require.Equal(t, int64(instances), executions.Load())
+	start(instances)
 
-	startVersion := a.place.PlacementTables(t, ctx).Tables["default"].Version
+	version := a.place.PlacementTables(t, ctx).Tables["default"].Version
+	join := func(d *daprd.Daprd) {
+		t.Helper()
+		d.Run(t, ctx)
+		t.Cleanup(func() { d.Cleanup(t) })
+		d.WaitUntilRunning(t, ctx)
 
-	for i, joiner := range a.joiners {
-		joiner.Run(t, ctx)
-		t.Cleanup(func() { joiner.Cleanup(t) })
-		joiner.WaitUntilRunning(t, ctx)
-
-		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		joinerClient := client.NewTaskHubGrpcClient(d.GRPCConn(t, ctx), backend.DefaultLogger())
 		require.NoError(t, joinerClient.StartWorkItemListener(ctx, newSurvivorRegistry()))
 
+		version++
 		require.EventuallyWithT(t, func(c *assert.CollectT) {
 			table := a.place.PlacementTables(t, ctx).Tables["default"]
 			if !assert.NotNil(c, table) {
 				return
 			}
-			//nolint:gosec
-			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+			assert.GreaterOrEqual(c, table.Version, version)
 		}, time.Second*15, time.Millisecond*10)
+	}
+
+	for _, joiner := range a.joiners {
+		join(joiner)
 	}
 
 	// The rebalance must have moved at least one in-flight actor and its
 	// guard must have written a record; only then does killing the victim
 	// freeze a claim mid-heartbeat and exercise the stale-reclaim path.
-	require.Eventually(t, func() bool {
-		return wf.CountClaimRecords(t, ctx, a.db) >= 1
-	}, time.Second*15, time.Millisecond*50,
-		"placement churn over in-flight activities must write execution-claim records")
+	// All-stay is possible per round, so each rescue round blocks another
+	// batch and churns again.
+	extends := make([]func(), 0, len(a.churners))
+	for _, churner := range a.churners {
+		extends = append(extends, func() {
+			start(instances)
+			join(churner)
+		})
+	}
+	wf.EnsureClaimRecords(t, ctx, a.db, extends)
 	a.victim.Kill(t)
 
 	survivor := a.joiners[len(a.joiners)-1]
@@ -194,6 +208,8 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 		assert.Equal(t, `"recovered"`, metadata.GetOutput().GetValue())
 	}
 
-	assert.GreaterOrEqual(t, executions.Load(), int64(2*instances),
+	// The initial batch all blocked on the victim and died with it, so each
+	// of those bodies executed twice; later batches at least once each.
+	assert.GreaterOrEqual(t, executions.Load(), int64(len(ids)+instances),
 		"every body killed with its host must have been re-executed by a survivor")
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
@@ -87,7 +88,9 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 	a.scheduler.WaitUntilRunning(t, ctx)
 	a.place.WaitUntilRunning(t, ctx)
 
-	const instances = 4
+	// Each of N actors stays put with probability ~1/3; the record gate
+	// below requires at least one to move.
+	const instances = 6
 
 	var executions atomic.Int64
 	started := make(chan struct{}, instances)
@@ -172,9 +175,13 @@ func (a *deadhost) Run(t *testing.T, ctx context.Context) {
 		}, time.Second*15, time.Millisecond*10)
 	}
 
-	// Let guards spawn and heartbeat for the moved actors, then kill the
-	// victim without any shutdown handling: records freeze mid-heartbeat.
-	time.Sleep(time.Millisecond * 1500)
+	// The rebalance must have moved at least one in-flight actor and its
+	// guard must have written a record; only then does killing the victim
+	// freeze a claim mid-heartbeat and exercise the stale-reclaim path.
+	require.Eventually(t, func() bool {
+		return wf.CountClaimRecords(t, ctx, a.db) >= 1
+	}, time.Second*15, time.Millisecond*50,
+		"placement churn over in-flight activities must write execution-claim records")
 	a.victim.Kill(t)
 
 	survivor := a.joiners[len(a.joiners)-1]

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/deadhost.go
@@ -1,0 +1,192 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handoff
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	procscheduler "github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(deadhost))
+}
+
+// deadhost keeps a raw control plane instead of the workflow harness: the
+// victim must start first and be killed mid-run, and every other daprd must
+// join after, which the harness's framework-time daprd cannot express.
+type deadhost struct {
+	place     *placement.Placement
+	scheduler *procscheduler.Scheduler
+	db        *sqlite.SQLite
+	victim    *daprd.Daprd
+	joiners   [2]*daprd.Daprd
+}
+
+func (a *deadhost) Setup(t *testing.T) []framework.Option {
+	a.place = placement.New(t)
+	a.scheduler = procscheduler.New(t)
+	a.db = sqlite.New(t,
+		sqlite.WithActorStateStore(true),
+		sqlite.WithMetadata("busyTimeout", "10s"),
+		sqlite.WithMetadata("disableWAL", "true"),
+	)
+
+	appID := uuid.New().String()
+	newDaprd := func() *daprd.Daprd {
+		return daprd.New(t,
+			daprd.WithAppID(appID),
+			daprd.WithResourceFiles(a.db.GetComponent(t)),
+			daprd.WithPlacementAddresses(a.place.Address()),
+			daprd.WithSchedulerAddresses(a.scheduler.Address()),
+			daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+			daprd.WithWorkflowJanitorPeriod(t, time.Second),
+		)
+	}
+	// Victim and joiners start mid-run (the victim is killed, the joiners
+	// trigger the rebalance): deliberately not in WithProcesses.
+	a.victim = newDaprd()
+	for i := range a.joiners {
+		a.joiners[i] = newDaprd()
+	}
+
+	return []framework.Option{
+		framework.WithProcesses(a.place, a.scheduler, a.db),
+	}
+}
+
+func (a *deadhost) Run(t *testing.T, ctx context.Context) {
+	a.scheduler.WaitUntilRunning(t, ctx)
+	a.place.WaitUntilRunning(t, ctx)
+
+	const instances = 4
+
+	var executions atomic.Int64
+	started := make(chan struct{}, instances)
+
+	newWorkflow := func(r *task.TaskRegistry) {
+		require.NoError(t, r.AddWorkflowN("HandoffDeadHost", func(c *task.WorkflowContext) (any, error) {
+			var out string
+			if err := c.CallActivity("Slow", task.WithActivityInput("Dapr")).Await(&out); err != nil {
+				return nil, err
+			}
+			return out, nil
+		}))
+	}
+
+	// The victim's bodies block until their host dies with them.
+	victimRegistry := task.NewTaskRegistry()
+	newWorkflow(victimRegistry)
+	require.NoError(t, victimRegistry.AddActivityN("Slow", func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-c.Context().Done()
+		return nil, c.Context().Err()
+	}))
+
+	// Survivor listeners complete the reclaimed re-execution promptly.
+	newSurvivorRegistry := func() *task.TaskRegistry {
+		r := task.NewTaskRegistry()
+		newWorkflow(r)
+		require.NoError(t, r.AddActivityN("Slow", func(task.ActivityContext) (any, error) {
+			executions.Add(1)
+			return "recovered", nil
+		}))
+		return r
+	}
+
+	a.victim.Run(t, ctx)
+	t.Cleanup(func() { a.victim.Cleanup(t) })
+	a.victim.WaitUntilRunning(t, ctx)
+
+	victimClient := client.NewTaskHubGrpcClient(a.victim.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, victimClient.StartWorkItemListener(ctx, victimRegistry))
+
+	ids := make([]string, instances)
+	for i := range ids {
+		resp, err := a.victim.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "HandoffDeadHost",
+		})
+		require.NoError(t, err)
+		ids[i] = resp.GetInstanceId()
+	}
+
+	for range instances {
+		select {
+		case <-started:
+		case <-time.After(time.Second * 30):
+			require.Fail(t, "timed out waiting for every activity body to start executing")
+		}
+	}
+	require.Equal(t, int64(instances), executions.Load())
+
+	startVersion := a.place.PlacementTables(t, ctx).Tables["default"].Version
+
+	for i, joiner := range a.joiners {
+		joiner.Run(t, ctx)
+		t.Cleanup(func() { joiner.Cleanup(t) })
+		joiner.WaitUntilRunning(t, ctx)
+
+		joinerClient := client.NewTaskHubGrpcClient(joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+		require.NoError(t, joinerClient.StartWorkItemListener(ctx, newSurvivorRegistry()))
+
+		require.EventuallyWithT(t, func(c *assert.CollectT) {
+			table := a.place.PlacementTables(t, ctx).Tables["default"]
+			if !assert.NotNil(c, table) {
+				return
+			}
+			//nolint:gosec
+			assert.GreaterOrEqual(c, table.Version, startVersion+uint64(i+1))
+		}, time.Second*15, time.Millisecond*10)
+	}
+
+	// Let guards spawn and heartbeat for the moved actors, then kill the
+	// victim without any shutdown handling: records freeze mid-heartbeat.
+	time.Sleep(time.Millisecond * 1500)
+	a.victim.Kill(t)
+
+	survivor := a.joiners[len(a.joiners)-1]
+	survivorClient := client.NewTaskHubGrpcClient(survivor.GRPCConn(t, ctx), backend.DefaultLogger())
+	for _, id := range ids {
+		metadata, err := survivorClient.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err,
+			"the new owner must reclaim a dead host's stale record within the grace, not strand behind it")
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+		assert.Equal(t, `"recovered"`, metadata.GetOutput().GetValue())
+	}
+
+	assert.GreaterOrEqual(t, executions.Load(), int64(2*instances),
+		"every body killed with its host must have been re-executed by a survivor")
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/restartnoguard.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/restartnoguard.go
@@ -1,0 +1,144 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package handoff
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(restartnoguard))
+}
+
+// restartnoguard gracefully restarts the hosting daprd mid-activity (the
+// HaltAll path): the workflow must recover through the normal janitor
+// re-dispatch, and no execution-claim record may ever be written, pinning
+// the deliberate no-guard-on-shutdown decision (a record for an execution
+// dying with its process would only stall the new owner).
+type restartnoguard struct {
+	workflow *workflow.Workflow
+}
+
+func (a *restartnoguard) Setup(t *testing.T) []framework.Option {
+	a.workflow = workflow.New(t, workflow.WithDaprdOptions(0,
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Second*2),
+	))
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *restartnoguard) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	// Poll the state store for execution-claim rows across the whole run,
+	// including the shutdown window. No require inside: this runs off the
+	// test goroutine.
+	conn := a.workflow.DB().GetConnection(t)
+	var recordSighted atomic.Bool
+	pollDone := make(chan struct{})
+	pollCtx, pollCancel := context.WithCancel(ctx)
+	t.Cleanup(func() { pollCancel(); <-pollDone })
+	go func() {
+		defer close(pollDone)
+		ticker := time.NewTicker(time.Millisecond * 100)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-pollCtx.Done():
+				return
+			case <-ticker.C:
+				var count int
+				if err := conn.QueryRowContext(pollCtx,
+					"SELECT COUNT(*) FROM "+a.workflow.DB().TableName()+" WHERE key LIKE ?",
+					"%||execution-claim",
+				).Scan(&count); err == nil && count > 0 {
+					recordSighted.Store(true)
+				}
+			}
+		}
+	}()
+
+	var restarted atomic.Bool
+	block := make(chan struct{})
+	t.Cleanup(func() { close(block) })
+	started := make(chan struct{}, 1)
+
+	require.NoError(t, a.workflow.Registry().AddWorkflowN("RestartNoGuard", func(c *task.WorkflowContext) (any, error) {
+		var out string
+		if err := c.CallActivity("Slow", task.WithActivityInput("Dapr")).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+	require.NoError(t, a.workflow.Registry().AddActivityN("Slow", func(task.ActivityContext) (any, error) {
+		if restarted.Load() {
+			return "recovered", nil
+		}
+		select {
+		case started <- struct{}{}:
+		default:
+		}
+		<-block
+		return nil, nil
+	}))
+	a.workflow.BackendClient(t, ctx)
+
+	resp, err := a.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+		WorkflowComponent: "dapr",
+		WorkflowName:      "RestartNoGuard",
+	})
+	require.NoError(t, err)
+
+	select {
+	case <-started:
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "timed out waiting for the activity to start executing")
+	}
+
+	// Graceful restart mid-execution: HaltAll runs with the claim unsettled,
+	// and must spawn no guard.
+	restarted.Store(true)
+	a.workflow.Dapr().RestartGraceful(t, ctx)
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	client2 := a.workflow.BackendClient(t, ctx)
+	metadata, err := client2.WaitForWorkflowCompletion(ctx, api.InstanceID(resp.GetInstanceId()))
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `"recovered"`, metadata.GetOutput().GetValue())
+
+	pollCancel()
+	<-pollDone
+	assert.False(t, recordSighted.Load(),
+		"a graceful shutdown must never write an execution-claim record")
+	assert.Zero(t, wf.CountClaimRecords(t, ctx, a.workflow.DB()))
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/restartnoguard.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/restartnoguard.go
@@ -59,33 +59,10 @@ func (a *restartnoguard) Setup(t *testing.T) []framework.Option {
 func (a *restartnoguard) Run(t *testing.T, ctx context.Context) {
 	a.workflow.WaitUntilRunning(t, ctx)
 
-	// Poll the state store for execution-claim rows across the whole run,
-	// including the shutdown window. No require inside: this runs off the
-	// test goroutine.
-	conn := a.workflow.DB().GetConnection(t)
-	var recordSighted atomic.Bool
-	pollDone := make(chan struct{})
-	pollCtx, pollCancel := context.WithCancel(ctx)
-	t.Cleanup(func() { pollCancel(); <-pollDone })
-	go func() {
-		defer close(pollDone)
-		ticker := time.NewTicker(time.Millisecond * 100)
-		defer ticker.Stop()
-		for {
-			select {
-			case <-pollCtx.Done():
-				return
-			case <-ticker.C:
-				var count int
-				if err := conn.QueryRowContext(pollCtx,
-					"SELECT COUNT(*) FROM "+a.workflow.DB().TableName()+" WHERE key LIKE ?",
-					"%||execution-claim",
-				).Scan(&count); err == nil && count > 0 {
-					recordSighted.Store(true)
-				}
-			}
-		}
-	}()
+	// Audit triggers record every execution-claim write inside the writer's
+	// own transaction, so a record written and deleted again during the
+	// shutdown window cannot slip between poll samples.
+	claimWrites := wf.AuditClaimWrites(t, ctx, a.workflow.DB())
 
 	var restarted atomic.Bool
 	block := make(chan struct{})
@@ -136,9 +113,7 @@ func (a *restartnoguard) Run(t *testing.T, ctx context.Context) {
 	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
 	assert.Equal(t, `"recovered"`, metadata.GetOutput().GetValue())
 
-	pollCancel()
-	<-pollDone
-	assert.False(t, recordSighted.Load(),
+	assert.Zero(t, claimWrites(),
 		"a graceful shutdown must never write an execution-claim record")
 	assert.Zero(t, wf.CountClaimRecords(t, ctx, a.workflow.DB()))
 }

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reuseid"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/activityv2"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/fold"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/localwake"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/wakev2"


### PR DESCRIPTION
Under WorkflowsFastPath the exactly-once-in-flight claim for an activity execution is host-local, so when placement moves the actor mid-execution the janitor re-dispatch or escalated run-activity reminder fires on the new owner and runs the body a second time while the old host is still executing. Result dedup converges, but the body observably runs twice.

The fix is a durable execution-claim record (a lease) under the activity actor's state key, in the new activity/claim subpackage, written only around the handoff: when HaltNonHosted deactivates an actor with an unsettled claim, a guard writes the record and heartbeats it every janitor period. A clean finish marks it Completed (retained for the inflight cache TTL), a failed finish deletes it, and a dead host goes stale after two periods. HaltAll spawns no guards; at shutdown the execution dies with the process. The steady-state fast path never touches the record.

Recovery arrivals on the new owner (janitor re-dispatches, marked via Execute metadata, and scheduler-fired run-activity reminders) gate on the record: live defers recoverably, Completed acks without executing, stale or missing proceeds, and a stale record from another scheduling is reaped on read. A local inflight entry acks the re-dispatch only while the stale-claim oracle reads it live; a stranded entry falls through so stale eviction re-executes (a blanket ack livelocked the rescue chain by also swallowing the escalation). The drive-failure escalation is suppressed while the aborted drive's claim is live locally. Reminder creates clamp a stale dueTime to now, since the scheduler paces failure retries from the scheduled time and a past dueTime replayed the whole elapsed backlog as a burst on every deferred trigger.

Contract: at most one live body per activity across hosts during handoff; at-least-once preserved (a failed record write degrades to today's behavior, a dead guard host is reclaimed after the grace).