### PR TITLE
Ignore generated devcontainer lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ config/crd/bases
 github.com/
 
 .vscode
+.devcontainer/devcontainer-lock.json
 
 # Auto-generated CRDs
 config/crd/bases/*.yaml


### PR DESCRIPTION
# Description

Adds `.devcontainer/devcontainer-lock.json` to `.gitignore`.

The Dev Containers tooling generates this file when the container is created or rebuilt. Ignoring it prevents the generated file from appearing in `git status` and being accidentally committed.

## Issue reference

Closes #10314

## Verification

- Reproduced the issue on `master`.
- Rebuilt the Dev Container and confirmed the lock file was generated.
- Verified the generated file does not appear in normal `git status`.
- Verified `git status --short --ignored` reports it with `!!`.
- Ran `git diff --check` successfully.

## Checklist

- [ ] Code compiles correctly — Not applicable; no code was changed.
- [ ] Created/updated tests — Not applicable; this is a `.gitignore` change.
- [ ] Unit tests passing — Not applicable; no runtime behavior was changed.
- [x] End-to-end tests passing — Manually rebuilt the Dev Container and verified the generated file is ignored.
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo — Not applicable.
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo — Not applicable.
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo — Not applicable.