### PR TITLE
ci: add an allowance to the sidecar heap validation

### DIFF
--- a/.github/scripts/validate_sidecar_resources.py
+++ b/.github/scripts/validate_sidecar_resources.py
@@ -137,15 +137,15 @@ def test_diff(arr_old, arr_new, label, test='ttest'):
             return True
 
         print(f"Passed! Did not find statistically significant increase in {label}.")
-    elif test == 'tp75_plus_10percent':
-        # Memory measurement has enough variation that the t-test is too strict.
-        # So, we created this custom comparison to avoid false positives.
-        # Picking 10% as a good enough margin observed by various runs with the same binary.
-        if p75_new > p75_old * 1.10:
-            print(f"Warning! Found significant increase in {label}.")
+    elif test == 'tp75_plus_margin':
+        ratio = float(getenv("LIMIT_HEAP_P75_RATIO", 1.10))
+        delta_mb = float(getenv("LIMIT_DELTA_HEAP_MB", 5))
+        limit = p75_old * ratio + delta_mb
+        if p75_new > limit:
+            print(f"Warning! Found significant increase in {label}: p75 {p75_new:.2f} exceeds limit {limit:.2f}.")
             return True
 
-        print(f"Passed! Did not find significant increase in {label}.")
+        print(f"Passed! Did not find significant increase in {label}: p75 {p75_new:.2f} within limit {limit:.2f}.")
 
     return False
 
@@ -178,7 +178,7 @@ if __name__ == "__main__":
     memory_data_new = run_sidecar(new_binary, "treatment")
     memory_data_old = run_sidecar(old_binary, "control")
 
-    memory_diff = test_diff(memory_data_old, memory_data_new, "Go heap in-use (in MB)", "tp75_plus_10percent")
+    memory_diff = test_diff(memory_data_old, memory_data_new, "Go heap in-use (in MB)", "tp75_plus_margin")
 
     if binary_size_diff or memory_diff:
         raise Exception("Found significant differences.")

--- a/.github/scripts/validate_sidecar_resources.py
+++ b/.github/scripts/validate_sidecar_resources.py
@@ -138,8 +138,8 @@ def test_diff(arr_old, arr_new, label, test='ttest'):
 
         print(f"Passed! Did not find statistically significant increase in {label}.")
     elif test == 'tp75_plus_margin':
-        ratio = float(getenv("LIMIT_HEAP_P75_RATIO", 1.10))
-        delta_mb = float(getenv("LIMIT_DELTA_HEAP_MB", 5))
+        ratio = getenv_float("LIMIT_HEAP_P75_RATIO", 1.10)
+        delta_mb = getenv_float("LIMIT_DELTA_HEAP_MB", 5)
         limit = p75_old * ratio + delta_mb
         if p75_new > limit:
             print(f"Warning! Found significant increase in {label}: p75 {p75_new:.2f} exceeds limit {limit:.2f}.")
@@ -166,6 +166,13 @@ def getenv(key, default):
     if not v or v == "":
         return default
     return v
+
+def getenv_float(key, default):
+    v = getenv(key, default)
+    try:
+        return float(v)
+    except ValueError:
+        raise Exception(f"{key} must be a number, got {v!r}")
 
 if __name__ == "__main__":
     goos=getenv("GOOS", "linux")


### PR DESCRIPTION
The standalone validation failed whenever the new build's p75 Go heap in-use exceeded the released binary's by 10%. At a ~20 MB baseline that margin is ~2 MB, inside the normal GC sawtooth, and since the baseline is the released binary rather than the merge base, legitimate feature drift accretes toward the limit between releases: the gate trips often on unrelated PRs. Fail only past the relative margin plus an absolute allowance (default 5 MB), both overridable from the workflow via LIMIT_HEAP_P75_RATIO and LIMIT_DELTA_HEAP_MB, mirroring LIMIT_DELTA_BINARY_SIZE.