### PR TITLE
workflow: reap escalated run-activity reminders when their task resolves

### DIFF
--- a/pkg/actors/targets/workflow/activity/reminder.go
+++ b/pkg/actors/targets/workflow/activity/reminder.go
@@ -25,6 +25,7 @@ import (
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
 )
@@ -32,7 +33,7 @@ import (
 // activityReminderName is the constant name of the per-activity-actor
 // execution reminder. One reminder per actor: retries and the drive-failure
 // escalation collapse onto a single scheduler entry (overwrite-by-name).
-const activityReminderName = "run-activity"
+const activityReminderName = todo.ActivityReminderName
 
 func (a *activity) createReminder(ctx context.Context, invocation *protos.ActivityInvocation, dueTime time.Time, activityName *string) error {
 	return a.createActivityReminder(ctx, a.actorID, invocation, dueTime, activityName)

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -101,9 +101,16 @@ type orchestrator struct {
 	// re-arming the unverifiable local drive (see redispatchActivities).
 	// INVARIANT: only touched by janitor fires, which hold the turn lock.
 	janitorRedispatched map[int32]struct{}
-	lock                *lock.Stallable
-	closed              atomic.Bool
-	wg                  sync.WaitGroup
+
+	// janitorEscalated records the task IDs whose re-dispatch escalated to
+	// the durable run-activity reminder this residency, so the turn that
+	// commits the task's completion can reap the reminder (the completion's
+	// own execution never knew it existed; see reapEscalatedCompletions).
+	// Same guard and generation scope as janitorRedispatched.
+	janitorEscalated map[int32]struct{}
+	lock             *lock.Stallable
+	closed           atomic.Bool
+	wg               sync.WaitGroup
 
 	streamFns map[int64]*streamFn
 	streamIDx int64

--- a/pkg/actors/targets/workflow/orchestrator/orchestrator.go
+++ b/pkg/actors/targets/workflow/orchestrator/orchestrator.go
@@ -102,12 +102,13 @@ type orchestrator struct {
 	// INVARIANT: only touched by janitor fires, which hold the turn lock.
 	janitorRedispatched map[int32]struct{}
 
-	// janitorEscalated records the task IDs whose re-dispatch escalated to
-	// the durable run-activity reminder this residency, so the turn that
-	// commits the task's completion can reap the reminder (the completion's
-	// own execution never knew it existed; see reapEscalatedCompletions).
-	// Same guard and generation scope as janitorRedispatched.
-	janitorEscalated map[int32]struct{}
+	// janitorEscalated records, per task ID, the TaskScheduled event whose
+	// re-dispatch escalated to the durable run-activity reminder this
+	// residency, so the turn that commits the task's resolution can reap the
+	// reminder (the resolving execution never knew it existed; see
+	// reapEscalatedCompletions). Same guard and generation scope as
+	// janitorRedispatched.
+	janitorEscalated map[int32]*backend.HistoryEvent
 	lock             *lock.Stallable
 	closed           atomic.Bool
 	wg               sync.WaitGroup

--- a/pkg/actors/targets/workflow/orchestrator/reap.go
+++ b/pkg/actors/targets/workflow/orchestrator/reap.go
@@ -1,0 +1,133 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+
+	"google.golang.org/grpc/codes"
+	grpcstatus "google.golang.org/grpc/status"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	diag "github.com/dapr/dapr/pkg/diagnostics"
+	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
+)
+
+// reapResolvedEscalation deletes the durable run-activity reminder an
+// escalation armed for a task that resolved while the create was in flight:
+// the execution's completion cannot delete a reminder it never knew existed,
+// and the leaked fire would re-run the activity body.
+func (o *orchestrator) reapResolvedEscalation(ctx context.Context, e *backend.HistoryEvent) {
+	cctx, cancel := context.WithTimeout(ctx, redispatchCallTimeout)
+	defer cancel()
+
+	unlock, err := o.lock.ContextLock(cctx)
+	if err != nil {
+		return
+	}
+	resolved := false
+	state, _, err := o.loadInternalState(cctx)
+	if err == nil {
+		resolved = state == nil || runtimestate.IsCompleted(o.rstate)
+		if !resolved {
+			resolved = true
+			for _, u := range unresolvedScheduledTasks(state, o.foldEvents()) {
+				if u.GetEventId() == e.GetEventId() {
+					resolved = false
+					break
+				}
+			}
+		}
+	}
+	if resolved {
+		delete(o.janitorEscalated, e.GetEventId())
+	}
+	unlock()
+	if !resolved {
+		return
+	}
+
+	appID := ""
+	if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
+		appID = router.GetTargetAppID()
+	}
+	o.reapEscalatedReminder(appID, e.GetEventId())
+}
+
+// reapEscalatedCompletions reaps the durable run-activity reminder of every
+// escalated task whose completion the turn just committed: the completion's
+// execution predates the escalation, so nothing else deletes the reminder and
+// its fire would re-run the body on a cold host. Runs under the turn lock,
+// after the commit is durable.
+func (o *orchestrator) reapEscalatedCompletions(events []*backend.HistoryEvent) {
+	if len(o.janitorEscalated) == 0 {
+		return
+	}
+	for _, e := range events {
+		var id int32
+		switch {
+		case e.GetTaskCompleted() != nil:
+			id = e.GetTaskCompleted().GetTaskScheduledId()
+		case e.GetTaskFailed() != nil:
+			id = e.GetTaskFailed().GetTaskScheduledId()
+		default:
+			continue
+		}
+		if _, ok := o.janitorEscalated[id]; !ok {
+			continue
+		}
+		delete(o.janitorEscalated, id)
+		o.reapEscalatedReminder(e.GetRouter().GetSourceAppID(), id)
+	}
+}
+
+// reapEscalatedReminder deletes a task's durable run-activity reminder,
+// detached and best-effort (a failed delete leaves a fire the inflight cache
+// absorbs on a warm host and the completion dedup absorbs at worst).
+func (o *orchestrator) reapEscalatedReminder(appID string, id int32) {
+	diag.DefaultWorkflowMonitoring.WorkflowLocalActivity(context.Background(), diag.StatusJanitorEscalationReaped)
+
+	activityActorType := o.activityActorType
+	if appID != "" && appID != o.appID {
+		activityActorType = o.actorTypeBuilder.Activity(appID)
+	}
+
+	o.escLock.Lock()
+	rootCtx := o.rootCtx
+	if rootCtx.Err() != nil {
+		o.escLock.Unlock()
+		return
+	}
+	o.escWG.Add(1)
+	o.escLock.Unlock()
+
+	go func() {
+		defer o.escWG.Done()
+		cctx, cancel := context.WithTimeout(rootCtx, escalateTimeout)
+		defer cancel()
+		if derr := o.reminders.Delete(cctx, &actorapi.DeleteReminderRequest{
+			Name:      todo.ActivityReminderName,
+			ActorType: activityActorType,
+			ActorID:   buildActivityActorID(o.actorID, id),
+		}); derr != nil {
+			if s, ok := grpcstatus.FromError(derr); !ok || s.Code() != codes.NotFound {
+				log.Debugf("Workflow actor '%s': failed to reap escalated run-activity reminder for resolved task %d (a warm-host fire is absorbed by the inflight cache): %v", o.actorID, id, derr)
+			}
+			return
+		}
+		log.Debugf("Workflow actor '%s': reaped escalated run-activity reminder for resolved task %d", o.actorID, id)
+	}()
+}

--- a/pkg/actors/targets/workflow/orchestrator/reap.go
+++ b/pkg/actors/targets/workflow/orchestrator/reap.go
@@ -21,6 +21,7 @@ import (
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/backend"
 	"github.com/dapr/durabletask-go/backend/runtimestate"
@@ -68,29 +69,37 @@ func (o *orchestrator) reapResolvedEscalation(ctx context.Context, e *backend.Hi
 }
 
 // reapEscalatedCompletions reaps the durable run-activity reminder of every
-// escalated task whose completion the turn just committed: the completion's
-// execution predates the escalation, so nothing else deletes the reminder and
-// its fire would re-run the body on a cold host. Runs under the turn lock,
+// escalated task the just-committed turn resolved, judged against the
+// committed state rather than the turn's incoming events: a stale completion
+// (e.g. a prior generation's) must not reap a live reminder, and the
+// reminder identity (workflow ID and task ID) carries no generation. Marks
+// from a previous generation are voided rather than reaped for the same
+// reason: a delete could race the new generation's re-dispatch of the same
+// task ID, and a leaked stale fire self-cleans (its completion is dropped
+// as stale and the ack deletes the reminder). Runs under the turn lock,
 // after the commit is durable.
-func (o *orchestrator) reapEscalatedCompletions(events []*backend.HistoryEvent) {
+func (o *orchestrator) reapEscalatedCompletions(state *wfenginestate.State) {
 	if len(o.janitorEscalated) == 0 {
 		return
 	}
-	for _, e := range events {
-		var id int32
-		switch {
-		case e.GetTaskCompleted() != nil:
-			id = e.GetTaskCompleted().GetTaskScheduledId()
-		case e.GetTaskFailed() != nil:
-			id = e.GetTaskFailed().GetTaskScheduledId()
-		default:
-			continue
-		}
-		if _, ok := o.janitorEscalated[id]; !ok {
+	if o.janitorRedispatchedGen != state.Generation {
+		o.janitorEscalated = nil
+		return
+	}
+	unresolved := make(map[int32]struct{})
+	for _, u := range unresolvedScheduledTasks(state, o.foldEvents()) {
+		unresolved[u.GetEventId()] = struct{}{}
+	}
+	for id, e := range o.janitorEscalated {
+		if _, still := unresolved[id]; still {
 			continue
 		}
 		delete(o.janitorEscalated, id)
-		o.reapEscalatedReminder(e.GetRouter().GetSourceAppID(), id)
+		appID := ""
+		if router := e.GetRouter(); router != nil && router.TargetAppID != nil {
+			appID = router.GetTargetAppID()
+		}
+		o.reapEscalatedReminder(appID, id)
 	}
 }
 

--- a/pkg/actors/targets/workflow/orchestrator/reap_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/reap_test.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+func Test_reapResolvedEscalation(t *testing.T) {
+	t.Parallel()
+	const instanceID = "wf-reap-escalation"
+
+	t.Run("an unresolved task keeps its escalated reminder", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		h.orch.reapResolvedEscalation(t.Context(), h.orch.state.History[1])
+		assert.NotContains(t, h.snapshotOps(), "delete:run-activity",
+			"an escalated reminder for a still-unresolved task is the recovery itself")
+	})
+
+	t.Run("a task resolved during the escalation reaps the reminder", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		taskScheduled := h.orch.state.History[1]
+		h.orch.state.AddToHistory(taskCompletedEvent(7))
+		h.orch.reapResolvedEscalation(t.Context(), taskScheduled)
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Contains(c, h.snapshotOps(), "delete:run-activity",
+				"a reminder for a resolved task has no deleter and its fire re-runs the body")
+		}, time.Second*5, time.Millisecond*5)
+	})
+}
+
+func Test_reapEscalatedCompletions(t *testing.T) {
+	t.Parallel()
+	const instanceID = "wf-reap-completion"
+
+	t.Run("a committed completion reaps its escalated reminder", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		h.orch.janitorEscalated = map[int32]struct{}{7: {}}
+
+		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{taskCompletedEvent(7)})
+		assert.Empty(t, h.orch.janitorEscalated, "a reaped task must not be reaped again")
+		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			assert.Contains(c, h.snapshotOps(), "delete:run-activity")
+		}, time.Second*5, time.Millisecond*5)
+	})
+
+	t.Run("a cross-app completion reaps on the remote activity actor type", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		h.orch.janitorEscalated = map[int32]struct{}{7: {}}
+
+		reqCh := make(chan *actorapi.DeleteReminderRequest, 1)
+		h.fact.reminders = remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
+			reqCh <- req
+			return nil
+		})
+
+		completion := taskCompletedEvent(7)
+		completion.Router = &protos.TaskRouter{SourceAppID: "otherapp"}
+		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{completion})
+
+		select {
+		case req := <-reqCh:
+			assert.Equal(t, "run-activity", req.Name)
+			assert.Equal(t, "dapr.internal.default.otherapp.activity", req.ActorType,
+				"a cross-app activity's reminder lives on the remote app's actor type")
+			assert.Equal(t, instanceID+"::7", req.ActorID)
+		case <-time.After(time.Second * 5):
+			require.Fail(t, "the reap delete never reached the reminder store")
+		}
+	})
+
+	t.Run("completions of unescalated tasks are ignored", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		h.orch.janitorEscalated = map[int32]struct{}{9: {}}
+
+		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{taskCompletedEvent(7)})
+		assert.Len(t, h.orch.janitorEscalated, 1)
+		assert.NotContains(t, h.snapshotOps(), "delete:run-activity")
+	})
+}

