### PR TITLE
grpc: preserve context error classification in InvokeService

### DIFF
--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -321,6 +321,11 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 			if errors.Is(rErr, context.DeadlineExceeded) || errors.Is(rErr, context.Canceled) {
 				return rResp, status.FromContextError(rErr).Err()
 			}
+			// A remote hop returns the same conditions as already-classified
+			// status errors rather than context sentinels: pass them through.
+			if c := status.Code(rErr); c == codes.DeadlineExceeded || c == codes.Canceled {
+				return rResp, rErr
+			}
 			return rResp, messages.ErrDirectInvoke.WithFormat(in.GetId(), rErr)
 		}
 

--- a/pkg/api/grpc/grpc.go
+++ b/pkg/api/grpc/grpc.go
@@ -312,6 +312,15 @@ func (a *api) InvokeService(ctx context.Context, in *runtimev1pb.InvokeServiceRe
 			}
 		}
 		if rErr != nil {
+			// A dead request context is not an internal daprd failure:
+			// preserve its gRPC classification (DeadlineExceeded/Canceled)
+			// so the caller observes the same code whether its own deadline
+			// timer or this reply wins the race. The blanket Internal wrap
+			// below would otherwise misclassify e.g. an app-channel
+			// concurrency-limiter acquire aborted by the caller's deadline.
+			if errors.Is(rErr, context.DeadlineExceeded) || errors.Is(rErr, context.Canceled) {
+				return rResp, status.FromContextError(rErr).Err()
+			}
 			return rResp, messages.ErrDirectInvoke.WithFormat(in.GetId(), rErr)
 		}
 

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -818,6 +818,8 @@ func TestInvokeServiceContextErrorClassification(t *testing.T) {
 	}{
 		{"deadline exceeded", fmt.Errorf("limiter acquire: %w", context.DeadlineExceeded), codes.DeadlineExceeded},
 		{"canceled", fmt.Errorf("limiter acquire: %w", context.Canceled), codes.Canceled},
+		{"remote deadline status", status.Error(codes.DeadlineExceeded, "remote hop deadline"), codes.DeadlineExceeded},
+		{"remote canceled status", status.Error(codes.Canceled, "remote hop canceled"), codes.Canceled},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/api/grpc/grpc_test.go
+++ b/pkg/api/grpc/grpc_test.go
@@ -787,6 +787,53 @@ func TestInvokeServiceFromGRPCResponse(t *testing.T) {
 	})
 }
 
