### PR TITLE
fix: guard circuit breaker cache maps with locks in endpoint/actor policy lookups

### DIFF
--- a/pkg/resiliency/resiliency.go
+++ b/pkg/resiliency/resiliency.go
@@ -634,14 +634,11 @@ func (r *Resiliency) EndpointPolicy(app string, endpoint string) *PolicyDefiniti
 		if policyNames.CircuitBreaker != "" {
 			template, ok := r.circuitBreakers[policyNames.CircuitBreaker]
 			if ok {
-				cache, ok := r.serviceCBs[app]
-				if ok {
-					policyDef.cb, ok = cache.Get(endpoint)
-					if !ok || policyDef.cb == nil {
-						policyDef.cb = newCB(endpoint, template, r.log)
-						cache.Add(endpoint, policyDef.cb)
-					}
+				serviceCBCache, err := r.getServiceCBCache(app)
+				if err != nil {
+					r.log.Errorf("error getting circuit breaker cache for app %s: %s", app, err)
 				}
+				policyDef.cb = r.getCBFromCache(serviceCBCache, endpoint, template)
 			}
 		}
 	} else {
@@ -768,21 +765,19 @@ func (r *Resiliency) ActorPreLockPolicy(actorType string, id string) *PolicyDefi
 		if policyNames.CircuitBreaker != "" {
 			template, ok := r.circuitBreakers[policyNames.CircuitBreaker]
 			if ok {
-				cache, ok := r.actorCBCaches[actorType]
-				if ok {
-					var key string
-					if policyNames.CircuitBreakerScope == ActorCircuitBreakerScopeType {
-						key = actorType
-					} else {
-						key = actorType + "-" + id
-					}
-
-					policyDef.cb, ok = cache.Get(key)
-					if !ok || policyDef.cb == nil {
-						policyDef.cb = newCB(key, template, r.log)
-						cache.Add(key, policyDef.cb)
-					}
+				actorCBCache, err := r.getActorCBCache(actorType)
+				if err != nil {
+					r.log.Errorf("error getting circuit breaker cache for actor type %s: %v", actorType, err)
 				}
+
+				var key string
+				if policyNames.CircuitBreakerScope == ActorCircuitBreakerScopeType {
+					key = actorType
+				} else {
+					key = actorType + "-" + id
+				}
+
+				policyDef.cb = r.getCBFromCache(actorCBCache, key, template)
 			}
 		}
 	} else {

--- a/pkg/resiliency/resiliency_test.go
+++ b/pkg/resiliency/resiliency_test.go
@@ -759,3 +759,105 @@ func concurrentPolicyExec(t *testing.T, policyDefFn func(idx int) *PolicyDefinit
 	}
 	wg.Wait()
 }
+
+// TestEndpointPolicyConcurrentCacheAccess guards against the concurrent-map
+// read/write crash (#10413). A goroutine resolving a named endpoint policy
+// reads the r.serviceCBs cache map, while another goroutine resolving a new
+// (default-policy) endpoint writes new entries to the same map under lock.
+// Go maps are not safe for concurrent read/write even on different keys, so
+// this must hold under `go test -race`.
+func TestEndpointPolicyConcurrentCacheAccess(t *testing.T) {
+	config := &resiliencyV1alpha.Resiliency{
+		Spec: resiliencyV1alpha.ResiliencySpec{
+			Policies: resiliencyV1alpha.Policies{
+				CircuitBreakers: map[string]resiliencyV1alpha.CircuitBreaker{
+					"testCB": {
+						Trip:        "consecutiveFailures > 1",
+						MaxRequests: 1,
+						Timeout:     "60s",
+					},
+					fmt.Sprintf(string(DefaultCircuitBreakerTemplate), ""): {
+						Trip:        "consecutiveFailures > 1",
+						MaxRequests: 1,
+						Timeout:     "60s",
+					},
+				},
+			},
+			Targets: resiliencyV1alpha.Targets{
+				Apps: map[string]resiliencyV1alpha.EndpointPolicyNames{
+					"namedApp": {CircuitBreaker: "testCB"},
+				},
+			},
+		},
+	}
+	r := FromConfigurations(log, config)
+
+	var wg sync.WaitGroup
+	wg.Add(20)
+	for i := range 20 {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if i%2 == 0 {
+					// Named-policy branch: previously read r.serviceCBs without a lock.
+					r.EndpointPolicy("namedApp", "localhost")
+				} else {
+					// Default-policy branch: writes a fresh entry to r.serviceCBs under lock.
+					r.EndpointPolicy(fmt.Sprintf("newApp-%d-%d", i, j), "localhost")
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}
+
+// TestActorPreLockPolicyConcurrentCacheAccess is the actor-cache analogue of
+// TestEndpointPolicyConcurrentCacheAccess (see #10413).
+func TestActorPreLockPolicyConcurrentCacheAccess(t *testing.T) {
+	config := &resiliencyV1alpha.Resiliency{
+		Spec: resiliencyV1alpha.ResiliencySpec{
+			Policies: resiliencyV1alpha.Policies{
+				CircuitBreakers: map[string]resiliencyV1alpha.CircuitBreaker{
+					"testCB": {
+						Trip:        "consecutiveFailures > 1",
+						MaxRequests: 1,
+						Timeout:     "60s",
+					},
+					fmt.Sprintf(string(DefaultCircuitBreakerTemplate), ""): {
+						Trip:        "consecutiveFailures > 1",
+						MaxRequests: 1,
+						Timeout:     "60s",
+					},
+				},
+			},
+			Targets: resiliencyV1alpha.Targets{
+				Actors: map[string]resiliencyV1alpha.ActorPolicyNames{
+					"namedActorType": {
+						CircuitBreaker:          "testCB",
+						CircuitBreakerScope:     "type",
+						CircuitBreakerCacheSize: 100,
+					},
+				},
+			},
+		},
+	}
+	r := FromConfigurations(log, config)
+
+	var wg sync.WaitGroup
+	wg.Add(20)
+	for i := range 20 {
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 200; j++ {
+				if i%2 == 0 {
+					// Named-policy branch: previously read r.actorCBCaches without a lock.
+					r.ActorPreLockPolicy("namedActorType", "actorID")
+				} else {
+					// Default-policy branch: writes a fresh entry to r.actorCBCaches under lock.
+					r.ActorPreLockPolicy(fmt.Sprintf("newActor-%d-%d", i, j), "actorID")
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
## What this PR does

Fixes #10413 — daprd can crash with a fatal `concurrent map read and map write`

`EndpointPolicy` (for named app policies) and `ActorPreLockPolicy` (for named actor-type policies) read the `r.serviceCBs` / `r.actorCBCaches` maps **without holding a lock**:

```go
cache, ok := r.serviceCBs[app]            // /\* unsynchronized read \*/
cache, ok := r.actorCBCaches[actorType]   // /\* unsynchronized read \*/
```

At the same time, the **default-policy** branch writes to those same maps under `r.serviceCBsMu` / `r.actorCBsCachesMu` (via `getServiceCBCache` / `getActorCBCache`). Go maps are not safe for concurrent read/write — even on different keys — so a goroutine hitting the named-policy branch while another is populating the default cache triggers Go's fatal, non-recoverable map-corruption error, taking down the whole sidecar.

## Fix

Route the named-policy branches through the same already-locked helpers used by the default-policy branch:

- `EndpointPolicy`: `r.getServiceCBCache(app)` + `r.getCBFromCache(serviceCBCache, endpoint, template)`
- `ActorPreLockPolicy`: `r.getActorCBCache(actorType)` + `r.getCBFromCache(actorCBCache, key, template)` (preserving the pre-lock scope-based cache key)

## Tests

Two new concurrent tests (`TestEndpointPolicyConcurrentCacheAccess`, `TestActorPreLockPolicyConcurrentCacheAccess`) that interleave named-policy lookups with default-policy cache creation; both reproduce the original data race under `go test -race` and pass with this fix.