--- a/pkg/actors/targets/workflow/orchestrator/reap_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/reap_test.go
@@ -58,24 +58,60 @@ func Test_reapEscalatedCompletions(t *testing.T) {
 	t.Parallel()
 	const instanceID = "wf-reap-completion"
 
-	t.Run("a committed completion reaps its escalated reminder", func(t *testing.T) {
+	t.Run("a committed resolution reaps its escalated reminder", func(t *testing.T) {
 		t.Parallel()
 		h := newWakeHarness(t, instanceID, true)
 		h.primeRunning(t, instanceID, 7)
-		h.orch.janitorEscalated = map[int32]struct{}{7: {}}
+		h.orch.janitorRedispatchedGen = h.orch.state.Generation
+		h.orch.janitorEscalated = map[int32]*backend.HistoryEvent{7: h.orch.state.History[1]}
+		h.orch.state.AddToHistory(taskCompletedEvent(7))
 
-		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{taskCompletedEvent(7)})
+		h.orch.reapEscalatedCompletions(h.orch.state)
 		assert.Empty(t, h.orch.janitorEscalated, "a reaped task must not be reaped again")
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.Contains(c, h.snapshotOps(), "delete:run-activity")
 		}, time.Second*5, time.Millisecond*5)
 	})
 
-	t.Run("a cross-app completion reaps on the remote activity actor type", func(t *testing.T) {
+	t.Run("an unresolved task keeps its mark and reminder", func(t *testing.T) {
 		t.Parallel()
 		h := newWakeHarness(t, instanceID, true)
 		h.primeRunning(t, instanceID, 7)
-		h.orch.janitorEscalated = map[int32]struct{}{7: {}}
+		h.orch.janitorRedispatchedGen = h.orch.state.Generation
+		h.orch.janitorEscalated = map[int32]*backend.HistoryEvent{7: h.orch.state.History[1]}
+
+		h.orch.reapEscalatedCompletions(h.orch.state)
+		assert.Len(t, h.orch.janitorEscalated, 1)
+		assert.NotContains(t, h.snapshotOps(), "delete:run-activity")
+	})
+
+	t.Run("a generation change voids the marks without reaping", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+		h.orch.janitorRedispatchedGen = h.orch.state.Generation
+		h.orch.janitorEscalated = map[int32]*backend.HistoryEvent{7: h.orch.state.History[1]}
+		h.orch.state.AddToHistory(taskCompletedEvent(7))
+		h.orch.state.Generation++
+
+		h.orch.reapEscalatedCompletions(h.orch.state)
+		assert.Empty(t, h.orch.janitorEscalated,
+			"stale-generation marks are void: their reminder identity is shared with the new generation")
+		assert.NotContains(t, h.snapshotOps(), "delete:run-activity",
+			"a stale-generation mark must not delete a reminder the new generation may own")
+	})
+
+	t.Run("a cross-app resolution reaps on the remote activity actor type", func(t *testing.T) {
+		t.Parallel()
+		h := newWakeHarness(t, instanceID, true)
+		h.primeRunning(t, instanceID, 7)
+
+		target := "otherapp"
+		scheduled := h.orch.state.History[1]
+		scheduled.Router = &protos.TaskRouter{SourceAppID: "testapp", TargetAppID: &target}
+		h.orch.janitorRedispatchedGen = h.orch.state.Generation
+		h.orch.janitorEscalated = map[int32]*backend.HistoryEvent{7: scheduled}
+		h.orch.state.AddToHistory(taskCompletedEvent(7))
 
 		reqCh := make(chan *actorapi.DeleteReminderRequest, 1)
 		h.fact.reminders = remindersfake.New().WithDelete(func(_ context.Context, req *actorapi.DeleteReminderRequest) error {
@@ -83,9 +119,7 @@ func Test_reapEscalatedCompletions(t *testing.T) {
 			return nil
 		})
 
-		completion := taskCompletedEvent(7)
-		completion.Router = &protos.TaskRouter{SourceAppID: "otherapp"}
-		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{completion})
+		h.orch.reapEscalatedCompletions(h.orch.state)
 
 		select {
 		case req := <-reqCh:
@@ -96,16 +130,5 @@ func Test_reapEscalatedCompletions(t *testing.T) {
 		case <-time.After(time.Second * 5):
 			require.Fail(t, "the reap delete never reached the reminder store")
 		}
-	})
-
-	t.Run("completions of unescalated tasks are ignored", func(t *testing.T) {
-		t.Parallel()
-		h := newWakeHarness(t, instanceID, true)
-		h.primeRunning(t, instanceID, 7)
-		h.orch.janitorEscalated = map[int32]struct{}{9: {}}
-
-		h.orch.reapEscalatedCompletions([]*backend.HistoryEvent{taskCompletedEvent(7)})
-		assert.Len(t, h.orch.janitorEscalated, 1)
-		assert.NotContains(t, h.snapshotOps(), "delete:run-activity")
 	})
 }

--- a/pkg/actors/targets/workflow/orchestrator/redispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/redispatch.go
@@ -131,6 +131,7 @@ func (o *orchestrator) redispatchActivities(ctx context.Context, state *wfengine
 		// durable reminder.
 		if o.janitorRedispatchedGen != state.Generation {
 			o.janitorRedispatched = nil
+			o.janitorEscalated = nil
 			o.janitorRedispatchedGen = state.Generation
 		}
 		if o.janitorRedispatched == nil {
@@ -142,6 +143,10 @@ func (o *orchestrator) redispatchActivities(ctx context.Context, state *wfengine
 			live[id] = struct{}{}
 			if _, ok := o.janitorRedispatched[id]; ok {
 				durable[id] = true
+				if o.janitorEscalated == nil {
+					o.janitorEscalated = make(map[int32]struct{})
+				}
+				o.janitorEscalated[id] = struct{}{}
 			} else {
 				o.janitorRedispatched[id] = struct{}{}
 			}
@@ -165,6 +170,7 @@ func (o *orchestrator) redispatchActivities(ctx context.Context, state *wfengine
 			case cerr == nil && durable[e.GetEventId()]:
 				log.Infof("Workflow actor '%s': janitor escalated unresolved activity '%s::%d' to its durable run-activity reminder (a prior re-dispatch did not resolve it)", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
 				diag.DefaultWorkflowMonitoring.WorkflowLocalActivity(context.Background(), diag.StatusJanitorRedispatchEscalated)
+				o.reapResolvedEscalation(wakeCtx, e)
 			case cerr == nil:
 				log.Infof("Workflow actor '%s': janitor re-dispatched unresolved activity '%s::%d'", o.actorID, e.GetTaskScheduled().GetName(), e.GetEventId())
 				diag.DefaultWorkflowMonitoring.WorkflowLocalActivity(context.Background(), diag.StatusJanitorRedispatched)

--- a/pkg/actors/targets/workflow/orchestrator/redispatch.go
+++ b/pkg/actors/targets/workflow/orchestrator/redispatch.go
@@ -144,9 +144,9 @@ func (o *orchestrator) redispatchActivities(ctx context.Context, state *wfengine
 			if _, ok := o.janitorRedispatched[id]; ok {
 				durable[id] = true
 				if o.janitorEscalated == nil {
-					o.janitorEscalated = make(map[int32]struct{})
+					o.janitorEscalated = make(map[int32]*backend.HistoryEvent)
 				}
-				o.janitorEscalated[id] = struct{}{}
+				o.janitorEscalated[id] = e
 			} else {
 				o.janitorRedispatched[id] = struct{}{}
 			}

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -579,6 +579,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			if saveErr != nil {
 				return todo.RunCompletedFalse, saveErr
 			}
+			o.reapEscalatedCompletions(newEvents)
 			diagnoseStatus = diag.StatusRecoverable
 			return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
 		}
@@ -602,6 +603,8 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// Bump before the elide so a stale escalation cannot recreate the
 	// reminder.
 	o.wakeEpoch.Add(1)
+
+	o.reapEscalatedCompletions(newEvents)
 
 	// This turn consumed the ExecutionStarted event and its commit above is
 	// durable, so the pending start one-shot can only ever fire as a no-op:

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -341,6 +341,10 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 				// including folded completions: their senders are acked.
 				foldedCommitted = true
 
+				// The generation bumped: void the escalation marks rather
+				// than reap them (see reapEscalatedCompletions).
+				o.reapEscalatedCompletions(state)
+
 				// Bump before the elide so a stale escalation cannot
 				// recreate the reminder.
 				o.wakeEpoch.Add(1)
@@ -579,7 +583,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 			if saveErr != nil {
 				return todo.RunCompletedFalse, saveErr
 			}
-			o.reapEscalatedCompletions(newEvents)
+			o.reapEscalatedCompletions(state)
 			diagnoseStatus = diag.StatusRecoverable
 			return todo.RunCompletedFalse, wferrors.NewRecoverable(dispatchErr)
 		}
@@ -604,7 +608,7 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	// reminder.
 	o.wakeEpoch.Add(1)
 
-	o.reapEscalatedCompletions(newEvents)
+	o.reapEscalatedCompletions(state)
 
 	// This turn consumed the ExecutionStarted event and its commit above is
 	// durable, so the pending start one-shot can only ever fire as a no-op:

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -72,6 +72,12 @@ const (
 	// recent progress (fresh durable commit or a running drive loop); the
 	// next period re-checks.
 	StatusJanitorRedispatchSuppressed = "janitor_redispatch_suppressed"
+	// An escalated run-activity reminder was deleted because its task
+	// resolved: the resolving execution predates the escalation and cannot
+	// delete a reminder it never knew existed, so the escalating and
+	// committing turns reap it (see reapEscalatedReminder). Without the
+	// reap, the fire re-runs the body on a cold host.
+	StatusJanitorEscalationReaped = "janitor_escalation_reaped"
 	// An activity arrival found the in-flight claim held by a dead execution
 	// (no engine-held work item after the stale grace) and evicted it so the
 	// arrival re-executes; the rescue event of the janitor-livelock class
@@ -398,7 +404,7 @@ func (w *workflowMetrics) Init(meter view.Meter, appID, namespace string, latenc
 			stats.WithTags(diagUtils.WithTags(w.localWakeCount.Name(), appIDKey, appID, namespaceKey, namespace, statusKey, s)...),
 			stats.WithMeasurements(w.localWakeCount.M(0)))
 	}
-	for _, s := range []string{StatusJanitorRedispatched, StatusJanitorRedispatchEscalated, StatusClaimEvicted} {
+	for _, s := range []string{StatusJanitorRedispatched, StatusJanitorRedispatchEscalated, StatusJanitorEscalationReaped, StatusClaimEvicted} {
 		stats.RecordWithOptions(context.Background(),
 			stats.WithRecorder(w.meter),
 			stats.WithTags(diagUtils.WithTags(w.localActivityCount.Name(), appIDKey, appID, namespaceKey, namespace, statusKey, s)...),

--- a/pkg/runtime/wfengine/todo/todo.go
+++ b/pkg/runtime/wfengine/todo/todo.go
@@ -58,6 +58,11 @@ const (
 	MetadataFetchOnly = "MetadataFetchOnly"
 
 	ActorTypePrefix = "dapr.internal."
+
+	// ActivityReminderName is the per-activity-actor execution reminder name.
+	// Shared so the orchestrator can reap an escalated reminder whose task
+	// resolved while the escalation create was in flight.
+	ActivityReminderName = "run-activity"
 )
 
 var (

--- a/tests/integration/framework/workflow/claimrecords.go
+++ b/tests/integration/framework/workflow/claimrecords.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
@@ -30,10 +31,15 @@ import (
 func CountClaimRecords(t *testing.T, ctx context.Context, db *sqlite.SQLite) int {
 	t.Helper()
 	var count int
-	require.NoError(t, db.GetConnection(t).QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM "+db.TableName()+" WHERE key LIKE ?",
-		"%||execution-claim",
-	).Scan(&count))
+	// The query shares the store with running daprds; a write transaction
+	// can hold the file lock past the connection's busy timeout under load,
+	// so transient SQLITE_BUSY reads retry rather than fail the test.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, db.GetConnection(t).QueryRowContext(ctx,
+			"SELECT COUNT(*) FROM "+db.TableName()+" WHERE key LIKE ?",
+			"%||execution-claim",
+		).Scan(&count))
+	}, time.Second*20, time.Millisecond*100)
 	return count
 }
 

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
@@ -144,4 +144,7 @@ func (e *basic) Run(t *testing.T, ctx context.Context) {
 		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
 			"no run-activity reminder may outlive its workflow")
 	}, time.Second*30, time.Millisecond*50)
+
+	assert.Equal(t, int64(batch), executions.Load(),
+		"every activity body must run exactly once; a reaped reminder cannot fire")
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package escalationreap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(basic))
+}
+
+// basic verifies the durable run-activity reminder armed by a janitor
+// escalation is reaped once its task resolves. The escalation can only land
+// during a handoff window (the dissemination cancels the in-flight execution's
+// wait and frees the activity actor lock), and the resolving execution
+// predates the escalation, so nothing else deletes the reminder and its fire
+// re-runs the body on a cold host.
+type basic struct {
+	workflow *workflow.Workflow
+	joiner   *daprd.Daprd
+}
+
+func (e *basic) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Millisecond*200),
+	}
+	e.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	e.joiner = daprd.New(t, append([]daprd.Option{
+		daprd.WithAppID(e.workflow.Dapr().AppID()),
+		daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
+		daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
+		daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
+	}, fp...)...)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *basic) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const batch = 6
+
+	var executions atomic.Int64
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		return nil, c.CallActivity("Slow").Await(nil)
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case <-release:
+			return nil, nil
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("EscalationReap", wfFn))
+	require.NoError(t, e.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := e.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, 0, batch)
+	for range batch {
+		resp, err := e.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "EscalationReap",
+		})
+		require.NoError(t, err)
+		ids = append(ids, resp.GetInstanceId())
+	}
+	require.Eventually(t, func() bool {
+		return executions.Load() >= int64(batch)
+	}, time.Second*30, time.Millisecond*10,
+		"every activity body must be mid-execution before the churn")
+
+	e.joiner.Run(t, ctx)
+	t.Cleanup(func() { e.joiner.Cleanup(t) })
+	e.joiner.WaitUntilRunning(t, ctx)
+
+	registry := task.NewTaskRegistry()
+	require.NoError(t, registry.AddWorkflowN("EscalationReap", wfFn))
+	require.NoError(t, registry.AddActivityN("Slow", actFn))
+	joinerClient := client.NewTaskHubGrpcClient(e.joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+	sumBoth := func(status string) float64 {
+		return e.workflow.Dapr().Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status) +
+			e.joiner.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status)
+	}
+	require.Eventually(t, func() bool {
+		return sumBoth("janitor_redispatch_escalated") >= 1
+	}, time.Second*30, time.Millisecond*50,
+		"the janitor must escalate at least one unresolved activity to its durable reminder")
+
+	close(release)
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(1))
+		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
+			"no run-activity reminder may outlive its workflow")
+	}, time.Second*30, time.Millisecond*50)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
@@ -145,4 +145,7 @@ func (e *failed) Run(t *testing.T, ctx context.Context) {
 		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
 			"no run-activity reminder may outlive its workflow")
 	}, time.Second*30, time.Millisecond*10)