+func TestInvokeServiceContextErrorClassification(t *testing.T) {
+	mockDirectMessaging := new(daprt.MockDirectMessaging)
+
+	fakeAPI := &api{
+		logger: logger.NewLogger("test"),
+		Universal: universal.New(universal.Options{
+			AppID:      "fakeAPI",
+			Resiliency: resiliency.New(nil),
+		}),
+		directMessaging: mockDirectMessaging,
+	}
+	lis := startDaprAPIServer(t, fakeAPI, "")
+	clientConn := createTestClient(lis)
+	defer clientConn.Close()
+	client := runtimev1pb.NewDaprClient(clientConn)
+
+	req := &runtimev1pb.InvokeServiceRequest{
+		Id:      "fakeAppID",
+		Message: &commonv1pb.InvokeRequest{Method: "fakeMethod"},
+	}
+
+	// A request context that dies mid-invoke (e.g. queued on the app
+	// channel's concurrency limiter) must keep its gRPC classification,
+	// not be wrapped as Internal.
+	tests := []struct {
+		name string
+		err  error
+		code codes.Code
+	}{
+		{"deadline exceeded", fmt.Errorf("limiter acquire: %w", context.DeadlineExceeded), codes.DeadlineExceeded},
+		{"canceled", fmt.Errorf("limiter acquire: %w", context.Canceled), codes.Canceled},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			mockDirectMessaging.Calls = nil
+			mockDirectMessaging.On("Invoke",
+				mock.MatchedBy(matchContextInterface),
+				"fakeAppID",
+				mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(nil, tc.err).Once()
+
+			_, err := client.InvokeService(t.Context(), req)
+			require.Error(t, err)
+			assert.Equal(t, tc.code, status.Code(err))
+		})
+	}
+}
+
 func TestSecretStoreNotConfigured(t *testing.T) {
 	lis := startDaprAPIServer(t, &api{
 		logger: logger.NewLogger("grpc.api.test"),

--- a/tests/integration/suite/daprd/serviceinvocation/grpc/resiliencytimeout.go
+++ b/tests/integration/suite/daprd/serviceinvocation/grpc/resiliencytimeout.go
@@ -1,0 +1,135 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package grpc
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	commonv1 "github.com/dapr/dapr/pkg/proto/common/v1"
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/grpc/app"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(resiliencytimeout))
+}
+
+type resiliencytimeout struct {
+	daprd *procdaprd.Daprd
+
+	entered chan struct{}
+	release chan struct{}
+}
+
+func (m *resiliencytimeout) Setup(t *testing.T) []framework.Option {
+	m.entered = make(chan struct{}, 1)
+	m.release = make(chan struct{})
+
+	appID := uuid.New().String()
+
+	srv := app.New(t, app.WithOnInvokeFn(func(ctx context.Context, in *commonv1.InvokeRequest) (*commonv1.InvokeResponse, error) {
+		if in.GetMethod() == "hold" {
+			select {
+			case m.entered <- struct{}{}:
+			default:
+			}
+			select {
+			case <-m.release:
+			case <-ctx.Done():
+			}
+		}
+		return new(commonv1.InvokeResponse), nil
+	}))
+
+	m.daprd = procdaprd.New(t,
+		procdaprd.WithAppID(appID),
+		procdaprd.WithAppProtocol("grpc"),
+		procdaprd.WithAppPort(srv.Port(t)),
+		procdaprd.WithAppMaxConcurrency(1),
+		procdaprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: myresiliency
+spec:
+  policies:
+    timeouts:
+      short: 1s
+  targets:
+    apps:
+      %s:
+        timeout: short
+`, appID)),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(srv, m.daprd),
+	}
+}
+
+func (m *resiliencytimeout) Run(t *testing.T, ctx context.Context) {
+	m.daprd.WaitUntilRunning(t, ctx)
+
+	client := m.daprd.GRPCClient(t, ctx)
+	invoke := func(ctx context.Context, method string) error {
+		_, err := client.InvokeService(ctx, &rtv1.InvokeServiceRequest{
+			Id: m.daprd.AppID(),
+			Message: &commonv1.InvokeRequest{
+				Method:        method,
+				HttpExtension: &commonv1.HTTPExtension{Verb: commonv1.HTTPExtension_POST},
+			},
+		})
+		return err
+	}
+
+	holdErr := make(chan error, 1)
+	go func() { holdErr <- invoke(ctx, "hold") }()
+	select {
+	case <-m.entered:
+	case <-time.After(time.Second * 10):
+		t.Fatal("hold invocation never reached the app")
+	}
+
+	waiterErr := make(chan error, 1)
+	go func() { waiterErr <- invoke(ctx, "fast") }()
+	select {
+	case err := <-waiterErr:
+		require.Error(t, err, "queued waiter must fail on the resiliency timeout")
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(time.Second * 10):
+		t.Fatal("queued waiter did not return after the resiliency timeout")
+	}
+
+	close(m.release)
+	select {
+	case err := <-holdErr:
+		require.Error(t, err, "held invocation must fail on the resiliency timeout")
+		require.Equal(t, codes.DeadlineExceeded, status.Code(err))
+	case <-time.After(time.Second * 10):
+		t.Fatal("held invocation did not return")
+	}
+
+	require.NoError(t, invoke(ctx, "fast"), "invocation after release failed")
+}


### PR DESCRIPTION
InvokeService wrapped every direct messaging failure as Internal, so an invoke aborted by a dead context (the caller's own deadline expiring while queued on the app channel's concurrency limiter, or a resiliency timeout cancelling the attempt) was answered with Internal whenever the aborted operation returned before the racing timeout path. The observed code then depended on which racer won: the windows leg of the maxconcurrency integration test flaked between DeadlineExceeded and Internal. Map DeadlineExceeded and Canceled context errors to their gRPC codes before the Internal wrap, so every racer yields the same classification.