### PR TITLE
workflow: allow meta watch on stalled workflow

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -7,6 +7,7 @@ This update contains the following bug fixes:
 - [Force purge failed for every workflow when history signing was enabled](#force-purge-failed-for-every-workflow-when-history-signing-was-enabled)
 - [Workflow wrongly failed as tampered when a stale completion arrived after ContinueAsNew or a transient state store fault](#workflow-wrongly-failed-as-tampered-when-a-stale-completion-arrived-after-continueasnew-or-a-transient-state-store-fault)
 - [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
+- [Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled](#workflow-schedule-and-status-waits-failed-with-a-stalled-actor-error-while-a-workflow-was-stalled)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -190,3 +191,24 @@ Since the engine trusted the executor's result and the event was consumed with t
 
 When a delivered batch contains an `ExecutionTerminated` event and the executor does not complete the workflow, daprd discards the doomed execution's pending work and completes the instance as `TERMINATED`.
 A `continue_as_new` returned alongside a terminate no longer starts a new iteration, and terminating a suspended workflow now terminates it without requiring a resume.
+
+## Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled
+
+### Problem
+
+Scheduling a workflow whose first turns stalled quickly, or waiting on the status of an already-stalled workflow, could fail with an error stating the actor is stalled.
+The instance itself was healthy: it was created, ran, and entered the intended `STALLED` state, but the call observing it returned an error instead of the status.
+
+### Impact
+
+You were affected if workflows stalled, for example on `PAYLOAD_SIZE_EXCEEDED` or a version mismatch, and clients scheduled instances or waited on their status while the stall was in place.
+`ScheduleNewWorkflow` could return an error for an instance that was created successfully, and status waits could fail instead of waiting for recovery.
+
+### Root Cause
+
+A stalling turn parks holding the workflow actor's turn lock so the stall is not retried hot.
+A status watch stream registering during that hold was rejected with the stalled-actor error, and the error propagated to the waiting client instead of being treated as a state to wait through.
+
+### Solution
+
+When a status watch finds the actor stalled, the stored workflow status is read directly from the state store: a wait whose condition the instance already reached, such as a schedule waiting for the workflow to start, resolves immediately, and any other wait re-registers with backoff until the stall clears.

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -793,10 +793,12 @@ func (abe *Actors) WatchWorkflowRuntimeStatus(ctx context.Context, id api.Instan
 		if meta, merr := abe.GetWorkflowMetadata(ctx, id, taskRouter); merr == nil && condition(meta) {
 			return nil
 		}
+		timer := time.NewTimer(wait)
 		select {
 		case <-ctx.Done():
+			timer.Stop()
 			return ctx.Err()
-		case <-time.After(wait):
+		case <-timer.C:
 		}
 		wait = min(wait*2, time.Second*5)
 	}

--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -37,6 +37,7 @@ import (
 	actorsapi "github.com/dapr/dapr/pkg/actors/api"
 	actorerrors "github.com/dapr/dapr/pkg/actors/errors"
 	"github.com/dapr/dapr/pkg/actors/table"
+	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/activity"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
@@ -761,26 +762,44 @@ func (abe *Actors) WatchWorkflowRuntimeStatus(ctx context.Context, id api.Instan
 		WithActor(actorType, string(id)).
 		WithContentType(invokev1.ProtobufContentType)
 
-	err = router.CallStream(ctx, req, func(resp *internalsv1pb.InternalInvokeResponse) (bool, error) {
-		var meta backend.WorkflowMetadata
-		perr := resp.GetMessage().GetData().UnmarshalTo(&meta)
-		if perr != nil {
-			log.Errorf("Failed to unmarshal orchestration metadata: %s", perr)
-			return false, perr
-		}
+	wait := time.Millisecond * 500
+	for {
+		err = router.CallStream(ctx, req, func(resp *internalsv1pb.InternalInvokeResponse) (bool, error) {
+			var meta backend.WorkflowMetadata
+			perr := resp.GetMessage().GetData().UnmarshalTo(&meta)
+			if perr != nil {
+				log.Errorf("Failed to unmarshal orchestration metadata: %s", perr)
+				return false, perr
+			}
 
-		return condition(&meta), nil
-	})
-	if err != nil {
+			return condition(&meta), nil
+		})
+		switch {
+		case err == nil:
+			return nil
 		// Actor invocations carry errors as wire strings; normalise not-found
 		// so callers can rely on errors.Is.
-		if strings.HasSuffix(err.Error(), api.ErrInstanceNotFound.Error()) {
+		case strings.HasSuffix(err.Error(), api.ErrInstanceNotFound.Error()):
 			return api.ErrInstanceNotFound
+		case !targeterrors.IsStalled(err):
+			return err
 		}
-		return err
-	}
 
-	return nil
+		// A stalled actor rejects stream registrations while the stall turn
+		// parks holding the turn lock, but the instance is quiescent and its
+		// status readable from the store. A condition the instance already
+		// reached must resolve (a schedule's wait-for-start racing a fast
+		// stall); otherwise re-register with backoff until the stall clears.
+		if meta, merr := abe.GetWorkflowMetadata(ctx, id, taskRouter); merr == nil && condition(meta) {
+			return nil
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(wait):
+		}
+		wait = min(wait*2, time.Second*5)
+	}
 }
 
 // PurgeWorkflowState implements backend.Backend.

--- a/tests/integration/suite/daprd/workflow/versioning/stalled/watch.go
+++ b/tests/integration/suite/daprd/workflow/versioning/stalled/watch.go
@@ -1,0 +1,124 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package stalled
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	wf "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(watch))
+}
+
+// watch verifies a completion watch opened while a workflow is stalled
+// resolves once the stall lifts: the stalled actor serves the stored status
+// snapshot on registration and parks the watcher until recovery, instead of
+// failing the watch with a stalled-actor error.
+type watch struct {
+	workflow *workflow.Workflow
+}
+
+func (w *watch) Setup(t *testing.T) []framework.Option {
+	w.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(w.workflow),
+	}
+}
+
+func (w *watch) Run(t *testing.T, ctx context.Context) {
+	w.workflow.WaitUntilRunning(t, ctx)
+
+	w.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("Continue", -1).Await(nil)
+	})
+
+	clientCtx, cancelClient := context.WithCancel(ctx)
+	cl := w.workflow.BackendClient(t, clientCtx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "workflow")
+	require.NoError(t, err)
+
+	wf.WaitForWorkflowStartedEvent(t, ctx, cl, id)
+
+	w.workflow.ResetRegistry(t)
+	cancelClient()
+	w.workflow.WaitForNoConnectedWorkers(t, ctx)
+
+	w.workflow.Registry().AddVersionedWorkflowN("workflow", "v2", true, func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("Continue", -1).Await(nil)
+	})
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	cl = w.workflow.BackendClient(t, clientCtx)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, cl.RaiseEvent(ctx, id, "Continue"))
+	}, time.Second*20, time.Millisecond*10)
+
+	// Dialed before the stall so the watch lands while the stalling turn still
+	// parks in the hold (which owns the actor turn lock). A worker-less client
+	// keeps the v2 version from being advertised while v1 recovers below.
+	watcher := client.NewTaskHubGrpcClient(w.workflow.Dapr().GRPCConn(t, ctx), logger.New(t))
+
+	wf.WaitForRuntimeStatus(t, ctx, cl, id, protos.OrchestrationStatus_ORCHESTRATION_STATUS_STALLED)
+
+	type outcome struct {
+		md  *protos.WorkflowMetadata
+		err error
+	}
+	watched := make(chan outcome, 1)
+	go func() {
+		md, werr := watcher.WaitForWorkflowCompletion(ctx, id)
+		watched <- outcome{md, werr}
+	}()
+
+	select {
+	case res := <-watched:
+		require.NoError(t, res.err, "a watch opened during the stall must park, not fail")
+		require.Fail(t, "the watch cannot resolve while the workflow is still stalled")
+	case <-time.After(time.Second * 2):
+	}
+
+	w.workflow.ResetRegistry(t)
+	cancelClient()
+	w.workflow.WaitForNoConnectedWorkers(t, ctx)
+
+	w.workflow.Registry().AddVersionedWorkflowN("workflow", "v1", true, func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("Continue", -1).Await(nil)
+	})
+	clientCtx, cancelClient = context.WithCancel(ctx)
+	t.Cleanup(cancelClient)
+	w.workflow.BackendClient(t, clientCtx)
+
+	select {
+	case res := <-watched:
+		require.NoError(t, res.err)
+		assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED.String(), res.md.GetRuntimeStatus().String())
+	case <-time.After(time.Second * 30):
+		require.Fail(t, "watch opened during the stall never resolved after recovery")
+	}
+}


### PR DESCRIPTION
A stall turn parks holding the actor turn lock, so a status watch stream (re)connecting during the hold fails with a stalled-actor error, which surfaced as ScheduleNewWorkflow failing when its wait-for-start watch raced a fast payload stall (windows leg of the maxbodysize test; the 500ms janitor period re-enters the hold every period, widening the window). A stalled instance is quiescent and its status readable from the store: on a stalled stream error, evaluate the wait condition against GetWorkflowMetadata, resolving conditions the instance already reached, and otherwise re-register with backoff (500ms doubling, 5s cap) until the stall clears. New versioning/stalled/watch test pins the semantic: a completion watch opened during a stall parks instead of failing and resolves after recovery.