### PR TITLE
workflow: cancel pending work-item completions when the last worker disconnects

### DIFF
--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -51,6 +51,7 @@ import (
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/backends/actors/pendingtracker"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state/list"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
@@ -117,7 +118,7 @@ type Actors struct {
 	retentionerActorType string
 	executorActorType    string
 
-	pendingTasksBackend    PendingTasksBackend
+	pendingTasksBackend    *pendingtracker.Tracker
 	activityExecs          *activityExecutions
 	resiliency             resiliency.Provider
 	actors                 actors.Interface
@@ -175,6 +176,10 @@ func New(opts Options) (*Actors, error) {
 		pendingTasksBackend = local.NewTasksBackend()
 	}
 
+	// Wrapped so pending completions can be cancelled while no executor is
+	// connected; see the pendingtracker package.
+	trackedPendingTasksBackend := pendingtracker.New(pendingTasksBackend)
+
 	return &Actors{
 		appID:                     opts.AppID,
 		namespace:                 opts.Namespace,
@@ -184,7 +189,7 @@ func New(opts Options) (*Actors, error) {
 		retentionerActorType:      todo.ActorTypePrefix + opts.Namespace + utils.DotDelimiter + opts.AppID + utils.DotDelimiter + RetentionerNameLabelKey,
 		actors:                    opts.Actors,
 		resiliency:                opts.Resiliency,
-		pendingTasksBackend:       pendingTasksBackend,
+		pendingTasksBackend:       trackedPendingTasksBackend,
 		activityExecs:             newActivityExecutions(),
 		compStore:                 opts.ComponentStore,
 		orchestrationWorkItemChan: make(chan *backend.WorkflowWorkItem, 1),
@@ -973,6 +978,10 @@ func (abe *Actors) ActivityActorType() string {
 
 func (abe *Actors) WorkflowActorType() string {
 	return abe.workflowActorType
+}
+
+func (abe *Actors) SetExecutorAvailable(available bool) {
+	abe.pendingTasksBackend.SetExecutorAvailable(available)
 }
 
 // CancelActivityTask implements backend.Backend.

--- a/pkg/runtime/wfengine/backends/actors/pendingexec_test.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingexec_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend/local"
+
+	"github.com/dapr/dapr/pkg/runtime/wfengine/backends/actors/pendingtracker"
 )
 
 func Test_activityExecutions(t *testing.T) {
@@ -61,7 +63,7 @@ func Test_onActivityCompletionMirrorsHeld(t *testing.T) {
 	t.Parallel()
 
 	abe := &Actors{
-		pendingTasksBackend: local.NewTasksBackend(),
+		pendingTasksBackend: pendingtracker.New(local.NewTasksBackend()),
 		activityExecs:       newActivityExecutions(),
 	}
 

--- a/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker.go
@@ -73,21 +73,30 @@ func New(inner Backend) *Tracker {
 
 // SetExecutorAvailable flips executor connectivity. Flipping to false sweeps
 // and cancels every currently pending task: with no executor connected,
-// nothing can ever complete them.
+// nothing can ever complete them. The sweep returns only once every cancel
+// has settled (cancelled, completed under the race, or timed out), so the
+// caller's subsequent unregister HaltAll does not wait on a turn whose
+// cancellation is still in flight.
 func (t *Tracker) SetExecutorAvailable(available bool) {
 	t.available.Store(available)
 	if available {
 		return
 	}
 
+	var wg sync.WaitGroup
 	t.workflows.Range(func(key, _ any) bool {
-		t.cancelWorkflow(key.(string))
+		wg.Go(func() {
+			t.cancelWorkflow(key.(string))
+		})
 		return true
 	})
 	t.activities.Range(func(_, value any) bool {
-		t.cancelActivity(value.(*activityKey))
+		wg.Go(func() {
+			t.cancelActivity(value.(*activityKey))
+		})
 		return true
 	})
+	wg.Wait()
 }
 
 // OnWorkflowTaskCompletion implements Backend. Registrations made while no
@@ -134,21 +143,67 @@ func (t *Tracker) OnActivityCompletion(req *protos.ActivityRequest, cb func(*pro
 	}
 }
 
-// cancelWorkflow cancels one pending workflow task. Errors are expected when
-// a completion or an earlier cancel raced the sweep and are safe to drop: the
-// executor's delivery arbiter accepts a single settlement per dispatch.
 func (t *Tracker) cancelWorkflow(instanceID string) {
-	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
-	defer cancel()
-	if err := t.CancelWorkflowTask(ctx, api.InstanceID(instanceID)); err != nil {
-		log.Debugf("No pending workflow task to cancel for instance '%s': %v", instanceID, err)
-	}
+	t.cancelWithRetry(
+		func(ctx context.Context) error {
+			return t.CancelWorkflowTask(ctx, api.InstanceID(instanceID))
+		},
+		func() bool {
+			_, ok := t.workflows.Load(instanceID)
+			return ok
+		},
+		"workflow task for instance '"+instanceID+"'",
+	)
 }
 
 func (t *Tracker) cancelActivity(ak *activityKey) {
+	key := backend.GetActivityExecutionKey(ak.instanceID, ak.taskID)
+	t.cancelWithRetry(
+		func(ctx context.Context) error {
+			return t.CancelActivityTask(ctx, api.InstanceID(ak.instanceID), ak.taskID)
+		},
+		func() bool {
+			_, ok := t.activities.Load(key)
+			return ok
+		},
+		"activity task '"+key+"'",
+	)
+}
+
+// cancelWithRetry drives one cancellation to a settled outcome within
+// cancelTimeout. An error with the registration already gone is the benign
+// completion race (the executor's delivery arbiter accepted another
+// settlement) and is dropped. An error with the registration still live can
+// be a transient failure of the cluster backend's non-local fall-through (a
+// watch-path waiter is cancelled via a remote executor-actor call), and is
+// retried: giving up would leave the turn parked and recreate the unregister
+// deadlock this package exists to break. An executor reconnecting mid-retry
+// stops the retry, since the completion can then be delivered normally.
+func (t *Tracker) cancelWithRetry(cancelTask func(context.Context) error, registered func() bool, desc string) {
 	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
 	defer cancel()
-	if err := t.CancelActivityTask(ctx, api.InstanceID(ak.instanceID), ak.taskID); err != nil {
-		log.Debugf("No pending activity task to cancel for instance '%s' task %d: %v", ak.instanceID, ak.taskID, err)
+
+	backoff := 50 * time.Millisecond
+	for {
+		err := cancelTask(ctx)
+		if err == nil {
+			return
+		}
+		if !registered() {
+			log.Debugf("No pending %s to cancel: %v", desc, err)
+			return
+		}
+		if t.available.Load() {
+			log.Debugf("An executor reconnected while cancelling the pending %s; leaving it to complete: %v", desc, err)
+			return
+		}
+		select {
+		case <-ctx.Done():
+			log.Warnf("Failed to cancel the pending %s within %s; its completion stays parked until an executor reconnects: %v",
+				desc, cancelTimeout, err)
+			return
+		case <-time.After(backoff):
+			backoff = min(backoff*2, time.Second)
+		}
 	}
 }

--- a/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker.go
@@ -1,0 +1,154 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pendingtracker
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/kit/logger"
+)
+
+const cancelTimeout = 10 * time.Second
+
+var log = logger.NewLogger("dapr.wfengine.backend.actors.pendingtracker")
+
+// Backend is the pending-tasks surface the tracker wraps. It is satisfied by
+// both the local and the cluster tasks backends.
+type Backend interface {
+	CancelActivityTask(ctx context.Context, instanceID api.InstanceID, taskID int32) error
+	CancelWorkflowTask(ctx context.Context, instanceID api.InstanceID) error
+	CompleteActivityTask(ctx context.Context, response *protos.ActivityResponse) error
+	CompleteWorkflowTask(ctx context.Context, response *protos.WorkflowResponse) error
+	OnActivityCompletion(request *protos.ActivityRequest, cb func(*protos.ActivityResponse, error)) func()
+	OnWorkflowTaskCompletion(request *protos.WorkflowRequest, cb func(*protos.WorkflowResponse, error)) func()
+}
+
+// Tracker decorates a Backend with executor-connectivity-aware cancellation
+// of pending completions.
+type Tracker struct {
+	Backend
+
+	// available is the executor connectivity flag. While false, every
+	// pending registration is cancelled: at the flip via the sweep, and on
+	// arrival for registrations racing the flip.
+	available atomic.Bool
+
+	workflows  sync.Map // instanceID string -> token *byte
+	activities sync.Map // execution key string -> *activityKey
+}
+
+type activityKey struct {
+	instanceID string
+	taskID     int32
+}
+
+func New(inner Backend) *Tracker {
+	t := &Tracker{Backend: inner}
+	// Available until an executor-count transition says otherwise: work items
+	// cannot be dispatched before the first executor registers actors, and
+	// defaulting to unavailable would cancel registrations made by callers
+	// that never report connectivity.
+	t.available.Store(true)
+	return t
+}
+
+// SetExecutorAvailable flips executor connectivity. Flipping to false sweeps
+// and cancels every currently pending task: with no executor connected,
+// nothing can ever complete them.
+func (t *Tracker) SetExecutorAvailable(available bool) {
+	t.available.Store(available)
+	if available {
+		return
+	}
+
+	t.workflows.Range(func(key, _ any) bool {
+		t.cancelWorkflow(key.(string))
+		return true
+	})
+	t.activities.Range(func(_, value any) bool {
+		t.cancelActivity(value.(*activityKey))
+		return true
+	})
+}
+
+// OnWorkflowTaskCompletion implements Backend. Registrations made while no
+// executor is available are cancelled immediately: they can never be
+// completed, and leaving them parked recreates the unregister deadlock.
+func (t *Tracker) OnWorkflowTaskCompletion(req *protos.WorkflowRequest, cb func(*protos.WorkflowResponse, error)) func() {
+	iid := req.GetInstanceId()
+	dereg := t.Backend.OnWorkflowTaskCompletion(req, cb)
+
+	// Unique token so a superseded attempt's late deregister cannot evict a
+	// newer attempt's tracking entry for the same instance. Non-zero-size:
+	// zero-size allocations share an address, which would defeat the compare.
+	token := new(byte)
+	t.workflows.Store(iid, token)
+
+	if !t.available.Load() {
+		t.cancelWorkflow(iid)
+	}
+
+	return func() {
+		t.workflows.CompareAndDelete(iid, token)
+		dereg()
+	}
+}
+
+// OnActivityCompletion implements Backend; see OnWorkflowTaskCompletion.
+func (t *Tracker) OnActivityCompletion(req *protos.ActivityRequest, cb func(*protos.ActivityResponse, error)) func() {
+	ak := &activityKey{
+		instanceID: req.GetWorkflowInstance().GetInstanceId(),
+		taskID:     req.GetTaskId(),
+	}
+	key := backend.GetActivityExecutionKey(ak.instanceID, ak.taskID)
+	dereg := t.Backend.OnActivityCompletion(req, cb)
+
+	t.activities.Store(key, ak)
+
+	if !t.available.Load() {
+		t.cancelActivity(ak)
+	}
+
+	return func() {
+		t.activities.CompareAndDelete(key, ak)
+		dereg()
+	}
+}
+
+// cancelWorkflow cancels one pending workflow task. Errors are expected when
+// a completion or an earlier cancel raced the sweep and are safe to drop: the
+// executor's delivery arbiter accepts a single settlement per dispatch.
+func (t *Tracker) cancelWorkflow(instanceID string) {
+	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+	defer cancel()
+	if err := t.CancelWorkflowTask(ctx, api.InstanceID(instanceID)); err != nil {
+		log.Debugf("No pending workflow task to cancel for instance '%s': %v", instanceID, err)
+	}
+}
+
+func (t *Tracker) cancelActivity(ak *activityKey) {
+	ctx, cancel := context.WithTimeout(context.Background(), cancelTimeout)
+	defer cancel()
+	if err := t.CancelActivityTask(ctx, api.InstanceID(ak.instanceID), ak.taskID); err != nil {
+		log.Debugf("No pending activity task to cancel for instance '%s' task %d: %v", ak.instanceID, ak.taskID, err)
+	}
+}

--- a/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker_test.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker_test.go
@@ -16,7 +16,11 @@ limitations under the License.
 package pendingtracker
 
 import (
+	"context"
+	"errors"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -25,6 +29,32 @@ import (
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend/local"
 )
+
+// flakyBackend fails the first n cancel calls with a transient error before
+// delegating, mimicking the cluster backend's remote fall-through failing.
+type flakyBackend struct {
+	Backend
+	wfFails  atomic.Int32
+	wfCalls  atomic.Int32
+	actFails atomic.Int32
+	actCalls atomic.Int32
+}
+
+func (f *flakyBackend) CancelWorkflowTask(ctx context.Context, id api.InstanceID) error {
+	f.wfCalls.Add(1)
+	if f.wfFails.Add(-1) >= 0 {
+		return errors.New("transient cancel failure")
+	}
+	return f.Backend.CancelWorkflowTask(ctx, id)
+}
+
+func (f *flakyBackend) CancelActivityTask(ctx context.Context, id api.InstanceID, taskID int32) error {
+	f.actCalls.Add(1)
+	if f.actFails.Add(-1) >= 0 {
+		return errors.New("transient cancel failure")
+	}
+	return f.Backend.CancelActivityTask(ctx, id, taskID)
+}
 
 func wfReq(iid string) *protos.WorkflowRequest {
 	return &protos.WorkflowRequest{InstanceId: iid}
@@ -114,6 +144,88 @@ func Test_DeregisteredEntriesAreNotCancelled(t *testing.T) {
 
 	tr.SetExecutorAvailable(false)
 	assert.Zero(t, wfCalls)
+}
+
+func Test_SweepRetriesTransientCancelFailures(t *testing.T) {
+	t.Parallel()
+
+	flaky := &flakyBackend{Backend: local.NewTasksBackend()}
+	flaky.wfFails.Store(2)
+	flaky.actFails.Store(2)
+	tr := New(flaky)
+
+	var wfErr, actErr error
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(_ *protos.WorkflowResponse, err error) {
+		wfErr = err
+	})
+	tr.OnActivityCompletion(actReq("wf1", 7), func(_ *protos.ActivityResponse, err error) {
+		actErr = err
+	})
+
+	tr.SetExecutorAvailable(false)
+
+	require.ErrorIs(t, wfErr, api.ErrTaskCancelled,
+		"a transient cancel failure must be retried, not dropped: an uncancelled turn wedges the unregister HaltAll")
+	require.ErrorIs(t, actErr, api.ErrTaskCancelled)
+	assert.Equal(t, int32(3), flaky.wfCalls.Load())
+	assert.Equal(t, int32(3), flaky.actCalls.Load())
+}
+
+func Test_CancelErrorWithDeregisteredEntryIsNotRetried(t *testing.T) {
+	t.Parallel()
+
+	// The cancel error coincides with the waiter settling (completion won the
+	// arbiter): the deregister removes the tracking entry, so the sweep must
+	// treat the error as the benign race and stop after one attempt.
+	inner := local.NewTasksBackend()
+	var dereg func()
+	var calls atomic.Int32
+	tr := New(&deregOnCancelBackend{Backend: inner, calls: &calls, dereg: &dereg})
+
+	dereg = tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(*protos.WorkflowResponse, error) {})
+
+	tr.SetExecutorAvailable(false)
+	assert.Equal(t, int32(1), calls.Load())
+}
+
+// deregOnCancelBackend errors every cancel and deregisters the waiter inside
+// the first one, simulating a completion racing the sweep.
+type deregOnCancelBackend struct {
+	Backend
+	calls *atomic.Int32
+	dereg *func()
+}
+
+func (d *deregOnCancelBackend) CancelWorkflowTask(context.Context, api.InstanceID) error {
+	if d.calls.Add(1) == 1 {
+		(*d.dereg)()
+	}
+	return errors.New("cancel failed")
+}
+
+func Test_RetryStopsWhenExecutorReconnects(t *testing.T) {
+	t.Parallel()
+
+	flaky := &flakyBackend{Backend: local.NewTasksBackend()}
+	flaky.wfFails.Store(1 << 30)
+	tr := New(flaky)
+
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(*protos.WorkflowResponse, error) {})
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		tr.SetExecutorAvailable(false)
+	}()
+
+	time.Sleep(time.Millisecond * 120)
+	tr.SetExecutorAvailable(true)
+
+	select {
+	case <-done:
+	case <-time.After(time.Second * 5):
+		t.Fatal("the sweep must stop retrying once an executor reconnects")
+	}
 }
 
 func Test_SupersededDeregisterKeepsNewRegistrationTracked(t *testing.T) {

--- a/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker_test.go
+++ b/pkg/runtime/wfengine/backends/actors/pendingtracker/pendingtracker_test.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pendingtracker
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend/local"
+)
+
+func wfReq(iid string) *protos.WorkflowRequest {
+	return &protos.WorkflowRequest{InstanceId: iid}
+}
+
+func actReq(iid string, taskID int32) *protos.ActivityRequest {
+	return &protos.ActivityRequest{
+		WorkflowInstance: &protos.WorkflowInstance{InstanceId: iid},
+		TaskId:           taskID,
+	}
+}
+
+func Test_SetExecutorAvailableSweepsPending(t *testing.T) {
+	t.Parallel()
+
+	tr := New(local.NewTasksBackend())
+
+	var wfErr, actErr error
+	var wfCalls, actCalls int
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(_ *protos.WorkflowResponse, err error) {
+		wfCalls++
+		wfErr = err
+	})
+	tr.OnActivityCompletion(actReq("wf1", 7), func(_ *protos.ActivityResponse, err error) {
+		actCalls++
+		actErr = err
+	})
+
+	// Registrations while available stay parked.
+	assert.Zero(t, wfCalls)
+	assert.Zero(t, actCalls)
+
+	tr.SetExecutorAvailable(false)
+
+	assert.Equal(t, 1, wfCalls)
+	assert.Equal(t, 1, actCalls)
+	require.ErrorIs(t, wfErr, api.ErrTaskCancelled)
+	require.ErrorIs(t, actErr, api.ErrTaskCancelled)
+}
+
+func Test_RegistrationWhileUnavailableIsCancelledImmediately(t *testing.T) {
+	t.Parallel()
+
+	tr := New(local.NewTasksBackend())
+	tr.SetExecutorAvailable(false)
+
+	var wfErr, actErr error
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(_ *protos.WorkflowResponse, err error) {
+		wfErr = err
+	})
+	tr.OnActivityCompletion(actReq("wf1", 3), func(_ *protos.ActivityResponse, err error) {
+		actErr = err
+	})
+
+	require.ErrorIs(t, wfErr, api.ErrTaskCancelled)
+	require.ErrorIs(t, actErr, api.ErrTaskCancelled)
+}
+
+func Test_AvailableCompletionsFlowThrough(t *testing.T) {
+	t.Parallel()
+
+	tr := New(local.NewTasksBackend())
+
+	var resp *protos.WorkflowResponse
+	var wfErr error
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(r *protos.WorkflowResponse, err error) {
+		resp = r
+		wfErr = err
+	})
+
+	require.NoError(t, tr.CompleteWorkflowTask(t.Context(), &protos.WorkflowResponse{InstanceId: "wf1"}))
+	require.NoError(t, wfErr)
+	require.NotNil(t, resp)
+	assert.Equal(t, "wf1", resp.GetInstanceId())
+}
+
+func Test_DeregisteredEntriesAreNotCancelled(t *testing.T) {
+	t.Parallel()
+
+	tr := New(local.NewTasksBackend())
+
+	var wfCalls int
+	dereg := tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(*protos.WorkflowResponse, error) {
+		wfCalls++
+	})
+	dereg()
+
+	tr.SetExecutorAvailable(false)
+	assert.Zero(t, wfCalls)
+}
+
+func Test_SupersededDeregisterKeepsNewRegistrationTracked(t *testing.T) {
+	t.Parallel()
+
+	tr := New(local.NewTasksBackend())
+
+	// First attempt registers, is superseded, and deregisters LATE, after the
+	// second attempt for the same instance registered. The stale deregister
+	// must not evict the newer attempt's tracking entry.
+	deregOld := tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(*protos.WorkflowResponse, error) {})
+
+	var newErr error
+	var newCalls int
+	tr.OnWorkflowTaskCompletion(wfReq("wf1"), func(_ *protos.WorkflowResponse, err error) {
+		newCalls++
+		newErr = err
+	})
+
+	deregOld()
+
+	tr.SetExecutorAvailable(false)
+	assert.Equal(t, 1, newCalls)
+	require.ErrorIs(t, newErr, api.ErrTaskCancelled)
+}

