### PR TITLE
Fix perf CI k6-operator stall & add multi-instance workflow perf tests

### DIFF
--- a/tests/apps/perf/workflowsapp/app.py
+++ b/tests/apps/perf/workflowsapp/app.py
@@ -191,6 +191,7 @@ def run_workflow(run_id):
             instance_id = start_resp.instance_id
         except DaprInternalError as e:
             print(f"{datetime.now():%Y-%m-%d %H:%M:%S.%f} [{run_id}] error starting workflow: {e.message}")
+            return f"error starting workflow: {e.message}", 500
 
         sleep(0.5)
 

--- a/tests/config/dapr_postgres_state.yaml
+++ b/tests/config/dapr_postgres_state.yaml
@@ -34,3 +34,5 @@ scopes:
   - disabledmetric
   - perf-workflowsapp
   - perf-workflowsapp-actors
+  - perf-workflowsapp-scaled
+  - perf-workflowsapp-scaled-actors

--- a/tests/config/dapr_postgres_state_actorstore.yaml
+++ b/tests/config/dapr_postgres_state_actorstore.yaml
@@ -47,6 +47,8 @@ scopes:
 - workflowsapp-retention
 - perf-workflowsapp
 - perf-workflowsapp-actors
+- perf-workflowsapp-scaled
+- perf-workflowsapp-scaled-actors
 - wfacl-caller
 - wfacl-target
 - wfxapp-caller

--- a/tests/perf/workflows/workflow_test.go
+++ b/tests/perf/workflows/workflow_test.go
@@ -38,7 +38,12 @@ var (
 	tr            *runner.TestRunner
 	appNamePrefix = "perf-workflowsapp"
 	appName       string // actual app name including backend suffix
+	scaledAppName string // multi-replica variant of the app
 )
