### PR TITLE
fix: handle NewRequest error in pathMatching.match to prevent nil deref panic

### DIFF
--- a/pkg/diagnostics/http_monitoring_path_matching.go
+++ b/pkg/diagnostics/http_monitoring_path_matching.go
@@ -92,7 +92,10 @@ func (pm *pathMatching) match(path string) (string, bool) {
 	}
 
 	cleanPath := NormalizeHTTPPath(path)
-	req, _ := http.NewRequest(http.MethodGet, cleanPath, nil)
+	req, err := http.NewRequest(http.MethodGet, cleanPath, nil)
+	if err != nil {
+		return "", false
+	}
 	if req.URL != nil {
 		req.URL.Path = cleanPath
 	}


### PR DESCRIPTION
### Problem

When an HTTP service invocation path contains a percent-encoded reserved or control character (e.g. `%1F`), the decoded path reaches `pathMatching.match()` with an unescaped control byte. Calling `http.NewRequest(method, path, nil)` on such a path returns an **error and a nil request** (`net/url: invalid control character in URL`), so the subsequent `req.URL != nil` check dereferences a nil pointer and panics the sidecar's HTTP server, killing the connection:

```
http: panic serving 127.0.0.1:35052: runtime error: invalid memory address or nil pointer dereference
github.com/dapr/dapr/pkg/diagnostics.(*pathMatching).match(...)
	http_monitoring_path_matching.go:96
```

### Fix

Capture the error returned by `http.NewRequest` and bail out early (return no match) when the path cannot be parsed, instead of dereferencing the nil request. Paths that parse cleanly are unaffected.

Fixes #10409