--- a/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
+++ b/pkg/runtime/wfengine/backends/actors/resolvehandshake_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
+
+	"github.com/dapr/dapr/pkg/runtime/wfengine/backends/actors/pendingtracker"
 )
 
 // fakePendingBackend hands the registered completion callback back to the
@@ -53,7 +55,7 @@ func Test_activityCompletionHandshake(t *testing.T) {
 	t.Run("resolver runs while the registration is still held", func(t *testing.T) {
 		t.Parallel()
 		fake := &fakePendingBackend{}
-		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+		abe := &Actors{pendingTasksBackend: pendingtracker.New(fake), activityExecs: newActivityExecutions()}
 
 		heldAtResolve := make(chan bool, 1)
 		unregister := abe.RegisterActivityResolver("wf1", 3, func() {
@@ -80,7 +82,7 @@ func Test_activityCompletionHandshake(t *testing.T) {
 	t.Run("error paths do not resolve, keeping the execution evictable", func(t *testing.T) {
 		t.Parallel()
 		fake := &fakePendingBackend{}
-		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+		abe := &Actors{pendingTasksBackend: pendingtracker.New(fake), activityExecs: newActivityExecutions()}
 
 		resolved := false
 		unregister := abe.RegisterActivityResolver("wf1", 4, func() { resolved = true })
@@ -143,7 +145,7 @@ func Test_activityCompletionHandshake(t *testing.T) {
 	t.Run("delivery with no resolver registered is a no-op resolve", func(t *testing.T) {
 		t.Parallel()
 		fake := &fakePendingBackend{}
-		abe := &Actors{pendingTasksBackend: fake, activityExecs: newActivityExecutions()}
+		abe := &Actors{pendingTasksBackend: pendingtracker.New(fake), activityExecs: newActivityExecutions()}
 		called := false
 		var gotErr error
 		dereg := abe.OnActivityCompletion(activityRequest("wf1", 8), func(_ *protos.ActivityResponse, err error) {

--- a/pkg/runtime/wfengine/wfengine.go
+++ b/pkg/runtime/wfengine/wfengine.go
@@ -187,6 +187,10 @@ func New(opts Options) (Interface, error) {
 		wfe.actorRegLock.Lock()
 		defer wfe.actorRegLock.Unlock()
 		if wfe.mcpRegistrationCount.Add(-1) == 0 && wfe.getWorkItemsCount.Load() == 0 && wfe.actorsRegistered {
+			// Cancel parked work-item completions BEFORE unregistering:
+			// UnRegisterActors' HaltAll waits on the actor turn locks those
+			// completions hold, and with no executor nothing can deliver them.
+			wfe.syncExecutorAvailable()
 			err := abackend.UnRegisterActors(context.Background())
 			wfe.actorsRegistered = false
 			if err != nil {
@@ -196,43 +200,8 @@ func New(opts Options) (Interface, error) {
 	})
 
 	grpcExec, registerGrpcServerFn := backend.NewGrpcExecutor(abackend, log,
-		backend.WithOnGetWorkItemsConnectionCallback(func(ctx context.Context) error {
-			wfe.actorRegLock.Lock()
-			defer wfe.actorRegLock.Unlock()
-
-			wfe.getWorkItemsCount.Add(1)
-			if !wfe.actorsRegistered {
-				log.Debug("Registering workflow actors")
-				if err := abackend.RegisterActors(ctx); err != nil {
-					wfe.getWorkItemsCount.Add(-1)
-					return err
-				}
-				wfe.actorsRegistered = true
-			}
-
-			return nil
-		}),
-		backend.WithOnGetWorkItemsDisconnectCallback(func(ctx context.Context) error {
-			wfe.actorRegLock.Lock()
-			defer wfe.actorRegLock.Unlock()
-
-			if ctx.Err() != nil {
-				ctx = context.Background()
-			}
-
-			if wfe.getWorkItemsCount.Add(-1) == 0 && wfe.mcpRegistrationCount.Load() == 0 && wfe.actorsRegistered {
-				log.Debug("Unregistering workflow actors")
-				// Reset unconditionally: UnRegisterActors removes types from the
-				// table before HaltAll, so an error here still means they're gone.
-				err := abackend.UnRegisterActors(ctx)
-				wfe.actorsRegistered = false
-				if err != nil {
-					return err
-				}
-			}
-
-			return nil
-		}),
+		backend.WithOnGetWorkItemsConnectionCallback(wfe.onWorkItemConnection),
+		backend.WithOnGetWorkItemsDisconnectCallback(wfe.onWorkItemDisconnection),
 		backend.WithStreamSendTimeout(time.Second*10),
 		backend.WithStreamShutdownChannel(wfe.streamShutdownCh),
 	)
@@ -285,15 +254,77 @@ func (wfe *engine) EnsureActorsRegistered(ctx context.Context) error {
 	defer wfe.actorRegLock.Unlock()
 
 	wfe.mcpRegistrationCount.Add(1)
+	wfe.syncExecutorAvailable()
 	if !wfe.actorsRegistered {
 		log.Debug("Registering workflow actors for internal workflows")
 		if err := wfe.backend.RegisterActors(ctx); err != nil {
 			wfe.mcpRegistrationCount.Add(-1)
+			wfe.syncExecutorAvailable()
 			return err
 		}
 		wfe.actorsRegistered = true
 	}
 	return nil
+}
+
+func (wfe *engine) onWorkItemConnection(ctx context.Context) error {
+	wfe.actorRegLock.Lock()
+	defer wfe.actorRegLock.Unlock()
+
+	wfe.getWorkItemsCount.Add(1)
+	wfe.syncExecutorAvailable()
+	if !wfe.actorsRegistered {
+		log.Debug("Registering workflow actors")
+		if err := wfe.backend.RegisterActors(ctx); err != nil {
+			// No compensating decrement: the executor invokes the paired
+			// disconnect callback also when this callback errors, and a
+			// second decrement would drift the count negative for good.
+			return err
+		}
+		wfe.actorsRegistered = true
+	}
+
+	return nil
+}
+
+func (wfe *engine) onWorkItemDisconnection(ctx context.Context) error {
+	wfe.actorRegLock.Lock()
+	defer wfe.actorRegLock.Unlock()
+
+	if ctx.Err() != nil {
+		ctx = context.Background()
+	}
+
+	last := wfe.getWorkItemsCount.Add(-1) == 0 && wfe.mcpRegistrationCount.Load() == 0
+	if last {
+		// Cancel parked work-item completions BEFORE unregistering:
+		// UnRegisterActors' HaltAll waits on the actor turn locks
+		// those completions hold, and with no executor connected
+		// nothing can ever deliver them. A turn racing in after the
+		// sweep is cancelled at registration by the tracker.
+		wfe.syncExecutorAvailable()
+	}
+
+	if last && wfe.actorsRegistered {
+		log.Debug("Unregistering workflow actors")
+		// Reset unconditionally: UnRegisterActors removes types from the
+		// table before HaltAll, so an error here still means they're gone.
+		err := wfe.backend.UnRegisterActors(ctx)
+		wfe.actorsRegistered = false
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// syncExecutorAvailable pushes current executor connectivity to the backend's
+// pending-tasks tracker. Must be called with actorRegLock held. Flipping to
+// unavailable cancels every parked work-item completion (see pendingTracker
+// in the actors backend).
+func (wfe *engine) syncExecutorAvailable() {
+	wfe.backend.SetExecutorAvailable(wfe.getWorkItemsCount.Load() > 0 || wfe.mcpRegistrationCount.Load() > 0)
 }
 
 // RegisterMCPServer installs workflows and ensures actors are registered.
@@ -325,6 +356,8 @@ func (wfe *engine) UnregisterMCPServer(serverName string) {
 	defer wfe.actorRegLock.Unlock()
 
 	if wfe.mcpRegistrationCount.Add(-1) == 0 && wfe.getWorkItemsCount.Load() == 0 && wfe.actorsRegistered {
+		// Sweep parked completions before HaltAll; see the disconnect callback.
+		wfe.syncExecutorAvailable()
 		log.Debug("Unregistering workflow actors")
 		err := wfe.backend.UnRegisterActors(context.Background())
 		wfe.actorsRegistered = false

--- a/pkg/runtime/wfengine/wfengine_workitemconn_test.go
+++ b/pkg/runtime/wfengine/wfengine_workitemconn_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wfengine
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/pkg/actors/table"
+	tablefake "github.com/dapr/dapr/pkg/actors/table/fake"
+	"github.com/dapr/durabletask-go/api/protos"
+
+	actorsfake "github.com/dapr/dapr/pkg/actors/fake"
+)
+
+// TestEngine_WorkItemConnectionFailurePairing pins the connect/disconnect
+// accounting contract with the grpc executor: the executor invokes the
+// disconnect callback exactly once per connect callback invocation, including
+// for connections whose connect callback returned an error. The connect error
+// path must therefore not decrement getWorkItemsCount itself; doing so drifts
+// the count negative permanently, which pins the pending tracker unavailable
+// and cancels every later completion registration on arrival even while a
+// healthy worker is connected (the churnstrand strand-everything signature).
+func TestEngine_WorkItemConnectionFailurePairing(t *testing.T) {
+	var tableErr atomic.Bool
+	tableErr.Store(true)
+	fa := actorsfake.New().WithTable(func(context.Context) (table.Interface, error) {
+		if tableErr.Load() {
+			return nil, errors.New("placement churn")
+		}
+		return tablefake.New(), nil
+	})
+
+	wfe, _ := newTestEngine(t, fa)
+
+	// A connection whose actor registration fails, then its paired
+	// disconnect, exactly as the executor drives them.
+	require.Error(t, wfe.onWorkItemConnection(t.Context()))
+	require.NoError(t, wfe.onWorkItemDisconnection(t.Context()))
+	require.Equal(t, int32(0), wfe.getWorkItemsCount.Load(),
+		"a failed connection must net the stream count to zero, not negative")
+
+	// A healthy reconnect must count as one connected worker and restore
+	// executor availability.
+	tableErr.Store(false)
+	require.NoError(t, wfe.onWorkItemConnection(t.Context()))
+	require.Equal(t, int32(1), wfe.getWorkItemsCount.Load())
+
+	// With a worker connected, a completion registration must stay armed
+	// rather than be cancelled on arrival by the pending tracker.
+	cancelled := make(chan error, 1)
+	dereg := wfe.backend.OnWorkflowTaskCompletion(
+		&protos.WorkflowRequest{InstanceId: "pairing-test"},
+		func(_ *protos.WorkflowResponse, err error) {
+			cancelled <- err
+		})
+	t.Cleanup(dereg)
+
+	select {
+	case err := <-cancelled:
+		t.Fatalf("completion registration cancelled while a worker is connected: %v", err)
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	require.NoError(t, wfe.onWorkItemDisconnection(t.Context()))
+	assert.Equal(t, int32(0), wfe.getWorkItemsCount.Load())
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/wakev2/reconnect.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/wakev2/reconnect.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package wakev2
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/exec"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(reconnect))
+}
+
+// reconnect asserts that a workflow whose FIRST turn is in-flight when its
+// worker disconnects is re-driven after the worker reconnects. The first turn
+// never commits, so the per-instance janitor is not yet armed: recovery must
+// come from the durable start-es reminder surviving the listener churn.
+// This test is not sensitive to the janitor period, but it is set short so a
+// janitor-based recovery would also be observed within the completion window.
+type reconnect struct {
+	workflow *workflow.Workflow
+	called   atomic.Int64
+	waitCh   chan struct{}
+}
+
+func (r *reconnect) Setup(t *testing.T) []framework.Option {
+	r.waitCh = make(chan struct{})
+	r.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0,
+			daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+			// WithWorkflowJanitorPeriod does not exist on this branch's
+			// framework, so set the env var directly.
+			daprd.WithExecOptions(exec.WithEnvVars(t,
+				"DAPR_WORKFLOW_JANITOR_PERIOD", "2s",
+			)),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.workflow),
+	}
+}
+
+func (r *reconnect) Run(t *testing.T, ctx context.Context) {
+	r.workflow.WaitUntilRunning(t, ctx)
+
+	require.NoError(t, r.workflow.Registry().AddWorkflowN("foo", func(c *task.WorkflowContext) (any, error) {
+		r.called.Add(1)
+		<-r.waitCh
+		return nil, c.CallActivity("bar").Await(nil)
+	}))
+	require.NoError(t, r.workflow.Registry().AddActivityN("bar", func(c task.ActivityContext) (any, error) {
+		return "", nil
+	}))
+
+	cctx, cancel := context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	client := r.workflow.BackendClient(t, cctx)
+
+	// A start time of now arms the durable start-es reminder with a dueTime
+	// that is already in the past by the time the scheduler processes it.
+	id, err := client.ScheduleNewWorkflow(ctx, "foo", api.WithStartTime(time.Now()))
+	require.NoError(t, err)
+
+	// The first turn is now in-flight, blocked in the workflow body.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(1), r.called.Load())
+	}, time.Second*10, time.Millisecond*10)
+
+	// Cancel the listener while the first turn is held: actor types
+	// unregister and the in-flight turn aborts without committing.
+	cancel()
+	r.workflow.WaitForNoConnectedWorkers(t, ctx)
+	close(r.waitCh)
+
+	cctx, cancel = context.WithCancel(ctx)
+	t.Cleanup(cancel)
+	client = r.workflow.BackendClient(t, cctx)
+
+	wctx, wcancel := context.WithTimeout(ctx, time.Second*10)
+	t.Cleanup(wcancel)
+	meta, err := client.WaitForWorkflowCompletion(wctx, id)
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(meta))
+
+	assert.Equal(t, int64(3), r.called.Load())
+}


### PR DESCRIPTION
Under WorkflowsFastPath, a start-time-now workflow arms both a local drive and a scheduler-fired start-es reminder, whose invocation queues on the actor turn lock behind the drive. When the worker disconnects mid-first-turn, the drive aborts and the queued reminder invocation starts a second turn whose work item lands in the executor's shared queue with no stream connected: never stream-stamped, so no disconnect cleanup can cancel it, and the turn parks forever. A circular wait then wedges the runtime: the disconnect callback holds actorRegLock while HaltAll blocks on the parked turn's lock, and the reconnecting worker's connect callback blocks on actorRegLock, so the item is never delivered. The start-es fire is held in-flight with no ack: no failure-policy retry, no staging, and no janitor (no turn ever committed). Non-fastpath escapes because the fire is the only turn and its abort acks FAILED.

Fix: a pendingtracker package wrapping the pending-tasks backend. The engine reports executor connectivity (work-item streams plus in-process registrations); when it drops to zero the tracker cancels every pending workflow and activity completion, and a registration arriving while disconnected is cancelled on arrival. Cancellation surfaces as the existing recoverable "execution aborted", so the parked turn unwinds, HaltAll drains, the fire acks FAILED, and the scheduler redelivers once the worker re-registers. Post-fix traces show exactly two start-es triggers and completion in about a second.