### PR TITLE
Workflow: fix payload stalled on fast path feature enabled

### DIFF
--- a/pkg/actors/targets/workflow/activity/claim_test.go
+++ b/pkg/actors/targets/workflow/activity/claim_test.go
@@ -108,6 +108,18 @@ func (s *recordStore) set(t *testing.T, actorID string, rec claim.Record) {
 	s.etag[actorID]++
 }
 
+// checkUntil polls Check every 75ms until it returns want: a single sleep
+// between reads races the 2x observation prune window on slow runners.
+func checkUntil(t *testing.T, g *claim.Guards, actorID, key string, want claim.Outcome, msgAndArgs ...any) {
+	t.Helper()
+	assert.EventuallyWithT(t, func(col *assert.CollectT) {
+		outcome, err := g.Check(t.Context(), actorID, key)
+		if assert.NoError(col, err) {
+			assert.Equal(col, want, outcome)
+		}
+	}, time.Second*5, time.Millisecond*75, msgAndArgs...)
+}
+
 func newClaimHarness(t *testing.T) (*factory, *recordStore, chan *backend.ActivityWorkItem) {
 	t.Helper()
 	store := newRecordStore()
@@ -417,12 +429,14 @@ func Test_checkClaimRecord(t *testing.T) {
 		_, ok := store.get(t, actorID)
 		assert.True(t, ok, "the record cannot read dead on a single observation")
 
-		time.Sleep(time.Millisecond * 75)
-		outcome, err = f.claims.Check(t.Context(), actorID, key)
-		require.NoError(t, err)
-		assert.Equal(t, claim.Proceed, outcome)
-		_, ok = store.get(t, actorID)
-		assert.False(t, ok, "a dead old-run record must not leak")
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			outcome, err := f.claims.Check(t.Context(), actorID, key)
+			if assert.NoError(col, err) {
+				assert.Equal(col, claim.Proceed, outcome)
+			}
+			_, ok := store.get(t, actorID)
+			assert.False(col, ok, "a dead old-run record must not leak")
+		}, time.Second*5, time.Millisecond*75)
 	})
 
 	t.Run("live record from another scheduling is ignored but kept", func(t *testing.T) {
@@ -449,12 +463,14 @@ func Test_checkClaimRecord(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, claim.Defer, outcome, "a single observation cannot read stale")
 
-		time.Sleep(time.Millisecond * 75)
-		outcome, err = f.claims.Check(t.Context(), actorID, key)
-		require.NoError(t, err)
-		assert.Equal(t, claim.Proceed, outcome)
-		_, ok := store.get(t, actorID)
-		assert.False(t, ok, "a stale record is dead weight and must be reclaimed")
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			outcome, err := f.claims.Check(t.Context(), actorID, key)
+			if assert.NoError(col, err) {
+				assert.Equal(col, claim.Proceed, outcome)
+			}
+			_, ok := store.get(t, actorID)
+			assert.False(col, ok, "a stale record is dead weight and must be reclaimed")
+		}, time.Second*5, time.Millisecond*75)
 	})
 
 	t.Run("skewed past heartbeat is not insta-reclaimed", func(t *testing.T) {
@@ -473,10 +489,7 @@ func Test_checkClaimRecord(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, claim.Defer, outcome, "cross-host clock skew must not reclaim a live execution")
 
-		time.Sleep(time.Millisecond * 75)
-		outcome, err = f.claims.Check(t.Context(), actorID, key)
-		require.NoError(t, err)
-		assert.Equal(t, claim.Proceed, outcome, "a value frozen past the grace is dead regardless of skew")
+		checkUntil(t, f.claims, actorID, key, claim.Proceed, "a value frozen past the grace is dead regardless of skew")
 	})
 
 	t.Run("skewed future heartbeat defers and later reclaims", func(t *testing.T) {
@@ -492,10 +505,7 @@ func Test_checkClaimRecord(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, claim.Defer, outcome)
 
-		time.Sleep(time.Millisecond * 75)
-		outcome, err = f.claims.Check(t.Context(), actorID, key)
-		require.NoError(t, err)
-		assert.Equal(t, claim.Proceed, outcome, "a frozen future timestamp must not shield a dead guard forever")
+		checkUntil(t, f.claims, actorID, key, claim.Proceed, "a frozen future timestamp must not shield a dead guard forever")
 	})
 
 	t.Run("heartbeat change resets the observation window", func(t *testing.T) {
@@ -517,10 +527,7 @@ func Test_checkClaimRecord(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, claim.Defer, outcome, "a changed heartbeat proves the guard lives; the window must restart")
 
-		time.Sleep(time.Millisecond * 75)
-		outcome, err = f.claims.Check(t.Context(), actorID, key)
-		require.NoError(t, err)
-		assert.Equal(t, claim.Proceed, outcome)
+		checkUntil(t, f.claims, actorID, key, claim.Proceed)
 	})
 
 	t.Run("failed reclaim delete defers instead of proceeding", func(t *testing.T) {
@@ -619,15 +626,28 @@ func Test_executeActivity_recoveryGate(t *testing.T) {
 
 		a := f.GetOrCreate(actorID).(*activity)
 
-		// The first arrival opens the observation window and defers; the
-		// retry past the grace observes the frozen value and reclaims.
+		// The first arrival opens the observation window and defers; a
+		// later retry observes the frozen value and reclaims. Arrivals are
+		// retried in a loop like real recovery arrivals: a single sleep
+		// must land between StaleAfter and the 2x prune window, a margin a
+		// loaded runner can miss.
 		err := a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
 		require.ErrorIs(t, err, claim.ErrHeldElsewhere)
-		time.Sleep(time.Millisecond * 75)
 
 		ownerErr := make(chan error, 1)
 		go func() {
-			ownerErr <- a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
+			for {
+				err := a.executeActivity(t.Context(), activityReminderName, testInvocation(), false, true)
+				if !errors.Is(err, claim.ErrHeldElsewhere) {
+					ownerErr <- err
+					return
+				}
+				select {
+				case <-t.Context().Done():
+					return
+				case <-time.After(time.Millisecond * 75):
+				}
+			}
 		}()
 
 		var wi *backend.ActivityWorkItem
@@ -735,14 +755,16 @@ func Test_gateJanitorRedispatch(t *testing.T) {
 		_, ok := store.get(t, actorID)
 		assert.True(t, ok, "a fresh completed row is retained for in-flight recovery arrivals")
 
-		// A later read past the grace (but inside the 2x prune window, so the
-		// observation survives) still acks and reaps the row.
-		time.Sleep(75 * time.Millisecond)
-		handled, err = a.gateJanitorRedispatch(t.Context(), testInvocation())
-		assert.True(t, handled)
-		require.NoError(t, err)
-		_, ok = store.get(t, actorID)
-		assert.False(t, ok, "a stale completed row must not linger forever")
+		// Later reads past the grace still ack and reap the row; reads are
+		// paced so consecutive observations land inside the prune window.
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			handled, err = a.gateJanitorRedispatch(t.Context(), testInvocation())
+			assert.True(col, handled)
+			if assert.NoError(col, err) {
+				_, ok := store.get(t, actorID)
+				assert.False(col, ok, "a stale completed row must not linger forever")
+			}
+		}, time.Second*5, time.Millisecond*75)
 	})
 
 	t.Run("missing record proceeds", func(t *testing.T) {

--- a/pkg/actors/targets/workflow/orchestrator/fold_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold_test.go
@@ -14,9 +14,13 @@ limitations under the License.
 package orchestrator
 
 import (
+	"context"
 	"errors"
+	"slices"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -24,7 +28,11 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 	"google.golang.org/protobuf/types/known/wrapperspb"
 
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 )
@@ -267,6 +275,63 @@ func Test_fold_executionIDMismatchKeepsInboxPath(t *testing.T) {
 	entry, err = h.orch.addWorkflowEventMaybeFold(t.Context(), absent)
 	require.NoError(t, err)
 	assert.Nil(t, entry, "an execution-id-carrying completion with no scheduling event is unmatched and must not fold")
+}
+
+// A turn stalling on payload size must persist taken folded completions to
+// the durable inbox and ack their senders: a nacked fold dies with the
+// sender's process, leaving the stall unrecoverable once a restart lifts
+// the limit.
+func Test_runWorkflow_oversizeStallPersistsFoldedToInbox(t *testing.T) {
+	t.Parallel()
+	const instanceID = "wf-stall-fold"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+	h.orch.maxRequestBodySize = 2048
+
+	var lock sync.Mutex
+	var saved []string
+	h.orch.actorState = statefake.New().
+		WithGetFn(func(context.Context, *actorapi.GetStateRequest, bool) (*actorapi.StateResponse, error) {
+			return &actorapi.StateResponse{}, nil
+		}).
+		WithTransactionalStateOperationFn(func(_ context.Context, _ bool, req *actorapi.TransactionalRequest, _ bool) error {
+			lock.Lock()
+			defer lock.Unlock()
+			for _, op := range req.Operations {
+				if u, ok := op.Request.(actorapi.TransactionalUpsert); ok {
+					saved = append(saved, u.Key)
+				}
+			}
+			return nil
+		})
+
+	big := taskCompletedEvent(7)
+	big.GetTaskCompleted().Result = wrapperspb.String(strings.Repeat("x", 4096))
+	entry := &foldEntry{event: big, gen: h.orch.state.Generation, committed: make(chan struct{})}
+	h.orch.foldPending = append(h.orch.foldPending, entry)
+
+	ctx, cancel := context.WithCancel(t.Context())
+	var completed todo.RunCompleted
+	runErr := make(chan error, 1)
+	go func() {
+		var err error
+		completed, err = h.orch.runWorkflow(ctx, &actorapi.Reminder{Name: "new-event-x"})
+		runErr <- err
+	}()
+
+	require.Eventually(t, func() bool {
+		lock.Lock()
+		defer lock.Unlock()
+		return slices.ContainsFunc(saved, func(k string) bool { return strings.HasPrefix(k, "inbox") })
+	}, time.Second*5, time.Millisecond*10,
+		"the folded completion must be durably in the inbox before the stall hold")
+
+	cancel()
+	require.ErrorIs(t, <-runErr, api.ErrStalled)
+	assert.Equal(t, todo.RunCompletedFalse, completed)
+	<-entry.committed
+	require.NoError(t, entry.err, "the sender must be acked: its completion is durable in the inbox")
 }
 
 // The payload stall guard must count folded completions.

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -219,8 +219,25 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 
 	workflowName := o.getExecutionStartedEvent(state).GetName()
 	if reason, description, oversize := o.workflowPayloadOversize(ctx, state, foldedEvents(folded), workflowName); oversize {
-		// foldedCommitted stays false: the deferred handler nacks the folded
-		// senders back into their retry chains.
+		// Persist taken completions into the durable inbox before stalling:
+		// a nacked fold dies with its sender's process, leaving the stall
+		// unrecoverable once a restart lifts the limit (the janitor skips
+		// stalled instances and the durable run-activity reminder was
+		// elided). The inbox write is a state-store Multi, not an app call,
+		// so the body limit does not apply; the janitor's pending-inbox arm
+		// re-runs this turn each period and proceeds once the limit allows.
+		if len(folded) > 0 {
+			for _, f := range folded {
+				state.AddToInbox(f.event)
+			}
+			if serr := o.signAndSaveState(ctx, state); serr != nil {
+				return todo.RunCompletedFalse, serr
+			}
+			if jerr := o.ensureJanitor(ctx, state); jerr != nil {
+				return todo.RunCompletedFalse, jerr
+			}
+			foldedCommitted = true
+		}
 		return todo.RunCompletedFalse, o.stallWorkflow(ctx, state, rs, reason, description)
 	}
 	// Executing workflow code is a one-way operation. We must wait for the app code to report its completion, which

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -451,6 +451,10 @@ func (d *Daprd) GetMetaSubscriptions(t assert.TestingT, ctx context.Context) []M
 	return d.meta(t, ctx).Subscriptions
 }
 
+func (d *Daprd) GetMetaEnabledFeatures(t assert.TestingT, ctx context.Context) []string {
+	return d.meta(t, ctx).EnabledFeatures
+}
+
 func (d *Daprd) GetMetaSubscriptionsWithType(t assert.TestingT, ctx context.Context, subType string) []MetadataResponsePubsubSubscription {
 	subs := d.GetMetaSubscriptions(t, ctx)
 	var filteredSubs []MetadataResponsePubsubSubscription
@@ -501,6 +505,7 @@ type Metadata struct {
 	Workflows              *MetadataWorkflows                   `json:"workflows"`
 	WorkflowAccessPolicies []*rtv1.MetadataWorkflowAccessPolicy `json:"workflowAccessPolicies,omitempty"`
 	Resiliencies           []*rtv1.MetadataResiliency           `json:"resiliencies,omitempty"`
+	EnabledFeatures        []string                             `json:"enabledFeatures,omitempty"`
 }
 
 // MetadataResponsePubsubSubscription copied from pkg/api/http/metadata.go:172 to be able to use in integration tests until we move to Proto format

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -134,10 +134,7 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 	// features replaces every earlier feature list. All harness-driven
 	// features must therefore land in a single manifest per daprd; it is
 	// built in the per-daprd loop below because signing is per-daprd.
-	baseFeatures := make([]string, 0, 1)
-	if clustered {
-		baseFeatures = append(baseFeatures, "WorkflowsClusteredDeployment")
-	}
+	baseFeatures := baseFeatureList(clustered)
 
 	if opts.schedulerAddress != nil {
 		// Reset so a caller-supplied override (e.g. a proxy in front of the
@@ -349,6 +346,26 @@ func (w *Workflow) GRPCClientN(t *testing.T, ctx context.Context, index int) rtv
 // ClusteredDeployment reports whether every daprd in this workflow runs with
 // the WorkflowsClusteredDeployment feature flag enabled. Tests use this to
 // branch assertions which differ between the two modes.
+func baseFeatureList(clustered bool) []string {
+	features := make([]string, 0, 1)
+	if clustered {
+		features = append(features, "WorkflowsClusteredDeployment")
+	}
+	return features
+}
+
+// FeatureOptions returns the feature manifest option matching this harness's
+// daprds. Tests spawning extra daprds into the cluster must apply it so the
+// extras run the same workflow feature set (daprd's config merge makes the
+// last spec.features list win, so all features must land in one manifest).
+func (w *Workflow) FeatureOptions(t *testing.T) []daprd.Option {
+	features := baseFeatureList(w.clustered)
+	if len(features) == 0 {
+		return nil
+	}
+	return []daprd.Option{daprd.WithFeatureEnabled(t, features...)}
+}
+
 func (w *Workflow) ClusteredDeployment() bool {
 	return w.clustered
 }

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -343,9 +343,6 @@ func (w *Workflow) GRPCClientN(t *testing.T, ctx context.Context, index int) rtv
 	return w.daprds[index].GRPCClient(t, ctx)
 }
 
-// ClusteredDeployment reports whether every daprd in this workflow runs with
-// the WorkflowsClusteredDeployment feature flag enabled. Tests use this to
-// branch assertions which differ between the two modes.
 func baseFeatureList(clustered bool) []string {
 	features := make([]string, 0, 1)
 	if clustered {
@@ -354,10 +351,11 @@ func baseFeatureList(clustered bool) []string {
 	return features
 }
 
-// FeatureOptions returns the feature manifest option matching this harness's
-// daprds. Tests spawning extra daprds into the cluster must apply it so the
-// extras run the same workflow feature set (daprd's config merge makes the
-// last spec.features list win, so all features must land in one manifest).
+// FeatureOptions returns the feature manifest option for extra daprds a test
+// adds to this harness's cluster. Only cluster-wide features are covered:
+// WorkflowHistorySigning is per-daprd and needs the harness's sentry wiring
+// besides the flag. daprd's config merge makes the last spec.features list
+// win, so all features must land in one manifest.
 func (w *Workflow) FeatureOptions(t *testing.T) []daprd.Option {
 	features := baseFeatureList(w.clustered)
 	if len(features) == 0 {
@@ -366,6 +364,9 @@ func (w *Workflow) FeatureOptions(t *testing.T) []daprd.Option {
 	return []daprd.Option{daprd.WithFeatureEnabled(t, features...)}
 }
 
+// ClusteredDeployment reports whether every daprd in this workflow runs with
+// the WorkflowsClusteredDeployment feature flag enabled. Tests use this to
+// branch assertions which differ between the two modes.
 func (w *Workflow) ClusteredDeployment() bool {
 	return w.clustered
 }

--- a/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
+++ b/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
@@ -96,16 +96,18 @@ func (d *disseminationcluster) Run(t *testing.T, ctx context.Context) {
 	startVersion := d.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
 
 	for i := range 2 {
-		extra := daprd.New(t,
+		extra := daprd.New(t, append([]daprd.Option{
 			daprd.WithAppID(d.appID),
 			daprd.WithPlacementAddresses(d.workflow.Placement().Address()),
 			daprd.WithScheduler(d.workflow.Scheduler()),
 			daprd.WithResourceFiles(d.workflow.DB().GetComponent(t)),
-			daprd.WithConfigManifests(t, workflow.ClusteredDeploymentConfig),
-		)
+		}, d.workflow.FeatureOptions(t)...)...)
 		extra.Run(t, ctx)
 		extra.WaitUntilRunning(t, ctx)
 		t.Cleanup(func() { extra.Cleanup(t) })
+
+		assert.Contains(t, extra.GetMetaEnabledFeatures(t, ctx), "WorkflowsClusteredDeployment",
+			"extras must join with the harness feature set")
 
 		registry := task.NewTaskRegistry()
 		require.NoError(t, registry.AddWorkflowN("dedup-disseminationcluster", workflowFn))

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalled/maxbodysize.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalled/maxbodysize.go
@@ -17,6 +17,7 @@ import (
 	"context"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -43,7 +44,10 @@ type maxbodysize struct {
 }
 
 func (m *maxbodysize) Setup(t *testing.T) []framework.Option {
-	m.workflow = workflow.NewClustered(t, 2, daprd.WithMaxBodySize("1Mi"))
+	m.workflow = workflow.NewClustered(t, 2,
+		daprd.WithMaxBodySize("1Mi"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Millisecond*500),
+	)
 
 	return []framework.Option{
 		framework.WithProcesses(m.workflow),

--- a/tests/integration/suite/daprd/workflow/payloadsize/restartfold.go
+++ b/tests/integration/suite/daprd/workflow/payloadsize/restartfold.go
@@ -33,20 +33,25 @@ import (
 )
 
 func init() {
-	suite.Register(new(restartresume))
+	suite.Register(new(restartresumefold))
 }
 
-// restartresume verifies that a workflow stalled with PAYLOAD_SIZE_EXCEEDED
-// resumes and runs to completion after the operator restarts daprd with a
-// larger --max-body-size.
-type restartresume struct {
+// restartresumefold verifies a PAYLOAD_SIZE_EXCEEDED stall whose completions
+// arrived through the WorkflowsFastPath fold path recovers after daprd
+// restarts with a larger --max-body-size: the stalling turn persists the
+// folded completions to the durable inbox (a nacked fold dies with the
+// sender's process), and the janitor re-drives the turn once the limit allows.
+type restartresumefold struct {
 	workflow *workflow.Workflow
 }
 
-func (r *restartresume) Setup(t *testing.T) []framework.Option {
+func (r *restartresumefold) Setup(t *testing.T) []framework.Option {
 	r.workflow = workflow.New(t,
 		workflow.WithDaprdOptions(0,
 			daprd.WithMaxBodySize("1Mi"),
+			daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+			// Post-restart recovery of the stalled instance rides the janitor; the
+			// default 20s period eats the 45s case budget.
 			daprd.WithWorkflowJanitorPeriod(t, time.Millisecond*500),
 		),
 	)
@@ -55,7 +60,7 @@ func (r *restartresume) Setup(t *testing.T) []framework.Option {
 	}
 }
 
-func (r *restartresume) Run(t *testing.T, ctx context.Context) {
+func (r *restartresumefold) Run(t *testing.T, ctx context.Context) {
 	r.workflow.WaitUntilRunning(t, ctx)
 
 	const chunkSize = 250 * 1024
@@ -75,7 +80,7 @@ func (r *restartresume) Run(t *testing.T, ctx context.Context) {
 		return chunk, nil
 	})
 
-	id := api.InstanceID("workflow-resume")
+	id := api.InstanceID("workflow-resume-fold")
 	preClient := r.workflow.BackendClient(t, ctx)
 	_, err := preClient.ScheduleNewWorkflow(ctx, "growing-history", api.WithInstanceID(id))
 	require.NoError(t, err)
@@ -84,11 +89,11 @@ func (r *restartresume) Run(t *testing.T, ctx context.Context) {
 
 	stalled := wf.GetLastHistoryEventOfType[protos.HistoryEvent_ExecutionStalled](t, ctx, preClient, id)
 	require.NotNil(t, stalled)
-	require.Equal(t, "PAYLOAD_SIZE_EXCEEDED", stalled.GetExecutionStalled().GetReason().String())
+	require.Equal(t, protos.StalledReason_PAYLOAD_SIZE_EXCEEDED, stalled.GetExecutionStalled().GetReason())
 
-	// Restart daprd with a larger max-body-size. The new threshold is well above
-	// the workflow's accumulated history, so the precheck no longer fires when
-	// the workflow actor reactivates.
+	// Restarting immediately kills the folded completion's sender with the
+	// process: only the durable inbox row written by the stalling turn can
+	// resolve the outstanding activity afterwards.
 	r.workflow.Dapr().ReplaceArg(t, "max-body-size", "16Mi")
 	r.workflow.Dapr().Restart(t, ctx)
 

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/basic.go
@@ -132,7 +132,11 @@ func (a *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Zero(c, a.scheduler.JobKeyCount(t, ctx, "run-activity"))
 	}, time.Second*60, time.Millisecond*50)
 
-	assert.GreaterOrEqual(t, a.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:success"), float64(2))
+	// The completion streams to the client before the second activity's
+	// metric increment is visible, so poll rather than read once.
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, a.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:success"), float64(2))
+	}, time.Second*10, time.Millisecond*50)
 	assert.Zero(t, a.daprd.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:janitor_redispatched"),
 		"a healthy run must not need janitor re-dispatch")
 }


### PR DESCRIPTION
A turn stalling on PAYLOAD_SIZE_EXCEEDED nacked its folded completions back to their senders. Under `WorkflowsFastPath` the durable run-activity reminder is elided, so once the sender's process died the completion was gone: the janitor skips stalled instances and nothing re-evaluates the stall after a restart raises --max-body-size. The workflow stayed STALLED forever.

Persist the taken folded completions to the durable inbox before stalling and ack their senders; the inbox write is a state-store Multi, so the body limit does not apply. The janitor's pending-inbox arm then re-runs the turn each period and proceeds once the limit allows. The tests also set a 2s janitor period: recovery rides the janitor, whose default 20s period races the tests' wait windows.

Includes other flaky test fixes.