### PR TITLE
[1.18] workflow: fix spurious failures under history signing (#10403)

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/accesspolicy.go
+++ b/pkg/actors/targets/workflow/orchestrator/accesspolicy.go
@@ -20,6 +20,7 @@ import (
 	"google.golang.org/grpc/status"
 
 	workflowacl "github.com/dapr/dapr/pkg/acl/workflow"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/messages"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
@@ -31,6 +32,23 @@ const workflowACLDeniedMsg = "access denied by workflow access policy"
 // preLoadedMeta lets callers that have already loaded the actor's metadata
 // (e.g. handleStream which needs ometa for the response anyway) skip the
 // state load inside the access check. Pass nil to load on demand.
+// isLocalSyntheticFailure reports whether e is a failure event this app authored
+// itself (a WorkflowAccessPolicy denial or an occupied-instance-ID rejection)
+// rather than a completion received over the wire. Such events carry no
+// attestation by design, so they must not be checked against one. A remote
+// completion carries the sender's appID and is unaffected.
+func (o *orchestrator) isLocalSyntheticFailure(e *backend.HistoryEvent) bool {
+	if e.GetRouter().GetSourceAppID() != o.appID {
+		return false
+	}
+	fd := e.GetChildWorkflowInstanceFailed().GetFailureDetails()
+	if fd == nil {
+		fd = e.GetTaskFailed().GetFailureDetails()
+	}
+	et := fd.GetErrorType()
+	return et == messages.ErrorTypeAccessPolicyDenied || et == messages.ErrorTypeAlreadyExists
+}
+
 func (o *orchestrator) checkAccessPolicy(ctx context.Context, method string, data []byte, parsedAddEvent *backend.HistoryEvent, preLoadedMeta *backend.WorkflowMetadata, md map[string]*internalsv1pb.ListStringValue) error {
 	if o.workflowAccessPolicies == nil {
 		return nil

--- a/pkg/actors/targets/workflow/orchestrator/add.go
+++ b/pkg/actors/targets/workflow/orchestrator/add.go
@@ -15,9 +15,16 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
+	"fmt"
+
+	"google.golang.org/protobuf/proto"
 
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/dedup"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
+	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/backend"
 )
@@ -45,11 +52,11 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 	// On a tombstoned workflow (cold-store load tamper or attestation
 	// verification failure - identified by the unsigned tamper marker at
 	// the end of history) reject inbound activity / child-workflow
-	// completion events with ErrInstanceNotFound. The activity actor
-	// treats ErrInstanceNotFound as terminal and stops re-delivering, so
-	// we don't loop the parent's actor lock against a workflow that will
-	// never accept the result. Other event types (RaiseEvent, terminate,
-	// etc.) still flow through.
+	// completion events with ErrInstanceNotFound. The activity actor and
+	// the child workflow's completion dispatch treat ErrInstanceNotFound
+	// as terminal and stop re-delivering, so we don't loop the parent's
+	// actor lock against a workflow that will never accept the result.
+	// Other event types (RaiseEvent, terminate, etc.) still flow through.
 	isCompletion := e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil ||
 		e.GetChildWorkflowInstanceCompleted() != nil || e.GetChildWorkflowInstanceFailed() != nil
 	if isCompletion && state.HasTamperMarker() {
@@ -89,30 +96,8 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 		o.activityResultAwaited.CompareAndSwap(true, false)
 	}
 
-	// Verify any attestation on the incoming event against the signed history
-	// and Sentry trust anchors, then absorb the signer certificate into the
-	// ext-sigcert table and strip the companion cert from the event so the
-	// stored form is cert-free. On any verification failure the workflow is
-	// tombstoned. No-op when signing is disabled.
-	if verr := o.signing.VerifyInboxAttestation(ctx, state, e); verr != nil {
-		log.Warnf("Workflow actor '%s': attestation verification failed, tombstoning workflow: %s", o.actorID, verr)
-		opts := wfenginestate.Options{
-			AppID:             o.appID,
-			Namespace:         o.namespace,
-			WorkflowActorType: o.actorType,
-			ActivityActorType: o.activityActorType,
-			Signer:            o.signer,
-		}
-		if _, _, terr := o.tombstoneTamperedState(ctx, opts, state, verr); terr != nil {
-			return terr
-		}
-		// Return ErrInstanceNotFound rather than the verification
-		// error so the activity actor on the sender side recognizes
-		// the workflow as gone and stops re-executing the activity.
-		// The reason for tombstoning is preserved in the workflow's
-		// FailureDetails (errorType=DAPR_WORKFLOW_HISTORY_TAMPERED,
-		// errorMessage=verr.Error()) for callers polling metadata.
-		return api.ErrInstanceNotFound
+	if err := o.verifyAndAbsorbAttestation(ctx, state, e); err != nil {
+		return err
 	}
 
 	// Save the inbox event BEFORE creating the wake-up reminder. The
@@ -150,4 +135,82 @@ func (o *orchestrator) addWorkflowEvent(ctx context.Context, e *backend.HistoryE
 	}
 
 	return nil
+}
+
+// verifyAndAbsorbAttestation verifies any attestation on the incoming event
+// against the signed history and Sentry trust anchors, absorbs the signer
+// certificate into the ext-sigcert table, and strips it from the event.
+// Unmatched completions are dropped; genuine verification failures tombstone
+// the workflow. Both return ErrInstanceNotFound so the sender stops
+// re-delivering. No-op when signing is disabled; locally-authored synthetic
+// failures are exempt (no attestation by design).
+func (o *orchestrator) verifyAndAbsorbAttestation(ctx context.Context, state *wfenginestate.State, e *backend.HistoryEvent) error {
+	if o.isLocalSyntheticFailure(e) {
+		return nil
+	}
+	verr := o.signing.VerifyInboxAttestation(ctx, state, e)
+	if verr == nil {
+		return nil
+	}
+
+	// Reclassify against durable truth before acting: a stale cache can make
+	// a legitimate completion look tampered or unmatched, the unknown-id drop
+	// below is terminal for the sender, and tombstoning is permanent. Load
+	// failures are retryable; the fresh verdict and state drive the decision.
+	// Verify a clone so nothing is observably mutated.
+	opts := wfenginestate.Options{
+		AppID:             o.appID,
+		Namespace:         o.namespace,
+		WorkflowActorType: o.actorType,
+		ActivityActorType: o.activityActorType,
+		Signer:            o.signer,
+	}
+	fresh, lerr := wfenginestate.LoadWorkflowState(ctx, o.actorState, o.actorID, opts)
+	if lerr != nil {
+		// A verification failure from the durable load is independent
+		// confirmation of tampering, not a transient condition: tombstone
+		// rather than retry forever.
+		var verifyErr *staterrors.VerificationError
+		if errors.As(lerr, &verifyErr) {
+			log.Warnf("Workflow actor '%s': durable state failed verification while classifying an attestation failure, tombstoning workflow: %s", o.actorID, lerr)
+			condemned := fresh
+			if condemned == nil {
+				condemned = state
+			}
+			if _, _, terr := o.tombstoneTamperedState(ctx, opts, condemned, lerr); terr != nil {
+				return terr
+			}
+			return api.ErrInstanceNotFound
+		}
+		return wferrors.NewRecoverable(fmt.Errorf("failed to reload state to classify attestation failure (%s): %w", verr, lerr))
+	}
+	if fresh == nil {
+		// Purged since the cached load: nothing to protect.
+		return api.ErrInstanceNotFound
+	}
+	clone, _ := proto.Clone(e).(*backend.HistoryEvent)
+	if clone == nil {
+		return wferrors.NewRecoverable(errors.New("failed to clone event to classify attestation failure"))
+	}
+	fverr := o.signing.VerifyInboxAttestation(ctx, fresh, clone)
+	if fverr == nil {
+		log.Warnf("Workflow actor '%s': attestation verification failed against cached state but passed against durable state; refreshing cache and asking the sender to retry: %s", o.actorID, verr)
+		o.invalidateCachedState()
+		return verr
+	}
+
+	// Not tampering: ContinueAsNew resets history and a rolled-back save can
+	// retract a scheduling row, so drop the unmatched completion like the
+	// unsigned path does (stripUnmatchedResolutions). Nothing is persisted,
+	// so a forged completion gains an attacker nothing.
+	if errors.Is(fverr, signing.ErrUnknownTaskScheduledID) {
+		log.Warnf("Workflow actor '%s': dropping completion with no matching scheduled task in signed history: %s", o.actorID, fverr)
+		return api.ErrInstanceNotFound
+	}
+
+	log.Warnf("Workflow actor '%s': attestation verification failed, tombstoning workflow: %s", o.actorID, fverr)
+	if _, _, terr := o.tombstoneTamperedState(ctx, opts, fresh, fverr); terr != nil {
+		return terr
+	}
+	return api.ErrInstanceNotFound
 }

--- a/pkg/actors/targets/workflow/orchestrator/add_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/add_test.go
@@ -15,22 +15,36 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
 	"strconv"
 	"strings"
 	"sync"
 	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	"github.com/dapr/kit/crypto/spiffe/signer"
+
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/fake"
 	"github.com/dapr/dapr/pkg/actors/reminders"
 	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
+	actorstate "github.com/dapr/dapr/pkg/actors/state"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
@@ -177,4 +191,135 @@ func Test_addWorkflowEvent_dedupReAssertsReminder(t *testing.T) {
 		"dedup branch must not append to the inbox (the duplicate is already there)")
 	assert.Len(t, wfState.History, len(history),
 		"dedup branch must not touch history")
+}
+
+// Test_addWorkflowEvent_unknownTaskIDDroppedNotTombstoned pins the signing
+// behavior for a completion that fails verification while the durable state
+// is gone (the fake store is empty): dropped with ErrInstanceNotFound, no
+// tombstone, nothing persisted. The sentinel classification itself is pinned
+// by the signing package unit tests and the canstraggler integration test.
+func Test_addWorkflowEvent_unknownTaskIDDroppedNotTombstoned(t *testing.T) {
+	const instanceID = "test-unknown-task-wf"
+
+	startEvent := &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name:  "TestWorkflow",
+				Input: wrapperspb.String(`null`),
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: instanceID,
+				},
+			},
+		},
+	}
+	history := []*backend.HistoryEvent{startEvent}
+
+	wfState := state.NewState(state.Options{
+		AppID:             "testapp",
+		Namespace:         "default",
+		WorkflowActorType: "dapr.internal.default.testapp.workflow",
+		ActivityActorType: "dapr.internal.default.testapp.activity",
+	})
+	for _, e := range history {
+		wfState.AddToHistory(e)
+	}
+
+	var (
+		mu       sync.Mutex
+		creates  []*actorapi.CreateReminderRequest
+		fakeRems = remindersfake.New().
+				WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
+				mu.Lock()
+				defer mu.Unlock()
+				creates = append(creates, req)
+				return nil
+			})
+	)
+	// The drop path corroborates against durable state before classifying;
+	// answer that probe with an empty store (the statefake default returns a
+	// nil response, which the loader does not expect from a real store).
+	fakeState := statefake.New().WithGetFn(func(context.Context, *actorapi.GetStateRequest, bool) (*actorapi.StateResponse, error) {
+		return &actorapi.StateResponse{}, nil
+	})
+	actors := fake.New().WithReminders(func(context.Context) (reminders.Interface, error) {
+		return fakeRems, nil
+	}).WithState(func(context.Context) (actorstate.Interface, error) {
+		return fakeState, nil
+	})
+
+	fact, err := New(t.Context(), Options{
+		AppID:             "testapp",
+		Namespace:         "default",
+		WorkflowActorType: "dapr.internal.default.testapp.workflow",
+		ActivityActorType: "dapr.internal.default.testapp.activity",
+		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
+		Actors:            actors,
+		Signer:            testAddSigner(t),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+	o.state = wfState
+	o.rstate = runtimestate.NewWorkflowRuntimeState(instanceID, nil, history)
+	o.ometa = o.ometaFromState(o.rstate, startEvent.GetExecutionStarted())
+
+	// A completion for a task never scheduled in this history. The attestation
+	// only needs to be non-nil: the unknown-id check precedes verification.
+	incoming := &protos.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 42,
+				Result:          wrapperspb.String(`"late"`),
+				Attestation:     &backend.ActivityCompletionAttestation{},
+			},
+		},
+	}
+
+	err = o.addWorkflowEvent(t.Context(), incoming)
+	require.ErrorIs(t, err, api.ErrInstanceNotFound)
+
+	assert.False(t, wfState.HasTamperMarker(),
+		"an unknown task scheduled id must not tombstone the workflow as tampered")
+	assert.Empty(t, wfState.Inbox, "the dropped completion must not be persisted")
+	assert.Len(t, wfState.History, len(history), "history must be untouched")
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Empty(t, creates, "no wake-up reminder for a dropped event")
+}
+
+func testAddSigner(t *testing.T) *signer.Signer {
+	t.Helper()
+	pub, priv, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC),
+		NotAfter:     time.Date(2027, 1, 1, 0, 0, 0, 0, time.UTC),
+		URIs:         []*url.URL{{Scheme: "spiffe", Host: "example.org", Path: "/ns/default/app-a"}},
+	}
+	certDER, err := x509.CreateCertificate(rand.Reader, template, template, pub, priv)
+	require.NoError(t, err)
+	certs, err := x509.ParseCertificates(certDER)
+	require.NoError(t, err)
+	id, err := x509svid.IDFromCert(certs[0])
+	require.NoError(t, err)
+	return signer.New(staticTestSVIDSource{svid: &x509svid.SVID{
+		ID:           id,
+		Certificates: certs,
+		PrivateKey:   priv,
+	}}, nil)
+}
+
+type staticTestSVIDSource struct {
+	svid *x509svid.SVID
+}
+
+func (s staticTestSVIDSource) GetX509SVID() (*x509svid.SVID, error) {
+	return s.svid, nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/messages/messages.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/messages.go
@@ -145,6 +145,18 @@ func (m *Messages) callStateMessage(ctx context.Context, msg proto.Message, hist
 		WithData(b).
 		WithContentType(invokev1.ProtobufContentType),
 	); err != nil {
+		// ErrInstanceNotFound means the parent deliberately dropped the
+		// completion (purged, tombstoned, or an unmatched straggler after
+		// ContinueAsNew): terminal, since retrying redelivers forever and a
+		// late redelivery can hit a reused task id and be misread as
+		// tampering.
+		if historyEvent != nil &&
+			(historyEvent.GetChildWorkflowInstanceCompleted() != nil || historyEvent.GetChildWorkflowInstanceFailed() != nil) &&
+			IsInstanceNotFound(err) {
+			log.Warnf("Workflow actor '%s': parent workflow '%s' dropped this child's completion event; not retrying: %v", m.ActorID, target, err)
+			return nil
+		}
+
 		// If the call was denied by a workflow access policy or the target
 		// instance ID is already taken by another workflow, fail the child
 		// orchestration immediately rather than retrying. Only do this when

--- a/pkg/actors/targets/workflow/orchestrator/messages/messages_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/messages_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messages
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// Test_CallAddEventStateMessage_ChildCompletionNotFoundIsTerminal pins that a
+// parent refusing a child completion with api.ErrInstanceNotFound (purged,
+// tombstoned, or a dropped straggler after ContinueAsNew) is terminal: the
+// dispatch is treated as delivered so the child's turn commits instead of
+// redelivering forever, where a later redelivery can collide with a reused
+// task id and be misread as tampering. Any other error keeps the dispatch
+// failed so the turn retries.
+func Test_CallAddEventStateMessage_ChildCompletionNotFoundIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	newMsg := func() *backend.WorkflowRuntimeStateMessage {
+		return &backend.WorkflowRuntimeStateMessage{
+			TargetInstanceId: "parent-instance",
+			HistoryEvent: &backend.HistoryEvent{
+				EventId: 5,
+				EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+					ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+						TaskScheduledId: 1,
+					},
+				},
+			},
+		}
+	}
+
+	newMessages := func(callErr error) (*Messages, *int) {
+		calls := new(int)
+		return &Messages{
+			AppID:     "app",
+			ActorID:   "child-instance",
+			ActorType: "dapr.internal.default.app.workflow",
+			Router: routerfake.New().WithCallFn(func(context.Context, *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
+				*calls++
+				return nil, callErr
+			}),
+		}, calls
+	}
+
+	t.Run("instance not found is treated as delivered", func(t *testing.T) {
+		t.Parallel()
+		m, calls := newMessages(errors.New("failed to invoke method 'AddWorkflowEvent' on actor 'parent-instance': no such instance exists"))
+		res := m.CallAddEventStateMessage(t.Context(), []*backend.WorkflowRuntimeStateMessage{newMsg()})
+		require.NoError(t, res.Err)
+		assert.Empty(t, res.FailedEventIDs)
+		assert.Equal(t, 1, *calls)
+	})
+
+	t.Run("other errors keep the dispatch failed", func(t *testing.T) {
+		t.Parallel()
+		m, calls := newMessages(errors.New("connection refused"))
+		res := m.CallAddEventStateMessage(t.Context(), []*backend.WorkflowRuntimeStateMessage{newMsg()})
+		require.Error(t, res.Err)
+		assert.Len(t, res.FailedEventIDs, 1)
+		assert.Equal(t, 1, *calls)
+	})
+}