+
+	assert.Equal(t, int64(batch), executions.Load(),
+		"every failing body must run exactly once; a reaped reminder cannot fire")
 }

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package escalationreap
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(failed))
+}
+
+// escalationreap verifies the durable run-activity reminder armed by a janitor
+// escalation is reaped once its task resolves. The escalation can only land
+// during a handoff window (the dissemination cancels the in-flight execution's
+// wait and frees the activity actor lock), and the resolving execution
+// predates the escalation, so nothing else deletes the reminder and its fire
+// re-runs the body on a cold host.
+type failed struct {
+	workflow *workflow.Workflow
+	joiner   *daprd.Daprd
+}
+
+func (e *failed) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Millisecond*200),
+	}
+	e.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	e.joiner = daprd.New(t, append([]daprd.Option{
+		daprd.WithAppID(e.workflow.Dapr().AppID()),
+		daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
+		daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
+		daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
+	}, fp...)...)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *failed) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const batch = 6
+
+	var executions atomic.Int64
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		return nil, c.CallActivity("Slow").Await(nil)
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case <-release:
+			return nil, errors.New("deliberate activity failure")
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("EscalationReapFailed", wfFn))
+	require.NoError(t, e.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := e.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, 0, batch)
+	for range batch {
+		resp, err := e.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "EscalationReapFailed",
+		})
+		require.NoError(t, err)
+		ids = append(ids, resp.GetInstanceId())
+	}
+	require.Eventually(t, func() bool {
+		return executions.Load() >= int64(batch)
+	}, time.Second*30, time.Millisecond*10,
+		"every activity body must be mid-execution before the churn")
+
+	e.joiner.Run(t, ctx)
+	t.Cleanup(func() { e.joiner.Cleanup(t) })
+	e.joiner.WaitUntilRunning(t, ctx)
+
+	registry := task.NewTaskRegistry()
+	require.NoError(t, registry.AddWorkflowN("EscalationReapFailed", wfFn))
+	require.NoError(t, registry.AddActivityN("Slow", actFn))
+	joinerClient := client.NewTaskHubGrpcClient(e.joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+	sumBoth := func(status string) float64 {
+		return e.workflow.Dapr().Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status) +
+			e.joiner.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status)
+	}
+	require.Eventually(t, func() bool {
+		return sumBoth("janitor_redispatch_escalated") >= 1
+	}, time.Second*30, time.Millisecond*10,
+		"the janitor must escalate at least one unresolved activity to its durable reminder")
+
+	close(release)
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_FAILED", metadata.GetRuntimeStatus().String())
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(1))
+		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
+			"no run-activity reminder may outlive its workflow")
+	}, time.Second*30, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/fanout.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/fanout.go
@@ -1,0 +1,161 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package escalationreap
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(fanout))
+}
+
+// escalationreap verifies the durable run-activity reminder armed by a janitor
+// escalation is reaped once its task resolves. The escalation can only land
+// during a handoff window (the dissemination cancels the in-flight execution's
+// wait and frees the activity actor lock), and the resolving execution
+// predates the escalation, so nothing else deletes the reminder and its fire
+// re-runs the body on a cold host.
+type fanout struct {
+	workflow *workflow.Workflow
+	joiner   *daprd.Daprd
+}
+
+func (e *fanout) Setup(t *testing.T) []framework.Option {
+	fp := []daprd.Option{
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithWorkflowJanitorPeriod(t, time.Millisecond*200),
+	}
+	e.workflow = workflow.New(t, workflow.WithDaprdOptions(0, fp...))
+
+	e.joiner = daprd.New(t, append([]daprd.Option{
+		daprd.WithAppID(e.workflow.Dapr().AppID()),
+		daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
+		daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
+		daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
+	}, fp...)...)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *fanout) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const batch = 2
+	const fanout = 4
+
+	var executions atomic.Int64
+	release := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-release:
+		default:
+			close(release)
+		}
+	})
+
+	wfFn := func(c *task.WorkflowContext) (any, error) {
+		tasks := make([]task.Task, fanout)
+		for i := range tasks {
+			tasks[i] = c.CallActivity("Slow")
+		}
+		for _, tk := range tasks {
+			if err := tk.Await(nil); err != nil {
+				return nil, err
+			}
+		}
+		return nil, nil
+	}
+	actFn := func(c task.ActivityContext) (any, error) {
+		executions.Add(1)
+		select {
+		case <-release:
+			return nil, nil
+		case <-c.Context().Done():
+			return nil, c.Context().Err()
+		}
+	}
+
+	require.NoError(t, e.workflow.Registry().AddWorkflowN("EscalationReapFanout", wfFn))
+	require.NoError(t, e.workflow.Registry().AddActivityN("Slow", actFn))
+	client1 := e.workflow.BackendClient(t, ctx)
+
+	ids := make([]string, 0, batch)
+	for range batch {
+		resp, err := e.workflow.GRPCClient(t, ctx).StartWorkflowBeta1(ctx, &rtv1.StartWorkflowRequest{
+			WorkflowComponent: "dapr",
+			WorkflowName:      "EscalationReapFanout",
+		})
+		require.NoError(t, err)
+		ids = append(ids, resp.GetInstanceId())
+	}
+	require.Eventually(t, func() bool {
+		return executions.Load() >= int64(batch*fanout)
+	}, time.Second*30, time.Millisecond*10,
+		"every activity body must be mid-execution before the churn")
+
+	e.joiner.Run(t, ctx)
+	t.Cleanup(func() { e.joiner.Cleanup(t) })
+	e.joiner.WaitUntilRunning(t, ctx)
+
+	registry := task.NewTaskRegistry()
+	require.NoError(t, registry.AddWorkflowN("EscalationReapFanout", wfFn))
+	require.NoError(t, registry.AddActivityN("Slow", actFn))
+	joinerClient := client.NewTaskHubGrpcClient(e.joiner.GRPCConn(t, ctx), backend.DefaultLogger())
+	require.NoError(t, joinerClient.StartWorkItemListener(ctx, registry))
+
+	sumBoth := func(status string) float64 {
+		return e.workflow.Dapr().Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status) +
+			e.joiner.Metrics(t, ctx).SumWithLabels("dapr_runtime_workflow_local_activity_count", "status:"+status)
+	}
+	require.Eventually(t, func() bool {
+		return sumBoth("janitor_redispatch_escalated") >= 1
+	}, time.Second*30, time.Millisecond*10,
+		"the janitor must escalate at least one unresolved activity to its durable reminder")
+
+	close(release)
+	for _, id := range ids {
+		metadata, err := client1.WaitForWorkflowCompletion(ctx, api.InstanceID(id))
+		require.NoError(t, err)
+		assert.Equal(t, "ORCHESTRATION_STATUS_COMPLETED", metadata.GetRuntimeStatus().String())
+	}
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(2),
+			"every escalated task of the fan-out must be reaped, not only the first")
+		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
+			"no run-activity reminder may outlive its workflow")
+	}, time.Second*30, time.Millisecond*10)
+
+	assert.Equal(t, int64(batch*fanout), executions.Load(),
+		"every activity body must run exactly once; a reaped reminder cannot fire")
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/reuseid"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/activityv2"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/fold"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/scheduler/localwake"


### PR DESCRIPTION
The janitor escalation arms the durable run-activity reminder without knowing whether the task resolves around the create; the resolving execution predates the escalation and cannot delete a reminder it never knew existed, so the leaked fire re-runs the activity body on a cold host.

Reap from both ends of the race: the escalating turn re-checks resolution after the create returns, and the turn that commits the completion of a marked-escalated task deletes the reminder. Both reaps are detached and best-effort, and emit the `janitor_escalation_reaped` metric.