### PR TITLE
Integration: move CRD generation into build step

### DIFF
--- a/tests/integration/framework/binary/binary.go
+++ b/tests/integration/framework/binary/binary.go
@@ -106,6 +106,9 @@ func BuildAll(t *testing.T) {
 	wg.Wait()
 
 	require.False(t, t.Failed())
+
+	generateCRDs(t)
+	require.False(t, t.Failed())
 }
 
 func RootDir(t *testing.T) string {
@@ -132,15 +135,7 @@ func build(t *testing.T, name string, opts options) {
 	if _, ok := os.LookupEnv(EnvKey(name)); !ok {
 		t.Logf("%q not set, building %q binary", EnvKey(name), name)
 
-		// Use a consistent temp dir for the binary so that the binary is cached on
-		// subsequent runs.
-		var tmpdir string
-		if runtime.GOOS == "darwin" {
-			tmpdir = "/tmp"
-		} else {
-			tmpdir = os.TempDir()
-		}
-		binPath := filepath.Join(tmpdir, "dapr_integration_tests/"+name)
+		binPath := filepath.Join(tmpDir(), "dapr_integration_tests/"+name)
 		if runtime.GOOS == "windows" {
 			binPath += ".exe"
 		}
@@ -191,4 +186,11 @@ func EnvValue(name string) string {
 
 func EnvKey(name string) string {
 	return fmt.Sprintf("DAPR_INTEGRATION_%s_PATH", strings.ToUpper(name))
+}
+
+func tmpDir() string {
+	if runtime.GOOS == "darwin" {
+		return "/tmp"
+	}
+	return os.TempDir()
 }

--- a/tests/integration/framework/binary/crds.go
+++ b/tests/integration/framework/binary/crds.go
@@ -50,8 +50,11 @@ func generateCRDs(t *testing.T) {
 	cmd.Dir = RootDir(t)
 	cmd.Stdout = &stdout
 	cmd.Stderr = ioerr
-	assert.NoError(t, cmd.Run())
+	err := cmd.Run()
 	assert.NoError(t, ioerr.Close())
+	if !assert.NoError(t, err) {
+		return
+	}
 
 	assert.NoError(t, os.MkdirAll(filepath.Dir(outPath), 0o700))
 	assert.NoError(t, os.WriteFile(outPath, stdout.Bytes(), 0o600))

--- a/tests/integration/framework/binary/crds.go
+++ b/tests/integration/framework/binary/crds.go
@@ -1,0 +1,60 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package binary
+
+import (
+	"bytes"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/dapr/dapr/tests/integration/framework/iowriter"
+)
+
+// generateCRDs runs the controllergen helper once at build time and stores the
+// output for tests to consume.
+func generateCRDs(t *testing.T) {
+	t.Helper()
+
+	const name = "generated_crds"
+	if _, ok := os.LookupEnv(EnvKey(name)); ok {
+		t.Logf("%q set, using %q pre-generated CRDs", EnvKey(name), EnvValue(name))
+		return
+	}
+
+	outPath := filepath.Join(tmpDir(), "dapr_integration_tests", "generated_crds.yaml")
+	t.Logf("%q not set, generating CRDs to %q", EnvKey(name), outPath)
+
+	ioerr := iowriter.New(t, "controllergen")
+	var stdout bytes.Buffer
+	//nolint:gosec
+	cmd := exec.Command(EnvValue("controllergen"),
+		"crd:crdVersions=v1",
+		"paths=github.com/dapr/dapr/pkg/apis/...",
+		"output:stdout",
+	)
+	cmd.Dir = RootDir(t)
+	cmd.Stdout = &stdout
+	cmd.Stderr = ioerr
+	assert.NoError(t, cmd.Run())
+	assert.NoError(t, ioerr.Close())
+
+	assert.NoError(t, os.MkdirAll(filepath.Dir(outPath), 0o700))
+	assert.NoError(t, os.WriteFile(outPath, stdout.Bytes(), 0o600))
+	//nolint:usetesting
+	assert.NoError(t, os.Setenv(EnvKey(name), outPath))
+}

--- a/tests/integration/suite/helm/crds/crds.go
+++ b/tests/integration/suite/helm/crds/crds.go
@@ -17,7 +17,6 @@ import (
 	"bytes"
 	"context"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"testing"
@@ -46,20 +45,10 @@ func (u *uptodate) Run(t *testing.T, ctx context.Context) {
 	rootDir := binary.RootDir(t)
 	chartDir := filepath.Join(rootDir, "charts", "dapr", "crds")
 
-	args := []string{
-		"crd:crdVersions=v1",
-		"paths=github.com/dapr/dapr/pkg/apis/...",
-		"output:stdout",
-	}
-	//nolint:gosec
-	cmd := exec.CommandContext(ctx, binary.EnvValue("controllergen"), args...)
-	cmd.Dir = rootDir
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	require.NoErrorf(t, cmd.Run(), "controller-gen failed: %s", stderr.String())
+	generated, err := os.ReadFile(binary.EnvValue("generated_crds"))
+	require.NoError(t, err)
 
-	want := parseCRDs(t, stdout.Bytes(), "controller-gen output")
+	want := parseCRDs(t, generated, "controller-gen output")
 	got := loadCRDs(t, chartDir)
 
 	assert.ElementsMatch(t, keys(want), keys(got),


### PR DESCRIPTION
Generating CRDs can sometimes take a while on slow CI runners when under pressure, more than the 45s of a max suite timeout. Move the CRD generation into the binary build step, and then reference the generated CRDs from suite test files where they are needed.