--- a/pkg/actors/targets/workflow/orchestrator/messages/status.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/status.go
@@ -15,9 +15,12 @@ package messages
 
 import (
 	"errors"
+	"strings"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+
+	"github.com/dapr/durabletask-go/api"
 )
 
 const (
@@ -32,6 +35,19 @@ func IsPermissionDenied(err error) bool {
 
 func IsAlreadyExists(err error) bool {
 	return hasGRPCStatusCode(err, codes.AlreadyExists)
+}
+
+// IsInstanceNotFound reports api.ErrInstanceNotFound, including when actor
+// invocation flattened it to a wire string (suffix match, as recursive purge
+// does).
+func IsInstanceNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, api.ErrInstanceNotFound) {
+		return true
+	}
+	return strings.HasSuffix(err.Error(), api.ErrInstanceNotFound.Error())
 }
 
 // hasGRPCStatusCode checks whether the error (possibly wrapped) contains the

--- a/pkg/actors/targets/workflow/orchestrator/messages/status_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/messages/status_test.go
@@ -1,0 +1,90 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package messages
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	"github.com/dapr/durabletask-go/api"
+)
+
+func TestIsPermissionDenied(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsPermissionDenied(nil))
+	})
+
+	t.Run("PermissionDenied gRPC error", func(t *testing.T) {
+		err := status.Error(codes.PermissionDenied, "access denied by workflow access policy")
+		assert.True(t, IsPermissionDenied(err))
+	})
+
+	t.Run("non-PermissionDenied gRPC error", func(t *testing.T) {
+		err := status.Error(codes.NotFound, "not found")
+		assert.False(t, IsPermissionDenied(err))
+	})
+
+	t.Run("plain error is not denied", func(t *testing.T) {
+		assert.False(t, IsPermissionDenied(errors.New("some other error")))
+	})
+}
+
+func TestIsAlreadyExists(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsAlreadyExists(nil))
+	})
+
+	t.Run("AlreadyExists gRPC error", func(t *testing.T) {
+		err := status.Error(codes.AlreadyExists, "an active workflow with ID 'x' already exists")
+		assert.True(t, IsAlreadyExists(err))
+	})
+
+	t.Run("non-AlreadyExists gRPC error", func(t *testing.T) {
+		err := status.Error(codes.PermissionDenied, "denied")
+		assert.False(t, IsAlreadyExists(err))
+	})
+}
+
+func TestIsInstanceNotFound(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		assert.False(t, IsInstanceNotFound(nil))
+	})
+
+	t.Run("direct sentinel", func(t *testing.T) {
+		assert.True(t, IsInstanceNotFound(api.ErrInstanceNotFound))
+	})
+
+	t.Run("wrapped sentinel", func(t *testing.T) {
+		assert.True(t, IsInstanceNotFound(fmt.Errorf("dispatch: %w", api.ErrInstanceNotFound)))
+	})
+
+	t.Run("wire string suffix from actor invocation", func(t *testing.T) {
+		err := errors.New("failed to invoke method 'AddWorkflowEvent' on actor 'wf-1': api error: code = Unknown desc = no such instance exists")
+		assert.True(t, IsInstanceNotFound(err))
+	})
+
+	t.Run("wire string not at suffix", func(t *testing.T) {
+		err := errors.New("no such instance exists: while doing something else")
+		assert.False(t, IsInstanceNotFound(err))
+	})
+
+	t.Run("unrelated error", func(t *testing.T) {
+		assert.False(t, IsInstanceNotFound(errors.New("connection refused")))
+	})
+}