+
+// scaledReplicas is the replica count for the multi-instance tests, where
+// workflows and activities are placed across instances.
+const scaledReplicas = 3
 
 type K6RunConfig struct {
 	TARGET_URL     string
@@ -51,6 +56,7 @@ type K6RunConfig struct {
 func TestMain(m *testing.M) {
 	backend := os.Getenv("DAPR_PERF_WORKFLOW_BACKEND_NAME")
 	appName = appNamePrefix + backend
+	scaledAppName = appNamePrefix + "-scaled" + backend
 
 	utils.SetupLogs("workflow_test")
 	testApps := []kube.AppDescription{
@@ -59,6 +65,24 @@ func TestMain(m *testing.M) {
 			DaprEnabled:       true,
 			ImageName:         "perf-workflowsapp",
 			Replicas:          1,
+			IngressEnabled:    true,
+			IngressPort:       3000,
+			MetricsEnabled:    true,
+			DaprCPULimit:      "1.0",
+			DaprCPURequest:    "0.5",
+			DaprMemoryLimit:   "2Gi",
+			DaprMemoryRequest: "1Gi",
+			AppCPULimit:       "2.0",
+			AppCPURequest:     "1.0",
+			AppMemoryLimit:    "2Gi",
+			AppMemoryRequest:  "1Gi",
+			AppPort:           3000,
+		},
+		{
+			AppName:           scaledAppName,
+			DaprEnabled:       true,
+			ImageName:         "perf-workflowsapp",
+			Replicas:          scaledReplicas,
 			IngressEnabled:    true,
 			IngressPort:       3000,
 			MetricsEnabled:    true,
@@ -152,8 +176,10 @@ func testWorkflow(t *testing.T, workflowName string, testAppName string, inputs 
 				// Initialize the workflow runtime
 				url := fmt.Sprintf("http://%s/start-workflow-runtime", externalURL)
 				// Calling start-workflow-runtime multiple times so that it is started in all app instances
-				_, err := utils.HTTPGet(url)
-				require.NoError(t, err, "error starting workflow runtime")
+				for range scaledReplicas * 3 {
+					_, err := utils.HTTPGet(url)
+					require.NoError(t, err, "error starting workflow runtime")
+				}
 
 				time.Sleep(5 * time.Second)
 
@@ -222,6 +248,26 @@ func TestWorkflowWithDifferentPayloads(t *testing.T) {
 	inputs := []string{"10000", "50000", "100000"}
 	rateChecks := [][]string{{"rate==1"}, {"rate==1"}, {"rate==1"}}
 	testWorkflow(t, workflowName, appName, inputs, scenarios, rateChecks, true, true)
+}
+
+// Runs tests for `sum_series_wf` against a multi-replica app, placing
+// workflows across instances
+func TestSeriesWorkflowMultiInstance(t *testing.T) {
+	workflowName := "sum_series_wf"
+	inputs := []string{"100"}
+	scenarios := []string{"t_30_300"} // t_workflowCount_iterations
+	rateChecks := [][]string{{"rate==1"}}
+	testWorkflow(t, workflowName, scaledAppName, inputs, scenarios, rateChecks, true, false)
+}
+
+// Runs tests for `sum_parallel_wf` against a multi-replica app, fanning
+// activities out across instances
+func TestParallelWorkflowMultiInstance(t *testing.T) {
+	workflowName := "sum_parallel_wf"
+	inputs := []string{"100"}
+	scenarios := []string{"t_110_440"} // t_workflowCount_iterations
+	rateChecks := [][]string{{"rate==1"}}
+	testWorkflow(t, workflowName, scaledAppName, inputs, scenarios, rateChecks, true, false)
 }
 
 // Runs test for delaying workflows: 500 VUs, 10,000 iterations

--- a/tests/runner/loadtest/k6.go
+++ b/tests/runner/loadtest/k6.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"sort"
 	"sync"
 	"time"
 
@@ -315,6 +316,7 @@ func (k6 *K6) k8sRun(k8s *runner.KubeTestPlatform) error {
 	}
 
 	if err = k6.waitForCompletion(); err != nil {
+		k6.dumpDiagnostics()
 		return err
 	}
 	return k6.streamLogs()
@@ -433,10 +435,28 @@ func (k6 *K6) waitForDeletion() error {
 	})
 }
 
+// operatorKickAfter is how long a K6 resource may sit without jobs before
+// the k6-operator is restarted. The v0.0.8 operator reconciles with a single
+// worker which waits inside the reconcile, so a wait that cannot complete,
+// ex: on a test whose jobs were already deleted, starves every later test
+// for up to the wait timeout, which scales with the test duration.
+const operatorKickAfter = 3 * time.Minute
+
 // waitForCompletion for the tests until it finish.
 func (k6 *K6) waitForCompletion() error {
+	start := time.Now()
+	kicked := false
 	return k6.waitUntilJobsState(func(jobList *batchv1.JobList, err error) bool {
-		if err != nil || jobList == nil || len(jobList.Items) < k6.parallelism {
+		if err != nil || jobList == nil {
+			return false
+		}
+
+		if len(jobList.Items) == 0 && !kicked && time.Since(start) > operatorKickAfter {
+			kicked = true
+			k6.kickOperator()
+		}
+
+		if len(jobList.Items) < k6.parallelism {
 			return false
 		}
 
@@ -450,15 +470,132 @@ func (k6 *K6) waitForCompletion() error {
 	})
 }
 
-// Dispose deletes the test resource.
+// kickOperator restarts the k6-operator by deleting its pods, so a fresh
+// reconcile worker picks up the K6 resource it never acted on.
+func (k6 *K6) kickOperator() {
+	const operatorNamespace = "k6-operator-system"
+	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+	defer cancel()
+	log.Printf("k6 %q has no jobs after %s, restarting the k6-operator", k6.name, operatorKickAfter)
+	err := k6.kubeClient.CoreV1().Pods(operatorNamespace).DeleteCollection(ctx, v1.DeleteOptions{}, v1.ListOptions{})
+	if err != nil {
+		log.Printf("restarting the k6-operator: %v", err)
+	}
+}
+
+// dumpDiagnostics logs the K6 resource, its jobs and pods, recent namespace
+// events, and the k6-operator manager logs after a k6 run fails to reach the
+// expected state. Everything is best-effort.
+func (k6 *K6) dumpDiagnostics() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	if cr, err := k6.k6Client.Get(ctx, k6.name); err != nil {
+		log.Printf("k6 diagnostics: get %q: %v", k6.name, err)
+	} else if raw, jerr := json.Marshal(cr); jerr != nil {
+		log.Printf("k6 diagnostics: marshal %q: %v", k6.name, jerr)
+	} else {
+		log.Printf("k6 diagnostics: resource %q: %s", k6.name, raw)
+	}
+
+	crSelector := "k6_cr=" + k6.name
+	if jobs, err := k6.kubeClient.BatchV1().Jobs(k6.namespace).List(ctx, v1.ListOptions{LabelSelector: crSelector}); err != nil {
+		log.Printf("k6 diagnostics: list jobs: %v", err)
+	} else {
+		log.Printf("k6 diagnostics: %d jobs labeled %s", len(jobs.Items), crSelector)
+		for _, job := range jobs.Items {
+			log.Printf("k6 diagnostics: job %s active=%d succeeded=%d failed=%d", job.Name, job.Status.Active, job.Status.Succeeded, job.Status.Failed)
+		}
+	}
+
+	if pods, err := k6.kubeClient.CoreV1().Pods(k6.namespace).List(ctx, v1.ListOptions{LabelSelector: crSelector}); err != nil {
+		log.Printf("k6 diagnostics: list pods: %v", err)
+	} else {
+		log.Printf("k6 diagnostics: %d pods labeled %s", len(pods.Items), crSelector)
+		for _, pod := range pods.Items {
+			raw, _ := json.Marshal(pod.Status)
+			log.Printf("k6 diagnostics: pod %s status: %s", pod.Name, raw)
+		}
+	}
+
+	if events, err := k6.kubeClient.CoreV1().Events(k6.namespace).List(ctx, v1.ListOptions{}); err != nil {
+		log.Printf("k6 diagnostics: list events: %v", err)
+	} else {
+		items := events.Items
+		sort.Slice(items, func(i, j int) bool {
+			return items[i].LastTimestamp.Before(&items[j].LastTimestamp)
+		})
+		if len(items) > 60 {
+			items = items[len(items)-60:]
+		}
+		for _, ev := range items {
+			log.Printf("k6 diagnostics: event %s %s %s/%s: %s", ev.LastTimestamp.Format(time.RFC3339), ev.Reason, ev.InvolvedObject.Kind, ev.InvolvedObject.Name, ev.Message)
+		}
+	}
+
+	k6.dumpOperatorState(ctx)
+}
+
+// dumpOperatorState logs the k6-operator pod statuses and manager logs.
+func (k6 *K6) dumpOperatorState(ctx context.Context) {
+	const operatorNamespace = "k6-operator-system"
+	pods, err := k6.kubeClient.CoreV1().Pods(operatorNamespace).List(ctx, v1.ListOptions{})
+	if err != nil {
+		log.Printf("k6 diagnostics: list operator pods: %v", err)
+		return
+	}
+	tail := int64(300)
+	for _, pod := range pods.Items {
+		raw, _ := json.Marshal(pod.Status)
+		log.Printf("k6 diagnostics: operator pod %s status: %s", pod.Name, raw)
+		stream, serr := k6.kubeClient.CoreV1().Pods(operatorNamespace).GetLogs(pod.Name, &corev1.PodLogOptions{Container: "manager", TailLines: &tail}).Stream(ctx)
+		if serr != nil {
+			log.Printf("k6 diagnostics: logs for %s: %v", pod.Name, serr)
+			continue
+		}
+		logs, rerr := io.ReadAll(stream)
+		stream.Close()
+		if rerr != nil {
+			log.Printf("k6 diagnostics: read logs for %s: %v", pod.Name, rerr)
+			continue
+		}
+		log.Printf("k6 diagnostics: operator pod %s manager logs:\n%s", pod.Name, logs)
+	}
+}
+
+// Dispose deletes the test resource once the k6-operator has finished acting
+// on it. Deleting earlier removes the jobs the operator is still polling for,
+// stranding its only reconcile worker until a timeout which can outlast every
+// later test.
 func (k6 *K6) Dispose() error {
 	if k6.k6Client == nil {
 		return nil
 	}
+	k6.waitOperatorFinished()
 	if err := k6.k6Client.Delete(k6.ctx, k6.name, v1.DeleteOptions{}); err != nil && !apierrors.IsNotFound(err) {
 		return err
 	}
 	return k6.waitForDeletion()
+}
+
+// waitOperatorFinished waits until the operator marks the test resource
+// finished, or two minutes: after a completed test the operator needs at most
+// one more 30 second poll tick, while an operator which is stuck or never
+// acted cannot be waited out.
+func (k6 *K6) waitOperatorFinished() {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	//nolint:errcheck
+	wait.PollUntilContextCancel(ctx, 5*time.Second, true, func(ctx context.Context) (bool, error) {
+		cr, err := k6.k6Client.Get(ctx, k6.name)
+		if apierrors.IsNotFound(err) {
+			return true, nil
+		}
+		if err != nil {
+			return false, nil
+		}
+		return cr.Status.Stage == "finished", nil
+	})
 }
 
 type K6Opt = func(*K6)

--- a/tests/runner/loadtest/k6.go
+++ b/tests/runner/loadtest/k6.go
@@ -435,28 +435,10 @@ func (k6 *K6) waitForDeletion() error {
 	})
 }
 
-// operatorKickAfter is how long a K6 resource may sit without jobs before
-// the k6-operator is restarted. The v0.0.8 operator reconciles with a single
-// worker which waits inside the reconcile, so a wait that cannot complete,
-// ex: on a test whose jobs were already deleted, starves every later test
-// for up to the wait timeout, which scales with the test duration.
-const operatorKickAfter = 3 * time.Minute
-
 // waitForCompletion for the tests until it finish.
 func (k6 *K6) waitForCompletion() error {
-	start := time.Now()
-	kicked := false
 	return k6.waitUntilJobsState(func(jobList *batchv1.JobList, err error) bool {
-		if err != nil || jobList == nil {
-			return false
-		}
-
-		if len(jobList.Items) == 0 && !kicked && time.Since(start) > operatorKickAfter {
-			kicked = true
-			k6.kickOperator()
-		}
-
-		if len(jobList.Items) < k6.parallelism {
+		if err != nil || jobList == nil || len(jobList.Items) < k6.parallelism {
 			return false
 		}
 
@@ -468,19 +450,6 @@ func (k6 *K6) waitForCompletion() error {
 
 		return true
 	})
-}
-
-// kickOperator restarts the k6-operator by deleting its pods, so a fresh
-// reconcile worker picks up the K6 resource it never acted on.
-func (k6 *K6) kickOperator() {
-	const operatorNamespace = "k6-operator-system"
-	ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-	defer cancel()
-	log.Printf("k6 %q has no jobs after %s, restarting the k6-operator", k6.name, operatorKickAfter)
-	err := k6.kubeClient.CoreV1().Pods(operatorNamespace).DeleteCollection(ctx, v1.DeleteOptions{}, v1.ListOptions{})
-	if err != nil {
-		log.Printf("restarting the k6-operator: %v", err)
-	}
 }
 
 // dumpDiagnostics logs the K6 resource, its jobs and pods, recent namespace

--- a/tests/runner/loadtest/k6.go
+++ b/tests/runner/loadtest/k6.go
@@ -561,7 +561,8 @@ func (k6 *K6) waitOperatorFinished() {
 			return true, nil
 		}
 		if err != nil {
-			return false, nil
+			// A transient Get error retries until the two minute ceiling.
+			return false, nil //nolint:nilerr
 		}
 		return cr.Status.Stage == "finished", nil
 	})

--- a/tests/runner/loadtest/k6_test.go
+++ b/tests/runner/loadtest/k6_test.go
@@ -197,6 +197,7 @@ func TestK6(t *testing.T) {
 		k6 := NewK6("")
 		k6.kubeClient = kubeClient
 		k6Client := new(fakeK6Client)
+		k6Client.On("Get", mock.Anything, k6.name).Return(apierrors.NewNotFound(schema.GroupResource{}, "k6"))
 		k6Client.On("Delete", mock.Anything, k6.name, mock.Anything).Return(nil)
 		k6.k6Client = k6Client
 		require.NoError(t, k6.Dispose())
@@ -219,6 +220,7 @@ func TestK6(t *testing.T) {
 		k6 := NewK6("")
 		k6.kubeClient = kubeClient
 		k6Client := new(fakeK6Client)
+		k6Client.On("Get", mock.Anything, k6.name).Return(apierrors.NewNotFound(schema.GroupResource{}, "k6"))
 		k6Client.On("Delete", mock.Anything, k6.name, mock.Anything).Return(apierrors.NewNotFound(schema.GroupResource{}, "k6"))
 		k6.k6Client = k6Client
 		require.NoError(t, k6.Dispose())
@@ -441,6 +443,7 @@ func TestK6(t *testing.T) {
 			},
 		}
 		k6Client := new(fakeK6Client)
+		k6Client.On("Get", mock.Anything, k6.name).Return(apierrors.NewNotFound(schema.GroupResource{}, "k6"))
 		k6Client.On("Delete", mock.Anything, k6.name, mock.Anything).Return(nil)
 		k6Client.On("Create", mock.Anything, mock.Anything).Return(nil)
 		k6.k6Client = k6Client


### PR DESCRIPTION
2 perf CI fixes & new coverage

k6-operator stall (the cause of recurring all-k6-tests-fail perf runs): the v0.0.8 operator reconciles with a single worker which polls a test's jobs inside the reconcile. When teardown deletes a K6 resource before the operator's next 30s look, the jobs vanish out from under that poll and it stalls, starving every later k6 test in the run. The framework now deletes a K6 resource only after the operator marks it finished, and dumps the K6 resource, jobs, events, and operator logs when a k6 wait fails, so future failures are self-diagnosing.

Fix a misleading wf app err and return an err with a 500 instead.

Also added multi-instance workflow perf tests (3 replicas), placing workflows and activities across instances - all workflow perf was single-replica before. Their app ID is added to the state store scopes.

[See perf runs in this PR which I pulled the logic out from.](https://github.com/dapr/dapr/pull/10364)