### PR TITLE
Placement -> Scheduler Part 0: Add rendezvous hashing lib

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aavaz-ai/pii-scrubber v0.0.0-20220812094047-3fa450ab6973
 	github.com/argoproj/argo-rollouts v1.4.1
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/cespare/xxhash/v2 v2.3.0
 	github.com/cloudevents/sdk-go/v2 v2.15.2
 	github.com/coreos/go-oidc/v3 v3.17.0
 	github.com/dapr/components-contrib v1.18.4
@@ -216,7 +217,6 @@ require (
 	github.com/camunda/zeebe/clients/go/v8 v8.5.25 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/cenkalti/backoff/v5 v5.0.3 // indirect
-	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/chebyrash/promise v0.0.0-20230709133807-42ec49ba1459 // indirect
 	github.com/cinience/go_rocketmq v0.0.2 // indirect
 	github.com/clbanning/mxj/v2 v2.5.6 // indirect

--- a/pkg/actors/hashing/rendezvous/contract_test.go
+++ b/pkg/actors/hashing/rendezvous/contract_test.go
@@ -1,0 +1,194 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rendezvous
+
+import (
+	"slices"
+	"strconv"
+	"testing"
+
+	"github.com/cespare/xxhash/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Pin the HASH_ALGORITHM_RENDEZVOUS wire contract, which every
+// party resolving actor ownership must implement identically. Changing any
+// value here re-shards every actor in every running cluster, so intended
+// algorithm changes need a new HashAlgorithm enum value instead.
+
+var contractHosts = []string{"10.0.0.1:50002", "10.0.0.2:50002", "10.0.0.3:50002"}
+
+// TestContractScore pins the score function, xxhash64("<host>||<key>"),
+// with values derived independently of this package.
+func TestContractScore(t *testing.T) {
+	t.Parallel()
+
+	for _, test := range []struct {
+		host string
+		key  string
+		want uint64
+	}{
+		{host: "10.0.0.1:50002", key: "actor-1", want: 11841101866786924059},
+		{host: "10.0.0.2:50002", key: "actor-1", want: 14141808514106082977},
+		{host: "10.0.0.3:50002", key: "actor-1", want: 1347952300613944576},
+	} {
+		assert.Equalf(t, test.want, score(test.host, test.key),
+			"score(%q, %q) changed: this re-shards every actor in every cluster",
+			test.host, test.key)
+	}
+}
+
+// TestContractSeparator pins the separator as the two byte string "||", by
+// asserting the score equals the hash of the concatenation built by hand.
+func TestContractSeparator(t *testing.T) {
+	t.Parallel()
+
+	assert.Equal(t, "||", separator)
+	assert.Equal(t,
+		xxhash.Sum64String("10.0.0.1:50002"+"||"+"actor-1"),
+		score("10.0.0.1:50002", "actor-1"),
+	)
+}
+
+// TestContractOwners pins the resolved owner for keys including the empty
+// key, a unicode key, and a key containing the separator itself.
+func TestContractOwners(t *testing.T) {
+	t.Parallel()
+
+	table := New(contractHosts)
+
+	for _, test := range []struct {
+		key  string
+		want string
+	}{
+		{key: "actor-1", want: "10.0.0.2:50002"},
+		{key: "actor-2", want: "10.0.0.3:50002"},
+		{key: "actor-3", want: "10.0.0.1:50002"},
+		{key: "actor-4", want: "10.0.0.1:50002"},
+		{key: "actor-5", want: "10.0.0.3:50002"},
+		{key: "0", want: "10.0.0.2:50002"},
+		{key: "", want: "10.0.0.2:50002"},
+		{key: "ολυ-unicode-κλειδί", want: "10.0.0.1:50002"},
+		{key: "myactor||weird", want: "10.0.0.1:50002"},
+	} {
+		owner, ok := table.Lookup(test.key)
+		require.Truef(t, ok, "no owner for key %q", test.key)
+		assert.Equalf(t, test.want, owner,
+			"owner of key %q changed: this re-shards actors across hosts", test.key)
+	}
+}
+
+func referenceLookup(hosts []string, key string) (string, bool) {
+	uniq := slices.Clone(hosts)
+	slices.Sort(uniq)
+	uniq = slices.Compact(uniq)
+	if len(uniq) == 0 {
+		return "", false
+	}
+
+	best := uniq[0]
+	bestScore := xxhash.Sum64String(best + "||" + key)
+	for _, host := range uniq[1:] {
+		// Strictly greater: on a tie the earlier, lexicographically smaller
+		// host keeps ownership.
+		if s := xxhash.Sum64String(host + "||" + key); s > bestScore {
+			best, bestScore = host, s
+		}
+	}
+
+	return best, true
+}
+
+func TestContractMatchesReference(t *testing.T) {
+	t.Parallel()
+
+	for _, numHosts := range []int{1, 2, 3, 7, 32, 128} {
+		t.Run(strconv.Itoa(numHosts)+"-hosts", func(t *testing.T) {
+			t.Parallel()
+
+			hostSet := hosts(numHosts)
+			table := New(hostSet)
+
+			for i := range 2000 {
+				key := "actor-" + strconv.Itoa(i)
+				want, wantOK := referenceLookup(hostSet, key)
+				got, gotOK := table.Lookup(key)
+				require.Equal(t, wantOK, gotOK)
+				require.Equalf(t, want, got, "owner mismatch for key %q", key)
+			}
+		})
+	}
+}
+
+func TestNewSortsAndCompacts(t *testing.T) {
+	t.Parallel()
+
+	table := New([]string{
+		"10.0.0.3:50002",
+		"10.0.0.1:50002",
+		"10.0.0.2:50002",
+		"10.0.0.1:50002",
+		"10.0.0.3:50002",
+	})
+
+	assert.Equal(t, []string{
+		"10.0.0.1:50002",
+		"10.0.0.2:50002",
+		"10.0.0.3:50002",
+	}, table.Hosts())
+	assert.True(t, slices.IsSorted(table.Hosts()))
+}
+
+// TestEqualNilReceiver covers the nil-table branch of Equal, which is reached
+// whenever a placement table has not been installed for an actor type yet.
+func TestEqualNilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var nilTable *Table
+
+	t.Run("nil equals nil", func(t *testing.T) {
+		t.Parallel()
+		var other *Table
+		assert.True(t, nilTable.Equal(other))
+	})
+
+	t.Run("nil equals empty", func(t *testing.T) {
+		t.Parallel()
+		assert.True(t, nilTable.Equal(New(nil)))
+		assert.True(t, New(nil).Equal(nilTable))
+	})
+
+	t.Run("nil does not equal populated", func(t *testing.T) {
+		t.Parallel()
+		assert.False(t, nilTable.Equal(New(contractHosts)))
+		assert.False(t, New(contractHosts).Equal(nilTable))
+	})
+}
+
+func TestHostsDoesNotRetainInput(t *testing.T) {
+	t.Parallel()
+
+	input := []string{"10.0.0.2:50002", "10.0.0.1:50002"}
+	table := New(input)
+	before := slices.Clone(table.Hosts())
+
+	// Mutating the caller's slice must not change the table.
+	input[0] = "10.0.0.9:50002"
+	assert.Equal(t, before, table.Hosts())
+
+	owner, ok := table.Lookup("actor-1")
+	require.True(t, ok)
+	assert.Contains(t, before, owner)
+}

--- a/pkg/actors/hashing/rendezvous/rendezvous.go
+++ b/pkg/actors/hashing/rendezvous/rendezvous.go
@@ -89,13 +89,12 @@ func (t *Table) score(i int, key string) uint64 {
 	return d.Sum64()
 }
 
-// Hosts returns the sorted host addresses in the table. The returned slice
-// must not be mutated.
+// Hosts returns a copy of the sorted host addresses in the table.
 func (t *Table) Hosts() []string {
 	if t == nil {
 		return nil
 	}
-	return t.hosts
+	return slices.Clone(t.hosts)
 }
 
 // Equal returns whether both tables are over the same host set.

--- a/pkg/actors/hashing/rendezvous/rendezvous.go
+++ b/pkg/actors/hashing/rendezvous/rendezvous.go
@@ -1,0 +1,119 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// Package rendezvous implements rendezvous (highest random weight) hashing
+// over a set of host addresses. It is the PlacementV2 actor placement
+// algorithm, used by both the daprd sidecar and the scheduler so that all
+// parties resolve the same owner host for a given actor ID from the same host
+// set. Compared to a vnode consistent hash ring it has optimal balance, needs
+// no replication factor tuning, and moves the provably minimal set of keys
+// when a host joins or leaves.
+package rendezvous
+
+import (
+	"slices"
+
+	"github.com/cespare/xxhash/v2"
+)
+
+// separator matches the wire contract documented on
+// dapr.proto.scheduler.v1.HashAlgorithm: the score of a (host, key) pair is
+// xxhash64("<host address>||<key>").
+const separator = "||"
+
+// Table is an immutable rendezvous hash table over a set of host addresses.
+type Table struct {
+	hosts []string
+	// prefixes[i] is a Digest pre-fed with hosts[i] and the separator.
+	// Lookup streams only the key into a copy of it.
+	prefixes []xxhash.Digest
+}
+
+// New returns a table over the given host addresses. Duplicates are removed
+// and the input slice is not retained.
+func New(hosts []string) *Table {
+	sorted := slices.Clone(hosts)
+	slices.Sort(sorted)
+	sorted = slices.Compact(sorted)
+
+	prefixes := make([]xxhash.Digest, len(sorted))
+	for i, host := range sorted {
+		prefixes[i].Reset()
+		//nolint:errcheck // Digest.WriteString never returns an error.
+		prefixes[i].WriteString(host)
+		//nolint:errcheck
+		prefixes[i].WriteString(separator)
+	}
+
+	return &Table{hosts: sorted, prefixes: prefixes}
+}
+
+// Lookup returns the host address owning the given key, false when the table
+// has no hosts. The owner is the host with the highest xxhash64 score for the
+// key. Score ties break to the lexicographically smaller host address so that
+// every party resolves the same owner.
+func (t *Table) Lookup(key string) (string, bool) {
+	if t == nil || len(t.hosts) == 0 {
+		return "", false
+	}
+
+	owner := t.hosts[0]
+	best := t.score(0, key)
+	// hosts are sorted, so on a tie the earlier (smaller) host wins by never
+	// replacing on equal score.
+	for i := 1; i < len(t.hosts); i++ {
+		if s := t.score(i, key); s > best {
+			owner, best = t.hosts[i], s
+		}
+	}
+
+	return owner, true
+}
+
+// score is xxhash64("<host>||<key>") for hosts[i], resumed from the host's
+// precomputed prefix digest.
+func (t *Table) score(i int, key string) uint64 {
+	d := t.prefixes[i]
+	//nolint:errcheck // Digest.WriteString never returns an error.
+	d.WriteString(key)
+	return d.Sum64()
+}
+
+// Hosts returns the sorted host addresses in the table. The returned slice
+// must not be mutated.
+func (t *Table) Hosts() []string {
+	if t == nil {
+		return nil
+	}
+	return t.hosts
+}
+
+// Equal returns whether both tables are over the same host set.
+func (t *Table) Equal(other *Table) bool {
+	if t == nil || other == nil {
+		return t == other || len(t.Hosts()) == len(other.Hosts())
+	}
+	return slices.Equal(t.hosts, other.hosts)
+}
+
+func score(host, key string) uint64 {
+	var d xxhash.Digest
+	d.Reset()
+	//nolint:errcheck // Digest.WriteString never returns an error.
+	d.WriteString(host)
+	//nolint:errcheck
+	d.WriteString(separator)
+	//nolint:errcheck
+	d.WriteString(key)
+	return d.Sum64()
+}

--- a/pkg/actors/hashing/rendezvous/rendezvous_test.go
+++ b/pkg/actors/hashing/rendezvous/rendezvous_test.go
@@ -1,0 +1,199 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package rendezvous
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func hostN(n int) string {
+	return "10.0." + strconv.Itoa(n/256) + "." + strconv.Itoa(n%256) + ":50002"
+}
+
+func hosts(n int) []string {
+	out := make([]string, n)
+	for i := range n {
+		out[i] = hostN(i)
+	}
+	return out
+}
+
+func TestLookup(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty and nil tables have no owner", func(t *testing.T) {
+		t.Parallel()
+		_, ok := New(nil).Lookup("actor-1")
+		assert.False(t, ok)
+		var nilTable *Table
+		_, ok = nilTable.Lookup("actor-1")
+		assert.False(t, ok)
+	})
+
+	t.Run("single host owns every key", func(t *testing.T) {
+		t.Parallel()
+		table := New([]string{"10.0.0.1:50002"})
+		for i := range 100 {
+			owner, ok := table.Lookup("actor-" + strconv.Itoa(i))
+			require.True(t, ok)
+			assert.Equal(t, "10.0.0.1:50002", owner)
+		}
+	})
+
+	t.Run("deterministic and independent of input order or duplicates", func(t *testing.T) {
+		t.Parallel()
+		a := New([]string{hostN(0), hostN(1), hostN(2)})
+		b := New([]string{hostN(2), hostN(0), hostN(1), hostN(0)})
+		require.True(t, a.Equal(b))
+		for i := range 1000 {
+			key := "actor-" + strconv.Itoa(i)
+			ownerA, okA := a.Lookup(key)
+			ownerB, okB := b.Lookup(key)
+			require.True(t, okA)
+			require.True(t, okB)
+			assert.Equal(t, ownerA, ownerB)
+			assert.Contains(t, a.Hosts(), ownerA)
+		}
+	})
+}
+
+func TestEqual(t *testing.T) {
+	t.Parallel()
+
+	assert.True(t, New(nil).Equal(New(nil)))
+	assert.True(t, New([]string{"a", "b"}).Equal(New([]string{"b", "a", "a"})))
+	assert.False(t, New([]string{"a"}).Equal(New([]string{"a", "b"})))
+	assert.False(t, New([]string{"a"}).Equal(New([]string{"b"})))
+}
+
+func TestBalance(t *testing.T) {
+	t.Parallel()
+
+	const numHosts = 10
+	const numKeys = 100_000
+
+	table := New(hosts(numHosts))
+	counts := make(map[string]int, numHosts)
+	for i := range numKeys {
+		owner, ok := table.Lookup("actor-" + strconv.Itoa(i))
+		require.True(t, ok)
+		counts[owner]++
+	}
+
+	require.Len(t, counts, numHosts)
+	expected := numKeys / numHosts
+	for host, count := range counts {
+		// Random uniform assignment of 100k keys over 10 hosts keeps every
+		// host well within 10% of the mean.
+		assert.InDeltaf(t, expected, count, 0.1*float64(expected),
+			"host %s owns %d keys, expected close to %d", host, count, expected)
+	}
+}
+
+func TestMinimalMovementOnLeave(t *testing.T) {
+	t.Parallel()
+
+	const numHosts = 10
+	const numKeys = 100_000
+	removed := hostN(3)
+
+	before := New(hosts(numHosts))
+	after := New(append(hosts(numHosts)[:3], hosts(numHosts)[4:]...))
+
+	moved := 0
+	for i := range numKeys {
+		key := "actor-" + strconv.Itoa(i)
+		ownerBefore, ok := before.Lookup(key)
+		require.True(t, ok)
+		ownerAfter, ok := after.Lookup(key)
+		require.True(t, ok)
+
+		if ownerBefore == removed {
+			moved++
+			assert.NotEqual(t, removed, ownerAfter)
+		} else {
+			// A key not owned by the removed host must not move: its
+			// remaining host scores are unchanged.
+			assert.Equal(t, ownerBefore, ownerAfter)
+		}
+	}
+
+	// Only the removed host's share moved, roughly 1/numHosts of all keys.
+	expected := numKeys / numHosts
+	assert.InDelta(t, expected, moved, 0.1*float64(expected))
+}
+
+func TestMinimalMovementOnJoin(t *testing.T) {
+	t.Parallel()
+
+	const numHosts = 9
+	const numKeys = 100_000
+	joined := hostN(100)
+
+	before := New(hosts(numHosts))
+	after := New(append(hosts(numHosts), joined))
+
+	moved := 0
+	for i := range numKeys {
+		key := "actor-" + strconv.Itoa(i)
+		ownerBefore, ok := before.Lookup(key)
+		require.True(t, ok)
+		ownerAfter, ok := after.Lookup(key)
+		require.True(t, ok)
+
+		if ownerBefore != ownerAfter {
+			moved++
+			// Every moved key must have moved to the new host, never
+			// between existing hosts.
+			assert.Equal(t, joined, ownerAfter)
+		}
+	}
+
+	// The new host takes over roughly 1/(numHosts+1) of all keys.
+	expected := numKeys / (numHosts + 1)
+	assert.InDelta(t, expected, moved, 0.1*float64(expected))
+}
+
+func BenchmarkLookup(b *testing.B) {
+	for _, n := range []int{3, 10, 50, 200} {
+		b.Run(strconv.Itoa(n)+"-hosts", func(b *testing.B) {
+			table := New(hosts(n))
+			b.ResetTimer()
+			for i := 0; b.Loop(); i++ {
+				table.Lookup("actor-" + strconv.Itoa(i%10_000))
+			}
+		})
+	}
+}
+
+// BenchmarkNew measures table construction, which runs on the placement
+// leader and on every sidecar for each actor type whose membership changed.
+// Per-type dissemination makes this the hot path on a membership change:
+// where a vnode ring sorts hosts*replicationFactor entries, a rendezvous
+// table sorts one entry per host.
+func BenchmarkNew(b *testing.B) {
+	for _, n := range []int{3, 10, 50, 200, 1000} {
+		b.Run(strconv.Itoa(n)+"-hosts", func(b *testing.B) {
+			hostSet := hosts(n)
+			b.ResetTimer()
+			for b.Loop() {
+				New(hostSet)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Adds a [rendezvous (highest-random-weight) hashing library](https://en.wikipedia.org/wiki/Rendezvous_hashing). The score for each (host, key) pair is - `xxhash64("<host>||<key>")` which every consumer must compute identical placements. This is the hashing the Scheduler will use to place actors.

First in a series of PRs breaking up #[10364](https://github.com/dapr/dapr/pull/10364) per review feedback, so the algorithm and its wire contract get an isolated review. Nothing consumes the package yet. Consumers arrive in the follow-up PRs.