--- a/pkg/actors/targets/workflow/orchestrator/signing/signing_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing/signing_test.go
@@ -292,7 +292,7 @@ func TestSignNewEvents_RoundTripDeterminism(t *testing.T) {
 	require.Len(t, st.Signatures, 1)
 	require.Len(t, st.RawSignatures, 1)
 
-	// Build save request — this is what goes to the state store.
+	// Build save request: this is what goes to the state store.
 	req, err := st.GetSaveRequest("test-actor")
 	require.NoError(t, err)
 
@@ -510,4 +510,302 @@ func TestVerifyInboxAttestation_MissingActivityAttestationReturnsError(t *testin
 	err := o.VerifyInboxAttestation(t.Context(), st, e)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "missing required attestation")
+}
+
+func TestVerifyInboxAttestation_UnknownActivityTaskIDReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	// History holds a scheduling event for a DIFFERENT task id, as after a
+	// ContinueAsNew history reset or a rolled-back save.
+	st := testState(makeTaskScheduledEvent(3, "say", "hello"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildActivityAttestation(sgn, historysigning.ActivityAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: 7,
+		ActivityName:          "say",
+		Input:                 wrapperspb.String("hello"),
+		Output:                wrapperspb.String("world"),
+		TerminalStatus:        protos.ActivityTerminalStatus_ACTIVITY_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	e := &backend.HistoryEvent{
+		EventId:   100,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId:   7,
+				Result:            wrapperspb.String("world"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.ErrorIs(t, err, ErrUnknownTaskScheduledID)
+	assert.Empty(t, st.ExternalSigningCertificates)
+}
+
+func TestVerifyInboxAttestation_UnknownChildTaskIDReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	st := testState(makeChildCreatedEvent(2, "child-instance", "in"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildChildAttestation(sgn, historysigning.ChildAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: 9,
+		Input:                 wrapperspb.String("in"),
+		Output:                wrapperspb.String("out"),
+		TerminalStatus:        protos.TerminalStatus_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	e := &backend.HistoryEvent{
+		EventId:   200,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId:   9,
+				Result:            wrapperspb.String("out"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.ErrorIs(t, err, ErrUnknownTaskScheduledID)
+	assert.Empty(t, st.ExternalSigningCertificates)
+}
+
+func TestVerifyInboxAttestation_StaleChildOnReusedTaskIDReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	const taskID int32 = 9
+	// Current history records a different invocation at the straggler's task
+	// id, as after a ContinueAsNew history reset reused the id.
+	st := testState(makeChildCreatedEvent(taskID, "child-new", "new-input"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildChildAttestation(sgn, historysigning.ChildAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: taskID,
+		Input:                 wrapperspb.String("old-input"),
+		Output:                wrapperspb.String("out"),
+		TerminalStatus:        protos.TerminalStatus_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	e := &backend.HistoryEvent{
+		EventId:   200,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId:   taskID,
+				Result:            wrapperspb.String("out"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.ErrorIs(t, err, ErrUnknownTaskScheduledID,
+		"a genuinely attested completion for a superseded invocation must be dropped, not tombstone")
+	assert.Empty(t, st.ExternalSigningCertificates)
+}
+
+func TestVerifyInboxAttestation_StaleChildTamperedSignatureStillTombstones(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	const taskID int32 = 9
+	st := testState(makeChildCreatedEvent(taskID, "child-new", "new-input"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildChildAttestation(sgn, historysigning.ChildAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: taskID,
+		Input:                 wrapperspb.String("old-input"),
+		Output:                wrapperspb.String("out"),
+		TerminalStatus:        protos.TerminalStatus_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	tamperedSig := make([]byte, len(att.GetSignature()))
+	copy(tamperedSig, att.GetSignature())
+	tamperedSig[0] ^= 0xFF
+	att.Signature = tamperedSig
+
+	e := &backend.HistoryEvent{
+		EventId:   200,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId:   taskID,
+				Result:            wrapperspb.String("out"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUnknownTaskScheduledID,
+		"an unverifiable attestation must never be classified as a stale completion")
+	assert.Contains(t, err.Error(), "verification failed")
+}
+
+func TestVerifyInboxAttestation_StaleChildStatusMismatchStillTombstones(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	const taskID int32 = 9
+	st := testState(makeChildCreatedEvent(taskID, "child-instance", "in"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	// Genuine attestation for a FAILED outcome delivered inside a Completed
+	// event: the enclosing event type contradicts the signed terminal status.
+	att, certChain, err := historysigning.BuildChildAttestation(sgn, historysigning.ChildAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: taskID,
+		Input:                 wrapperspb.String("in"),
+		TerminalStatus:        protos.TerminalStatus_TERMINAL_STATUS_FAILED,
+	})
+	require.NoError(t, err)
+
+	e := &backend.HistoryEvent{
+		EventId:   200,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+			ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+				TaskScheduledId:   taskID,
+				Result:            wrapperspb.String("out"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUnknownTaskScheduledID,
+		"a terminal status contradiction is tampering evidence, not a stale completion")
+}
+
+func TestVerifyInboxAttestation_StaleActivityOnReusedTaskIDReturnsSentinel(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	const taskID int32 = 7
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildActivityAttestation(sgn, historysigning.ActivityAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: taskID,
+		ActivityName:          "say",
+		Input:                 wrapperspb.String("old-input"),
+		Output:                wrapperspb.String("world"),
+		TerminalStatus:        protos.ActivityTerminalStatus_ACTIVITY_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	newEvent := func() *backend.HistoryEvent {
+		return &backend.HistoryEvent{
+			EventId:   100,
+			Timestamp: timestamppb.New(time.Now()),
+			EventType: &protos.HistoryEvent_TaskCompleted{
+				TaskCompleted: &protos.TaskCompletedEvent{
+					TaskScheduledId:   taskID,
+					Result:            wrapperspb.String("world"),
+					Attestation:       att,
+					SignerCertificate: certChain,
+				},
+			},
+		}
+	}
+
+	t.Run("same name, different input", func(t *testing.T) {
+		st := testState(makeTaskScheduledEvent(taskID, "say", "new-input"))
+		err := o.VerifyInboxAttestation(t.Context(), st, newEvent())
+		require.ErrorIs(t, err, ErrUnknownTaskScheduledID)
+		assert.Empty(t, st.ExternalSigningCertificates)
+	})
+
+	t.Run("different activity name", func(t *testing.T) {
+		st := testState(makeTaskScheduledEvent(taskID, "compute", "old-input"))
+		err := o.VerifyInboxAttestation(t.Context(), st, newEvent())
+		require.ErrorIs(t, err, ErrUnknownTaskScheduledID)
+		assert.Empty(t, st.ExternalSigningCertificates)
+	})
+}
+
+func TestVerifyInboxAttestation_StaleActivityTamperedSignatureStillTombstones(t *testing.T) {
+	t.Parallel()
+
+	certDER, priv := generateTestCert(t)
+	sgn := testSignerWithTrust(t, certDER, priv, true)
+
+	const taskID int32 = 7
+	st := testState(makeTaskScheduledEvent(taskID, "say", "new-input"))
+
+	o := &Signing{Signer: sgn, ActorID: "parent-instance"}
+
+	att, certChain, err := historysigning.BuildActivityAttestation(sgn, historysigning.ActivityAttestationInput{
+		ParentInstanceId:      o.ActorID,
+		ParentTaskScheduledId: taskID,
+		ActivityName:          "say",
+		Input:                 wrapperspb.String("old-input"),
+		Output:                wrapperspb.String("world"),
+		TerminalStatus:        protos.ActivityTerminalStatus_ACTIVITY_TERMINAL_STATUS_COMPLETED,
+	})
+	require.NoError(t, err)
+
+	tamperedSig := make([]byte, len(att.GetSignature()))
+	copy(tamperedSig, att.GetSignature())
+	tamperedSig[0] ^= 0xFF
+	att.Signature = tamperedSig
+
+	e := &backend.HistoryEvent{
+		EventId:   100,
+		Timestamp: timestamppb.New(time.Now()),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId:   taskID,
+				Result:            wrapperspb.String("world"),
+				Attestation:       att,
+				SignerCertificate: certChain,
+			},
+		},
+	}
+
+	err = o.VerifyInboxAttestation(t.Context(), st, e)
+	require.Error(t, err)
+	require.NotErrorIs(t, err, ErrUnknownTaskScheduledID)
+	assert.Contains(t, err.Error(), "verification failed")
 }

--- a/pkg/actors/targets/workflow/orchestrator/signing/verify.go
+++ b/pkg/actors/targets/workflow/orchestrator/signing/verify.go
@@ -14,10 +14,13 @@ limitations under the License.
 package signing
 
 import (
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
+	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
 	diag "github.com/dapr/dapr/pkg/diagnostics"
@@ -26,6 +29,13 @@ import (
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/historysigning"
 )
+
+// ErrUnknownTaskScheduledID marks a completion whose task scheduled id is
+// absent from signed history or records a different invocation (ids restart
+// after ContinueAsNew). Not proof of tampering: ContinueAsNew resets history
+// and a store fault can roll back a save after dispatch. Callers should drop
+// the event like the unsigned path does, not tombstone.
+var ErrUnknownTaskScheduledID = errors.New("completion does not correspond to a task scheduled in signed history")
 
 // VerifyInboxAttestation validates an attestation on an inbound completion
 // event, absorbs the signer certificate into the state's ext-sigcert table for
@@ -150,7 +160,7 @@ type verifyChildOptions struct {
 func (s *Signing) verifyChild(ctx context.Context, opts verifyChildOptions) error {
 	created := opts.state.FindHistoryEventByID(opts.taskID).GetChildWorkflowInstanceCreated()
 	if created == nil {
-		return fmt.Errorf("child completion references unknown task scheduled id %d", opts.taskID)
+		return fmt.Errorf("child completion: %w (task %d)", ErrUnknownTaskScheduledID, opts.taskID)
 	}
 
 	certDigest := historysigning.CertDigest(opts.certDER)
@@ -174,6 +184,9 @@ func (s *Signing) verifyChild(ctx context.Context, opts verifyChildOptions) erro
 		ChainOfTrustVerifiedExternally: chainOfTrustVerifiedExternally,
 	})
 	if err != nil {
+		if s.isStaleChildCompletion(opts, created, chainOfTrustVerifiedExternally) {
+			return fmt.Errorf("child completion for task %d reports a superseded invocation of a reused scheduled id: %w", opts.taskID, ErrUnknownTaskScheduledID)
+		}
 		return fmt.Errorf("child attestation verification failed for task %d: %w", opts.taskID, err)
 	}
 	if payload.GetTerminalStatus() != opts.expectedStatus {
@@ -205,7 +218,7 @@ type verifyActivityOptions struct {
 func (s *Signing) verifyActivity(ctx context.Context, opts verifyActivityOptions) error {
 	scheduled := opts.state.FindHistoryEventByID(opts.taskID).GetTaskScheduled()
 	if scheduled == nil {
-		return fmt.Errorf("activity completion references unknown task scheduled id %d", opts.taskID)
+		return fmt.Errorf("activity completion: %w (task %d)", ErrUnknownTaskScheduledID, opts.taskID)
 	}
 
 	certDigest := historysigning.CertDigest(opts.certDER)
@@ -230,6 +243,9 @@ func (s *Signing) verifyActivity(ctx context.Context, opts verifyActivityOptions
 		ChainOfTrustVerifiedExternally: chainOfTrustVerifiedExternally,
 	})
 	if err != nil {
+		if s.isStaleActivityCompletion(opts, scheduled, chainOfTrustVerifiedExternally) {
+			return fmt.Errorf("activity completion for task %d reports a superseded invocation of a reused scheduled id: %w", opts.taskID, ErrUnknownTaskScheduledID)
+		}
 		return fmt.Errorf("activity attestation verification failed for task %d: %w", opts.taskID, err)
 	}
 	if payload.GetTerminalStatus() != opts.expectedStatus {
@@ -245,4 +261,102 @@ func (s *Signing) verifyActivity(ctx context.Context, opts verifyActivityOptions
 		return fmt.Errorf("activity attestation: failed to absorb signer cert for task %d: %w", opts.taskID, err)
 	}
 	return nil
+}
+
+// isStaleChildCompletion reports whether a child completion that failed full
+// verification is a straggler for a superseded invocation of a reused task id
+// (ids restart after ContinueAsNew) rather than tampering. The wire carries
+// no child instance id, so the check is by error class: the attestation must
+// be genuinely signed, trusted, and bound to this parent, task id, and
+// status, with only the io digest disagreeing with the recorded invocation.
+// Bad signatures, untrusted certs, and wrong bindings still tombstone.
+func (s *Signing) isStaleChildCompletion(opts verifyChildOptions, created *protos.ChildWorkflowInstanceCreatedEvent, chainVerified bool) bool {
+	if opts.att == nil || s.Signer == nil {
+		return false
+	}
+
+	var payload protos.ChildCompletionAttestationPayload
+	if proto.Unmarshal(opts.att.GetPayload(), &payload) != nil {
+		return false
+	}
+	if payload.GetCanonicalSpecVersion() != historysigning.CanonicalSpecVersion ||
+		payload.GetParentInstanceId() != s.ActorID ||
+		payload.GetParentTaskScheduledId() != opts.taskID ||
+		payload.GetTerminalStatus() != opts.expectedStatus {
+		return false
+	}
+
+	if !bytes.Equal(historysigning.CertDigest(opts.certDER), payload.GetSignerCertDigest()) {
+		return false
+	}
+	if s.Signer.VerifySignature(historysigning.PayloadSignatureInput(opts.att.GetPayload()), opts.att.GetSignature(), opts.certDER) != nil {
+		return false
+	}
+	if !chainVerified && s.Signer.VerifyCertChainOfTrust(opts.certDER, opts.eventTS) != nil {
+		return false
+	}
+
+	out, ok := canonicalOutput(opts.expectedStatus == protos.TerminalStatus_TERMINAL_STATUS_COMPLETED, opts.output, opts.failure)
+	if !ok {
+		return false
+	}
+	return !bytes.Equal(historysigning.IODigest(historysigning.CanonicalInput(created.GetInput()), out), payload.GetIoDigest())
+}
+
+// isStaleActivityCompletion is the activity counterpart of
+// isStaleChildCompletion: a genuinely signed attestation bound to this parent
+// instance, task id, and terminal status whose activity name or io digest
+// does not match the invocation currently recorded at that task id.
+func (s *Signing) isStaleActivityCompletion(opts verifyActivityOptions, scheduled *protos.TaskScheduledEvent, chainVerified bool) bool {
+	if opts.att == nil || s.Signer == nil {
+		return false
+	}
+
+	var payload protos.ActivityCompletionAttestationPayload
+	if proto.Unmarshal(opts.att.GetPayload(), &payload) != nil {
+		return false
+	}
+	if payload.GetCanonicalSpecVersion() != historysigning.CanonicalSpecVersion ||
+		payload.GetParentInstanceId() != s.ActorID ||
+		payload.GetParentTaskScheduledId() != opts.taskID ||
+		payload.GetTerminalStatus() != opts.expectedStatus {
+		return false
+	}
+
+	if !bytes.Equal(historysigning.CertDigest(opts.certDER), payload.GetSignerCertDigest()) {
+		return false
+	}
+	if s.Signer.VerifySignature(historysigning.PayloadSignatureInput(opts.att.GetPayload()), opts.att.GetSignature(), opts.certDER) != nil {
+		return false
+	}
+	if !chainVerified && s.Signer.VerifyCertChainOfTrust(opts.certDER, opts.eventTS) != nil {
+		return false
+	}
+
+	if payload.GetActivityName() != scheduled.GetName() {
+		return true
+	}
+	var completed bool
+	switch opts.expectedStatus {
+	case protos.ActivityTerminalStatus_ACTIVITY_TERMINAL_STATUS_COMPLETED:
+		completed = true
+	case protos.ActivityTerminalStatus_ACTIVITY_TERMINAL_STATUS_FAILED:
+	default:
+		return false
+	}
+	out, ok := canonicalOutput(completed, opts.output, opts.failure)
+	if !ok {
+		return false
+	}
+	return !bytes.Equal(historysigning.IODigest(historysigning.CanonicalInput(scheduled.GetInput()), out), payload.GetIoDigest())
+}
+
+// canonicalOutput mirrors the canonical output selection inside
+// historysigning's verify helpers for the given terminal outcome.
+func canonicalOutput(completed bool, output *wrapperspb.StringValue, failure *protos.TaskFailureDetails) ([]byte, bool) {
+	if completed {
+		return historysigning.CanonicalSuccessOutput(output), true
+	}
+	out, err := historysigning.CanonicalFailureOutput(failure)
+	return out, err == nil
 }

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -50,6 +50,7 @@ import (
 	"github.com/dapr/dapr/pkg/resiliency"
 	"github.com/dapr/dapr/pkg/runtime/compstore"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/state/list"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/dapr/utils"
@@ -943,11 +944,21 @@ func (abe *Actors) purgeWorkflowForce(ctx context.Context, id api.InstanceID) er
 
 	s, err := state.LoadWorkflowState(ctx, astate, id.String(), state.Options{
 		AppID:             abe.appID,
+		Namespace:         abe.namespace,
 		WorkflowActorType: abe.workflowActorType,
 		ActivityActorType: abe.activityActorType,
+		Signer:            abe.signer,
 	})
 	if err != nil {
-		return err
+		// Force purge is the escape hatch for instances that cannot be
+		// handled normally, which includes tampered or misconfigured signed
+		// state: purge the loaded rows anyway rather than refusing.
+		var verifyErr *staterrors.VerificationError
+		var configErr *staterrors.ConfigurationError
+		if s == nil || (!errors.As(err, &verifyErr) && !errors.As(err, &configErr)) {
+			return err
+		}
+		log.Warnf("Force purging workflow '%s' whose state failed signature verification or signing configuration checks: %v", id.String(), err)
 	}
 
 	req, err := s.GetPurgeRequest(id.String())

--- a/tests/integration/framework/process/workflow/options.go
+++ b/tests/integration/framework/process/workflow/options.go
@@ -45,6 +45,7 @@ type options struct {
 	daprds          int
 	skipDB          bool
 	mtls            bool
+	signing         bool
 	signingDisabled []int
 
 	orchestrators     []orchestratorConfig
@@ -120,9 +121,23 @@ func WithMTLS(t *testing.T) Option {
 	}
 }
 
+// WithHistorySigning enables the WorkflowHistorySigning feature flag on
+// every daprd in the workflow. History signing needs the Sentry-issued
+// workload identity for its attestation and signing keys, so this also
+// enables the mTLS setup of WithMTLS. Prefer this over WithMTLS in tests
+// that are about signing behavior, so the intent is explicit at the call
+// site.
+func WithHistorySigning(t *testing.T) Option {
+	t.Helper()
+	return func(o *options) {
+		o.signing = true
+		o.mtls = true
+	}
+}
+
 // WithSigningDisabledN excludes the daprd at the given index from having
 // the WorkflowHistorySigning feature flag set. Has no effect without
-// WithMTLS.
+// WithMTLS or WithHistorySigning.
 func WithSigningDisabledN(index int) Option {
 	return func(o *options) {
 		o.signingDisabled = append(o.signingDisabled, index)

--- a/tests/integration/suite/daprd/workflow/signing/canstraggler.go
+++ b/tests/integration/suite/daprd/workflow/signing/canstraggler.go
@@ -1,0 +1,117 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(canstraggler))
+}
+
+type canstraggler struct {
+	workflow *workflow.Workflow
+}
+
+func (c *canstraggler) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *canstraggler) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	r := c.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("think", func(actx task.ActivityContext) (any, error) {
+		var ms int
+		if err := actx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+		return ms, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("agent", func(octx *task.WorkflowContext) (any, error) {
+		var ms int
+		if err := octx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(ms)).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	// Gen 0 fires a fire-and-forget child and ContinueAsNews before it
+	// completes, so the child's completion arrives as a straggler against the
+	// reset history and must be dropped, not treated as tampering. Gen 1
+	// schedules no child, so the straggler's task id is never reused; the
+	// reused-id collision variant is covered by canstragglercollide.
+	require.NoError(t, r.AddWorkflowN("loop", func(octx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := octx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+
+		if gen == 0 {
+			timer := octx.CreateTimer(100 * time.Millisecond)
+			octx.CallChildWorkflow("agent",
+				task.WithChildWorkflowInput(2000),
+				task.WithChildWorkflowInstanceID("sign-canstraggler-straggler"),
+			)
+			if err := timer.Await(nil); err != nil {
+				return nil, err
+			}
+			octx.ContinueAsNew(1)
+			return nil, nil
+		}
+
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(4000)).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	client := c.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewWorkflow(ctx, "loop",
+		api.WithInstanceID("sign-canstraggler-parent"),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, id)
+	require.NoError(t, err, "parent did not complete: the straggler child completion was treated as tampering")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"the straggler must be dropped, not tombstone the parent; failure details: %v", meta.GetFailureDetails())
+}

--- a/tests/integration/suite/daprd/workflow/signing/canstragglercollide.go
+++ b/tests/integration/suite/daprd/workflow/signing/canstragglercollide.go
@@ -1,0 +1,143 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(canstragglercollide))
+}
+
+// canstragglercollide is the reused-task-id variant of canstraggler: task ids
+// restart at 0 after ContinueAsNew, so generation 1 schedules a real child at
+// the same task id the generation-0 straggler claims. The straggler's
+// completion arrives while the real child is running and must be classified
+// as a stale completion of a superseded invocation and dropped, not as
+// history tampering; the parent must complete with the real child's result,
+// and the straggler child itself must complete once its dropped completion is
+// acknowledged as delivered.
+type canstragglercollide struct {
+	workflow *workflow.Workflow
+}
+
+func (c *canstragglercollide) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *canstragglercollide) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	r := c.workflow.Registry()
+
+	require.NoError(t, r.AddActivityN("think", func(actx task.ActivityContext) (any, error) {
+		var ms int
+		if err := actx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		time.Sleep(time.Duration(ms) * time.Millisecond)
+		return ms, nil
+	}))
+
+	require.NoError(t, r.AddWorkflowN("agent", func(octx *task.WorkflowContext) (any, error) {
+		var ms int
+		if err := octx.GetInput(&ms); err != nil {
+			return nil, err
+		}
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(ms)).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	// Gen 0: task 0 is a timer, task 1 the fire-and-forget straggler child.
+	// Gen 1: task 0 is a short activity, task 1 the awaited real child, so
+	// the straggler's task id 1 is reused by a different invocation. The
+	// straggler (4s) completes after the real child is scheduled (~0.7s) and
+	// before it completes (8s), so its completion lands mid-run against the
+	// reused id.
+	require.NoError(t, r.AddWorkflowN("loop", func(octx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := octx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+
+		if gen == 0 {
+			timer := octx.CreateTimer(100 * time.Millisecond)
+			octx.CallChildWorkflow("agent",
+				task.WithChildWorkflowInput(4000),
+				task.WithChildWorkflowInstanceID("sign-collide-straggler"),
+			)
+			if err := timer.Await(nil); err != nil {
+				return nil, err
+			}
+			octx.ContinueAsNew(1)
+			return nil, nil
+		}
+
+		var out int
+		if err := octx.CallActivity("think", task.WithActivityInput(300)).Await(&out); err != nil {
+			return nil, err
+		}
+		if err := octx.CallChildWorkflow("agent",
+			task.WithChildWorkflowInput(8000),
+			task.WithChildWorkflowInstanceID("sign-collide-real"),
+		).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	}))
+
+	client := c.workflow.BackendClient(t, ctx)
+
+	id, err := client.ScheduleNewWorkflow(ctx, "loop",
+		api.WithInstanceID("sign-collide-parent"),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	waitCtx, cancel := context.WithTimeout(ctx, 45*time.Second)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, id)
+	require.NoError(t, err, "parent did not complete: the straggler completion on the reused task id was treated as tampering")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"the stale straggler completion must be dropped, not tombstone the parent; failure details: %v", meta.GetFailureDetails())
+	require.Equal(t, "8000", meta.GetOutput().GetValue(),
+		"the parent must absorb the real child's result, not the straggler's")
+
+	// The parent's drop is terminal for the sender: the straggler child's
+	// completion dispatch must be acknowledged so its own turn commits and it
+	// reaches COMPLETED instead of redelivering forever.
+	stragglerCtx, stragglerCancel := context.WithTimeout(ctx, 20*time.Second)
+	t.Cleanup(stragglerCancel)
+	smeta, err := client.WaitForWorkflowCompletion(stragglerCtx, api.InstanceID("sign-collide-straggler"))
+	require.NoError(t, err, "straggler child did not complete: its dropped completion was not acknowledged as delivered")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), smeta.GetRuntimeStatus().String())
+}

--- a/tests/integration/suite/daprd/workflow/signing/forcepurge.go
+++ b/tests/integration/suite/daprd/workflow/signing/forcepurge.go
@@ -1,0 +1,80 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(forcepurge))
+}
+
+type forcepurge struct {
+	workflow *workflow.Workflow
+}
+
+func (f *forcepurge) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *forcepurge) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	require.NoError(t, reg.AddWorkflowN("sign-forcepurge", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("noop").Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	}))
+	require.NoError(t, reg.AddActivityN("noop", func(dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	}))
+
+	client := f.workflow.WorkflowClient(t, ctx)
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-forcepurge")
+	require.NoError(t, err)
+
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	db := f.workflow.DB().GetConnection(t)
+	tableName := f.workflow.DB().TableName()
+
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
+	assert.Positive(t, count, "the signed workflow must have persisted rows before the purge")
+
+	require.NoError(t, client.PurgeWorkflowState(ctx, id, dworkflow.WithForcePurge(true)),
+		"force purge must load signed history with the signer wired, not reject it as unverifiable")
+
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
+	assert.Equal(t, 0, count, "force purge must delete every row, including signatures and certificates")
+}

--- a/tests/integration/suite/daprd/workflow/signing/forcepurgetampered.go
+++ b/tests/integration/suite/daprd/workflow/signing/forcepurgetampered.go
@@ -1,0 +1,96 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api/protos"
+	dworkflow "github.com/dapr/durabletask-go/workflow"
+)
+
+func init() {
+	suite.Register(new(forcepurgetampered))
+}
+
+type forcepurgetampered struct {
+	workflow *workflow.Workflow
+}
+
+func (f *forcepurgetampered) Setup(t *testing.T) []framework.Option {
+	f.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+
+	return []framework.Option{
+		framework.WithProcesses(f.workflow),
+	}
+}
+
+func (f *forcepurgetampered) Run(t *testing.T, ctx context.Context) {
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	reg := dworkflow.NewRegistry()
+	require.NoError(t, reg.AddWorkflowN("sign-fpt", func(ctx *dworkflow.WorkflowContext) (any, error) {
+		if err := ctx.CallActivity("noop").Await(nil); err != nil {
+			return nil, err
+		}
+		return "", nil
+	}))
+	require.NoError(t, reg.AddActivityN("noop", func(dworkflow.ActivityContext) (any, error) {
+		return nil, nil
+	}))
+
+	client := f.workflow.WorkflowClient(t, ctx)
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	id, err := client.ScheduleWorkflow(ctx, "sign-fpt")
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+
+	// Tamper a history event so the signature chain no longer verifies.
+	histKey, raw := f.workflow.DB().FirstStateValue(t, ctx, id, "history")
+	var evt protos.HistoryEvent
+	require.NoError(t, proto.Unmarshal(raw, &evt))
+	evt.EventId += 9999
+	updated, err := proto.Marshal(&evt)
+	require.NoError(t, err)
+	f.workflow.DB().WriteStateValue(t, ctx, histKey, updated)
+
+	// Restart to drop the cached (untampered) state.
+	f.workflow.Dapr().Restart(t, ctx)
+	f.workflow.WaitUntilRunning(t, ctx)
+
+	client = f.workflow.WorkflowClient(t, ctx)
+	require.NoError(t, client.StartWorker(ctx, reg))
+
+	db := f.workflow.DB().GetConnection(t)
+	tableName := f.workflow.DB().TableName()
+	var count int
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
+	assert.Positive(t, count, "the tampered workflow must still have rows to purge")
+
+	require.NoError(t, client.PurgeWorkflowState(ctx, id, dworkflow.WithForcePurge(true)),
+		"force purge must proceed despite the signature verification failure")
+
+	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
+	assert.Equal(t, 0, count, "force purge must delete every row of the tampered workflow")
+}


### PR DESCRIPTION
* workflow: fix spurious failures under history signing

Force purge failed for every signed workflow because purgeWorkflowForce loaded state without the runtime's Signer and Namespace, tripping the loader's tamper protection; the call site now passes all five state.Options fields.

Completions that no longer correspond to a scheduling event in signed history (a straggler after ContinueAsNew, a save rolled back by a transient store fault, or a collision with a task id the new generation reused) were tombstoned as tampering; verification now returns the signing.ErrUnknownTaskScheduledID sentinel when a genuinely signed, correctly bound attestation merely fails to match the recorded invocation's io digest or activity name, and the orchestrator drops the event unpersisted, mirroring the unsigned path, while bad signatures, untrusted certificates, wrong bindings, and status mismatches still tombstone.

The drop is terminal for the sender, with the child's completion dispatch treating ErrInstanceNotFound as delivered instead of retrying forever, so every verification failure is first corroborated against freshly loaded durable state and a stale cache leads to a retry rather than a lost completion or a condemned workflow.



* Rehydrate cache



* Fix force purging on tampered workflow



---------

(cherry picked from commit bac32efb20b250b20c1be439cd57df03b43bf01a)