### PR TITLE
[1.18] workflow: assert start reminder after the creation commit

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -2,6 +2,7 @@
 
 This update contains the following bug fixes:
 - [Workflow left permanently PENDING when its start reminder fails during a scheduler restart](#workflow-left-permanently-pending-when-its-start-reminder-fails-during-a-scheduler-restart)
+- [Workflow stranded permanently PENDING when its start reminder fired before the creation commit](#workflow-stranded-permanently-pending-when-its-start-reminder-fired-before-the-creation-commit)
 - [Parent workflow deadlocked forever when a child workflow created after ContinueAsNew collided with a still-running child's instance ID](#parent-workflow-deadlocked-forever-when-a-child-workflow-created-after-continueasnew-collided-with-a-still-running-childs-instance-id)
 - [Output binding invocations over gRPC forwarding binary trace metadata to components](#output-binding-invocations-over-grpc-forwarding-binary-trace-metadata-to-components)
 - [Force purge failed for every workflow when history signing was enabled](#force-purge-failed-for-every-workflow-when-history-signing-was-enabled)
@@ -37,6 +38,32 @@ The Scheduler now returns etcd space-quota exhaustion with gRPC code `ResourceEx
 Previously only `Unavailable` and `DeadlineExceeded` were retried, so any other transient error, including the Scheduler's shutdown and etcd errors that cross the wire as `Unknown`, was dropped on the first attempt.
 This applies to all workflow-related reminder creates (start, timer, activity, and termination reminders), and a genuinely permanent error still surfaces within the bounded retry budget.
 The reminder scheduling error log now also includes the actor type and ID, so any failure can be attributed to the affected workflow instance.
+
+## Workflow stranded permanently PENDING when its start reminder fired before the creation commit
+
+### Problem
+
+Creating a workflow during placement rebalancing or Scheduler leadership churn could leave the new instance permanently stuck in `PENDING`, with an empty history and no reminder registered for it.
+The workflow actor created the one-shot start reminder before committing the instance's state.
+Under rebalancing, the reminder could fire on another host before that commit landed: the firing host found no inbox to process, acknowledged success, and the Scheduler deleted the one-shot reminder.
+The commit then landed on an instance whose only execution trigger was already gone.
+
+### Impact
+
+You were affected if workflows were created concurrently with placement dissemination (hosts joining or leaving) or Scheduler quorum loss, as reported in the field on 1.18.4-rc.2.
+Affected instances reported `PENDING` forever, never executed, and never transitioned to `FAILED`.
+Because the start reminder's name contained a random suffix, no retry of the create could re-register it: retries only ever returned an already exists error, so the instance could only be recovered by purging and recreating it.
+
+### Root Cause
+
+The start reminder was created before the `ExecutionStarted` inbox event was persisted, so a reminder firing in that window found an empty inbox and was acknowledged as complete, permanently consuming the one-shot.
+The random reminder name made the loss unrecoverable: nothing could deterministically re-assert the same reminder afterwards.
+
+### Solution
+
+The workflow actor now persists the `ExecutionStarted` inbox event first and creates the start reminder after the commit, under a deterministic name derived from the saved event.
+A reminder can no longer fire against uncommitted state, and a reminder creation failure now surfaces to the caller as a retryable error instead of stranding the instance.
+Retrying the create for an instance that was saved but whose start reminder is missing re-asserts the reminder under its deterministic name and reports success, reviving the instance instead of failing with already exists.
 
 ## Parent workflow deadlocked forever when a child workflow created after ContinueAsNew collided with a still-running child's instance ID
 

--- a/pkg/actors/targets/workflow/common/retry.go
+++ b/pkg/actors/targets/workflow/common/retry.go
@@ -71,10 +71,10 @@ func CreateReminderWithRetry(ctx context.Context, r reminderCreator, req *actora
 	}, backoff.WithContext(bo, ctx))
 }
 
-// CreateReminderWithRetryForever calls reminders.Create and retries on every
-// error except a context error or a clearly-permanent request error (see
-// isPermanentCreateError), with no overall time bound: it stops only when ctx
-// is cancelled (i.e. the actor is torn down).
+// CreateReminderWithRetryForever calls reminders.Create and retries every
+// error except a context error, a clearly-permanent request error (see
+// isPermanentCreateError), or ResourceExhausted (NOSPACE only clears with
+// compaction or a quota raise): it stops only when ctx is cancelled.
 func CreateReminderWithRetryForever(ctx context.Context, r reminderCreator, req *actorapi.CreateReminderRequest) error {
 	bo := backoff.NewExponentialBackOff()
 	bo.InitialInterval = 100 * time.Millisecond
@@ -86,7 +86,7 @@ func CreateReminderWithRetryForever(ctx context.Context, r reminderCreator, req 
 			return backoff.Permanent(err)
 		}
 		err := r.Create(ctx, req)
-		if err != nil && isPermanentCreateError(err) {
+		if err != nil && (isPermanentCreateError(err) || status.Code(err) == codes.ResourceExhausted) {
 			return backoff.Permanent(err)
 		}
 		return err
@@ -99,9 +99,8 @@ func CreateReminderWithRetryForever(ctx context.Context, r reminderCreator, req 
 // Internal, Aborted, and notably Unknown (the code carried by the scheduler's
 // plain-error returns, including cron shutdown), is treated as retryable by
 // both retry helpers, because the scheduler may recover and the create is an
-// idempotent overwrite-by-name. ResourceExhausted (transient etcd pressure)
-// is also retryable for the forever helper; the bounded helper additionally
-// treats it as permanent, see CreateReminderWithRetry.
+// idempotent overwrite-by-name. ResourceExhausted is permanent in both
+// helpers, see CreateReminderWithRetry.
 func isPermanentCreateError(err error) bool {
 	s, ok := status.FromError(err)
 	if !ok {

--- a/pkg/actors/targets/workflow/common/retry_test.go
+++ b/pkg/actors/targets/workflow/common/retry_test.go
@@ -129,6 +129,8 @@ func Test_CreateReminderWithRetryForever_ResourceExhausted(t *testing.T) {
 
 	req := &actorapi.CreateReminderRequest{Name: "start-es-1", ActorType: "wf", ActorID: "id"}
 	creator := &failNCreator{n: 2, err: status.Error(codes.ResourceExhausted, "quota")}
-	require.NoError(t, CreateReminderWithRetryForever(t.Context(), creator, req))
-	assert.Equal(t, 3, creator.calls)
+	err := CreateReminderWithRetryForever(t.Context(), creator, req)
+	require.Error(t, err)
+	assert.Equal(t, codes.ResourceExhausted, status.Code(err))
+	assert.Equal(t, 1, creator.calls)
 }

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -182,8 +182,9 @@ func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *ba
 	// a reminder created first can fire on another host before the save
 	// commits, ack SUCCESS off the empty inbox and be deleted, stranding the
 	// workflow once the save lands. Saving first makes the failure
-	// recoverable: a failed reminder create surfaces to the caller, and a
-	// create retry re-asserts it by deterministic name from the saved event.
+	// recoverable: the reminder create retries until the caller's context
+	// dies, and a create retry re-asserts it by deterministic name from the
+	// saved event.
 	state.AddToInbox(startEvent)
 	if err := o.signAndSaveState(ctx, state); err != nil {
 		return err

--- a/pkg/actors/targets/workflow/orchestrator/create.go
+++ b/pkg/actors/targets/workflow/orchestrator/create.go
@@ -23,6 +23,8 @@ import (
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
 
+	actorapi "github.com/dapr/dapr/pkg/actors/api"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/events"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -93,6 +95,8 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 	// We block (re)creation of existing workflows unless they are in a completed state
 	// Or if they still have any pending activity result awaited.
 	if !runtimestate.IsCompleted(rs) {
+		pending := pendingStartEvent(state)
+
 		// This happens when the parent's runWorkflow created the child workflow
 		// successfully but crashed before persisting its own state, causing it to
 		// re-execute and attempt the child creation again.
@@ -100,7 +104,35 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 		if sameParent {
 			log.Debugf("Workflow actor '%s': ignoring duplicate child workflow creation from parent '%s'",
 				o.actorID, startEvent.GetExecutionStarted().GetParentInstance().GetWorkflowInstance().GetInstanceId())
+			// A child that saved but never armed its start reminder has no
+			// other driver: re-assert from the saved event.
+			if pending != nil {
+				missing, err := o.startReminderMissing(ctx, pending)
+				if err != nil {
+					return err
+				}
+				if missing {
+					return o.assertStartReminder(ctx, pending)
+				}
+			}
 			return nil
+		}
+
+		// A saved-but-never-run instance with no armed start reminder is
+		// stranded: retries of the same logical create re-assert it from the
+		// SAVED event (the incoming one has a regenerated timestamp). The
+		// reminder-missing check keeps healthy duplicate creates failing
+		// with AlreadyExists, since a duplicate always observes the first
+		// create's reminder.
+		if pending != nil && isSameLogicalStart(pending.GetExecutionStarted(), startEvent.GetExecutionStarted()) {
+			missing, err := o.startReminderMissing(ctx, pending)
+			if err != nil {
+				return err
+			}
+			if missing {
+				log.Infof("Workflow actor '%s': re-driving pending start for saved-but-never-run workflow", o.actorID)
+				return o.assertStartReminder(ctx, pending)
+			}
 		}
 
 		if parentExecMismatch {
@@ -146,28 +178,91 @@ func (o *orchestrator) createIfCompleted(ctx context.Context, rs *backend.Workfl
 }
 
 func (o *orchestrator) scheduleWorkflowStart(ctx context.Context, startEvent *backend.HistoryEvent, state *wfenginestate.State) error {
-	start := startEvent.GetTimestamp().AsTime()
-	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
-		start = ts.AsTime()
-	}
-
-	// Schedule a reminder to execute immediately after this operation. The reminder will trigger the actual
-	// workflow execution. This is preferable to using the current thread so that we don't block the client
-	// while the workflow logic is running.
-	workflowName := startEvent.GetExecutionStarted().GetName()
-	reminderName, err := randomReminderName(reminderPrefixStart)
-	if err != nil {
-		return err
-	}
-	if err := o.createWorkflowReminder(ctx, reminderName, nil, start, o.appID, &workflowName); err != nil {
-		return err
-	}
+	// Save BEFORE creating the wake-up reminder, mirroring AddWorkflowEvent:
+	// a reminder created first can fire on another host before the save
+	// commits, ack SUCCESS off the empty inbox and be deleted, stranding the
+	// workflow once the save lands. Saving first makes the failure
+	// recoverable: a failed reminder create surfaces to the caller, and a
+	// create retry re-asserts it by deterministic name from the saved event.
 	state.AddToInbox(startEvent)
 	if err := o.signAndSaveState(ctx, state); err != nil {
 		return err
 	}
 
+	return o.assertStartReminder(ctx, startEvent)
+}
+
+// pendingStartEvent returns the ExecutionStarted inbox event of a saved but
+// never-run workflow (empty history), or nil. Other inbox rows (pre-start
+// RaiseEvent) are ignored.
+func pendingStartEvent(state *wfenginestate.State) *backend.HistoryEvent {
+	if len(state.History) > 0 {
+		return nil
+	}
+	for _, e := range state.Inbox {
+		if e.GetExecutionStarted() != nil {
+			return e
+		}
+	}
 	return nil
+}
+
+// startReminderMissing reports whether the pending start's wake-up reminder
+// is absent from the scheduler; Get errors surface as retryable.
+func (o *orchestrator) startReminderMissing(ctx context.Context, saved *backend.HistoryEvent) (bool, error) {
+	rem, err := o.reminders.Get(ctx, &actorapi.GetReminderRequest{
+		Name:      events.EventReminderName(reminderPrefixStart, saved),
+		ActorType: o.actorTypeBuilder.Workflow(o.appID),
+		ActorID:   o.actorID,
+	})
+	if err != nil {
+		// Missing is contractually (nil, nil), but tolerate NotFound-as-error.
+		if st, ok := status.FromError(err); ok && st.Code() == codes.NotFound {
+			return true, nil
+		}
+		return false, fmt.Errorf("failed to check for pending start reminder: %w", err)
+	}
+	return rem == nil, nil
+}
+
+// isSameLogicalStart reports whether the incoming ExecutionStarted describes
+// the same logical creation as the saved pending one, ignoring per-attempt
+// volatile fields (Timestamp, own ExecutionId, trace context). The parent's
+// ExecutionId is not volatile and is compared when present on both sides.
+func isSameLogicalStart(saved, incoming *protos.ExecutionStartedEvent) bool {
+	if saved.GetName() != incoming.GetName() {
+		return false
+	}
+
+	if saved.GetVersion().GetValue() != incoming.GetVersion().GetValue() {
+		return false
+	}
+
+	if saved.GetInput().GetValue() != incoming.GetInput().GetValue() {
+		return false
+	}
+
+	savedTS, incomingTS := saved.GetScheduledStartTimestamp(), incoming.GetScheduledStartTimestamp()
+	if (savedTS == nil) != (incomingTS == nil) {
+		return false
+	}
+	if savedTS != nil && !savedTS.AsTime().Equal(incomingTS.AsTime()) {
+		return false
+	}
+
+	savedParent, incomingParent := saved.GetParentInstance(), incoming.GetParentInstance()
+	if (savedParent == nil) != (incomingParent == nil) {
+		return false
+	}
+	if savedParent != nil {
+		if savedParent.GetWorkflowInstance().GetInstanceId() != incomingParent.GetWorkflowInstance().GetInstanceId() ||
+			savedParent.GetTaskScheduledId() != incomingParent.GetTaskScheduledId() ||
+			!sameParentExecution(savedParent, incomingParent) {
+			return false
+		}
+	}
+
+	return true
 }
 
 // isSameParentCreation reports whether the incoming child creation is a

--- a/pkg/actors/targets/workflow/orchestrator/create_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/create_test.go
@@ -15,6 +15,8 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -41,10 +43,17 @@ import (
 )
 
 // createHarness captures every state save and reminder create in a single
-// ordered operation log so tests can assert what a create attempt persisted.
+// ordered operation log so tests can assert save-before-create ordering.
 type createHarness struct {
-	lock sync.Mutex
-	ops  []string
+	lock    sync.Mutex
+	ops     []string
+	creates []*actorapi.CreateReminderRequest
+
+	createErr error
+
+	// armedReminder, when non-nil, is returned by the reminders Get fake:
+	// the pending start's scheduler reminder exists. Nil means missing.
+	armedReminder *actorapi.Reminder
 
 	orch *orchestrator
 }
@@ -58,8 +67,17 @@ func newCreateHarness(t *testing.T, instanceID string) *createHarness {
 		WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
 			h.lock.Lock()
 			defer h.lock.Unlock()
+			if h.createErr != nil {
+				return h.createErr
+			}
 			h.ops = append(h.ops, "create:"+req.Name)
+			h.creates = append(h.creates, req)
 			return nil
+		}).
+		WithGet(func(context.Context, *actorapi.GetReminderRequest) (*actorapi.Reminder, error) {
+			h.lock.Lock()
+			defer h.lock.Unlock()
+			return h.armedReminder, nil
 		})
 
 	fakeState := statefake.New().
@@ -115,9 +133,9 @@ func startEventFor(instanceID string, ts time.Time, mutate func(*protos.Executio
 	}
 }
 
-// primeActiveStart primes the orchestrator with an active, not-completed
-// state: empty history, the given start event in the inbox.
-func (h *createHarness) primeActiveStart(savedStart *backend.HistoryEvent) *wfenginestate.State {
+// primePendingStart primes the orchestrator with a saved-but-never-run state:
+// empty history, the given events in the inbox.
+func (h *createHarness) primePendingStart(savedStart *backend.HistoryEvent, extraInbox ...*backend.HistoryEvent) *wfenginestate.State {
 	state := wfenginestate.NewState(wfenginestate.Options{
 		AppID:             "testapp",
 		Namespace:         "default",
@@ -125,6 +143,9 @@ func (h *createHarness) primeActiveStart(savedStart *backend.HistoryEvent) *wfen
 		ActivityActorType: "dapr.internal.default.testapp.activity",
 	})
 	state.AddToInbox(savedStart)
+	for _, e := range extraInbox {
+		state.AddToInbox(e)
+	}
 
 	h.orch.state = state
 	h.orch.rstate = runtimestate.NewWorkflowRuntimeState(h.orch.actorID, nil, nil)
@@ -137,6 +158,180 @@ func createRequestBytes(t *testing.T, startEvent *backend.HistoryEvent) []byte {
 	b, err := proto.Marshal(&backend.CreateWorkflowInstanceRequest{StartEvent: startEvent})
 	require.NoError(t, err)
 	return b
+}
+
+func Test_scheduleWorkflowStart_savesBeforeReminderCreate(t *testing.T) {
+	const instanceID = "test-start-order"
+
+	ts := time.Now()
+	h := newCreateHarness(t, instanceID)
+
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, startEventFor(instanceID, ts, nil))))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	wantName := "start-es-" + strconv.Itoa(int(ts.UnixNano()))
+	require.Equal(t, []string{"save", "create:" + wantName}, h.ops,
+		"the inbox must be durably saved before the start reminder is created")
+
+	require.Len(t, h.creates, 1)
+	got := h.creates[0]
+	assert.Equal(t, "dapr.internal.default.testapp.workflow", got.ActorType)
+	assert.Equal(t, instanceID, got.ActorID)
+	assert.Equal(t, ts.UTC().Format(time.RFC3339Nano), got.DueTime)
+
+	require.Len(t, h.orch.state.Inbox, 1)
+	assert.NotNil(t, h.orch.state.Inbox[0].GetExecutionStarted())
+}
+
+func Test_scheduleWorkflowStart_honorsScheduledStartTimestamp(t *testing.T) {
+	const instanceID = "test-start-delayed"
+
+	ts := time.Now()
+	delayed := ts.Add(time.Hour)
+	h := newCreateHarness(t, instanceID)
+
+	start := startEventFor(instanceID, ts, func(es *protos.ExecutionStartedEvent) {
+		es.ScheduledStartTimestamp = timestamppb.New(delayed)
+	})
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, start)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	require.Len(t, h.creates, 1)
+	assert.Equal(t, delayed.UTC().Format(time.RFC3339Nano), h.creates[0].DueTime,
+		"delayed starts must keep the future due time")
+}
+
+func Test_scheduleWorkflowStart_reminderCreateFailureReturnsErrorAfterSave(t *testing.T) {
+	const instanceID = "test-start-create-fails"
+
+	h := newCreateHarness(t, instanceID)
+	h.createErr = errors.New("scheduler exploded")
+
+	err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, startEventFor(instanceID, time.Now(), nil)))
+	require.ErrorContains(t, err, "scheduler exploded")
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	assert.Equal(t, []string{"save"}, h.ops,
+		"the save must have happened; the create failure surfaces to the caller for retry")
+	require.Len(t, h.orch.state.Inbox, 1)
+	assert.NotNil(t, h.orch.state.Inbox[0].GetExecutionStarted(),
+		"the ExecutionStarted inbox row is durable, recoverable via the pending-start path")
+}
+
+func Test_createWorkflowInstance_pendingStartReassertsByDeterministicName(t *testing.T) {
+	const instanceID = "test-pending-reassert"
+
+	savedTS := time.Now().Add(-time.Minute)
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(startEventFor(instanceID, savedTS, nil))
+
+	// A client retry of the same logical create regenerates timestamp (and
+	// ExecutionId); the re-assert must derive the name from the SAVED event.
+	incoming := startEventFor(instanceID, time.Now(), nil)
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	wantName := "start-es-" + strconv.Itoa(int(savedTS.UnixNano()))
+	require.Equal(t, []string{"create:" + wantName}, h.ops,
+		"pending-start re-drive must re-assert exactly one reminder named from the saved event, with no state save")
+	assert.Len(t, h.orch.state.Inbox, 1, "no duplicate inbox append")
+}
+
+func Test_createWorkflowInstance_pendingStartWithArmedReminderAlreadyExists(t *testing.T) {
+	const instanceID = "test-pending-armed"
+
+	// The pending start's scheduler reminder exists: this is a healthy
+	// concurrent duplicate create of an identical workflow (the reuse race),
+	// NOT a stranded start. The duplicate must keep failing with
+	// AlreadyExists and must not re-assert anything.
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), nil))
+	h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
+
+	incoming := startEventFor(instanceID, time.Now(), nil)
+	err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming))
+	require.Error(t, err)
+	assert.Equal(t, codes.AlreadyExists, status.Code(err))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	assert.Empty(t, h.ops, "an armed pending start must not be re-driven or saved")
+}
+
+func Test_createWorkflowInstance_pendingStartParentWithArmedReminderNoop(t *testing.T) {
+	const instanceID = "test-pending-parent-armed"
+
+	parent := func(es *protos.ExecutionStartedEvent) {
+		es.ParentInstance = &protos.ParentInstanceInfo{
+			TaskScheduledId:  3,
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "parent-1"},
+		}
+	}
+
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parent))
+	h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
+
+	// The duplicate child creation is ignored as before; with the reminder
+	// armed there is nothing to re-drive.
+	incoming := startEventFor(instanceID, time.Now(), parent)
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	assert.Empty(t, h.ops)
+}
+
+func Test_createWorkflowInstance_pendingStartMismatchAlreadyExists(t *testing.T) {
+	const instanceID = "test-pending-mismatch"
+
+	for name, mutate := range map[string]func(*protos.ExecutionStartedEvent){
+		"different name":  func(es *protos.ExecutionStartedEvent) { es.Name = "OtherWorkflow" },
+		"different input": func(es *protos.ExecutionStartedEvent) { es.Input = wrapperspb.String(`"other"`) },
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newCreateHarness(t, instanceID)
+			h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), nil))
+
+			incoming := startEventFor(instanceID, time.Now(), mutate)
+			err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming))
+			require.Error(t, err)
+			assert.Equal(t, codes.AlreadyExists, status.Code(err))
+
+			h.lock.Lock()
+			defer h.lock.Unlock()
+			assert.Empty(t, h.ops, "a conflicting create must not re-assert or save anything")
+		})
+	}
+}
+
+func Test_createWorkflowInstance_pendingStartSameParentReasserts(t *testing.T) {
+	const instanceID = "test-pending-parent"
+
+	parent := func(es *protos.ExecutionStartedEvent) {
+		es.ParentInstance = &protos.ParentInstanceInfo{
+			TaskScheduledId:  3,
+			WorkflowInstance: &protos.WorkflowInstance{InstanceId: "parent-1"},
+		}
+	}
+
+	savedTS := time.Now().Add(-time.Minute)
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(startEventFor(instanceID, savedTS, parent))
+
+	// The parent re-executes and re-issues the child creation with a fresh
+	// timestamp: the pending-start child must be re-driven, not ignored.
+	incoming := startEventFor(instanceID, time.Now(), parent)
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	wantName := "start-es-" + strconv.Itoa(int(savedTS.UnixNano()))
+	require.Equal(t, []string{"create:" + wantName}, h.ops)
 }
 
 // parentWithExec returns a startEventFor mutate hook attaching a
@@ -159,7 +354,8 @@ func Test_createWorkflowInstance_sameParentSameExecutionDedups(t *testing.T) {
 	const instanceID = "test-parent-same-exec"
 
 	h := newCreateHarness(t, instanceID)
-	h.primeActiveStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+	h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+	h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
 
 	// A crash-replay duplicate carries the same parent ExecutionId and is
 	// ignored exactly as when no ExecutionId is present at all.
@@ -177,20 +373,30 @@ func Test_createWorkflowInstance_parentExecutionMismatchAlreadyExists(t *testing
 	// A differing parent ExecutionId means the parent continued-as-new (or was
 	// recreated) and scheduled a genuinely new child colliding with a live
 	// child of a previous execution. It must fail with AlreadyExists so the
-	// parent's child task is faulted, never silently deduplicated.
-	h := newCreateHarness(t, instanceID)
-	h.primeActiveStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+	// parent's child task is faulted, never silently deduplicated. The
+	// reminder-missing variant proves the pending-start re-drive gate does not
+	// resurrect the OLD execution's start either.
+	for name, armed := range map[string]*actorapi.Reminder{
+		"reminder armed":   {Name: "start-es-1"},
+		"reminder missing": nil,
+	} {
+		t.Run(name, func(t *testing.T) {
+			h := newCreateHarness(t, instanceID)
+			h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec("exec-a")))
+			h.armedReminder = armed
 
-	incoming := startEventFor(instanceID, time.Now(), parentWithExec("exec-b"))
-	err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming))
-	require.Error(t, err)
-	assert.Equal(t, codes.AlreadyExists, status.Code(err))
-	assert.Contains(t, err.Error(), "already exists")
-	assert.Contains(t, err.Error(), "previous execution")
+			incoming := startEventFor(instanceID, time.Now(), parentWithExec("exec-b"))
+			err := h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming))
+			require.Error(t, err)
+			assert.Equal(t, codes.AlreadyExists, status.Code(err))
+			assert.Contains(t, err.Error(), "already exists")
+			assert.Contains(t, err.Error(), "previous execution")
 
-	h.lock.Lock()
-	defer h.lock.Unlock()
-	assert.Empty(t, h.ops, "a colliding create from a new parent execution must not save or re-arm the old execution's start")
+			h.lock.Lock()
+			defer h.lock.Unlock()
+			assert.Empty(t, h.ops, "a colliding create from a new parent execution must not save or re-arm the old execution's start")
+		})
+	}
 }
 
 func Test_createWorkflowInstance_parentExecutionNilEitherSideDedups(t *testing.T) {
@@ -204,7 +410,8 @@ func Test_createWorkflowInstance_parentExecutionNilEitherSideDedups(t *testing.T
 	} {
 		t.Run(name, func(t *testing.T) {
 			h := newCreateHarness(t, instanceID)
-			h.primeActiveStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec(execs.saved)))
+			h.primePendingStart(startEventFor(instanceID, time.Now().Add(-time.Minute), parentWithExec(execs.saved)))
+			h.armedReminder = &actorapi.Reminder{Name: "start-es-1"}
 
 			incoming := startEventFor(instanceID, time.Now(), parentWithExec(execs.incoming))
 			require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
@@ -243,4 +450,30 @@ func Test_sameParentExecution(t *testing.T) {
 			assert.Equal(t, tc.want, sameParentExecution(tc.existing, tc.incoming))
 		})
 	}
+}
+
+func Test_createWorkflowInstance_pendingStartWithRaisedEventStillReasserts(t *testing.T) {
+	const instanceID = "test-pending-raised"
+
+	savedTS := time.Now().Add(-time.Minute)
+	h := newCreateHarness(t, instanceID)
+	h.primePendingStart(
+		startEventFor(instanceID, savedTS, nil),
+		&backend.HistoryEvent{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{Name: "early"},
+			},
+		},
+	)
+
+	incoming := startEventFor(instanceID, time.Now(), nil)
+	require.NoError(t, h.orch.createWorkflowInstance(t.Context(), createRequestBytes(t, incoming)))
+
+	h.lock.Lock()
+	defer h.lock.Unlock()
+	wantName := "start-es-" + strconv.Itoa(int(savedTS.UnixNano()))
+	require.Equal(t, []string{"create:" + wantName}, h.ops,
+		"a pre-start RaiseEvent in the inbox must not prevent the pending-start re-drive")
 }

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -86,11 +86,10 @@ func (o *orchestrator) createRetentionReminder(ctx context.Context, name string,
 // assertStartReminder creates (or overwrites by name) the deterministic
 // start wake-up reminder (start-es-<unixnano>, from the event timestamp).
 // Callers re-driving a saved instance must pass the SAVED inbox event: a
-// client retry regenerates the incoming event's timestamp. The create
-// retries until the caller's context dies: the state is already saved, and
-// SDKs generate a fresh instance ID per schedule call, so a bounded give-up
-// would strand a persisted instance that only a same-ID retry could ever
-// re-drive via the pending-start path.
+// client retry regenerates the incoming event's timestamp. Transient create
+// errors retry until the caller's context dies (SDKs regenerate instance
+// IDs, so a bounded give-up strands the saved instance); permanent errors,
+// including a full scheduler quota, surface immediately.
 func (o *orchestrator) assertStartReminder(ctx context.Context, startEvent *backend.HistoryEvent) error {
 	start := startEvent.GetTimestamp().AsTime()
 	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -86,9 +86,11 @@ func (o *orchestrator) createRetentionReminder(ctx context.Context, name string,
 // assertStartReminder creates (or overwrites by name) the deterministic
 // start wake-up reminder (start-es-<unixnano>, from the event timestamp).
 // Callers re-driving a saved instance must pass the SAVED inbox event: a
-// client retry regenerates the incoming event's timestamp. A bounded create
-// is safe here because any create retry re-asserts via the pending-start
-// path.
+// client retry regenerates the incoming event's timestamp. The create
+// retries until the caller's context dies: the state is already saved, and
+// SDKs generate a fresh instance ID per schedule call, so a bounded give-up
+// would strand a persisted instance that only a same-ID retry could ever
+// re-drive via the pending-start path.
 func (o *orchestrator) assertStartReminder(ctx context.Context, startEvent *backend.HistoryEvent) error {
 	start := startEvent.GetTimestamp().AsTime()
 	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
@@ -97,7 +99,7 @@ func (o *orchestrator) assertStartReminder(ctx context.Context, startEvent *back
 
 	workflowName := startEvent.GetExecutionStarted().GetName()
 	reminderName := events.EventReminderName(reminderPrefixStart, startEvent)
-	return o.createWorkflowReminder(ctx, reminderName, nil, start, o.appID, &workflowName)
+	return o.createWorkflowReminderForever(ctx, reminderName, nil, start, o.appID, &workflowName)
 }
 
 // assertNewEventReminder creates (or overwrites by name) the deterministic

--- a/pkg/actors/targets/workflow/orchestrator/reminder.go
+++ b/pkg/actors/targets/workflow/orchestrator/reminder.go
@@ -83,6 +83,23 @@ func (o *orchestrator) createRetentionReminder(ctx context.Context, name string,
 	})
 }
 
+// assertStartReminder creates (or overwrites by name) the deterministic
+// start wake-up reminder (start-es-<unixnano>, from the event timestamp).
+// Callers re-driving a saved instance must pass the SAVED inbox event: a
+// client retry regenerates the incoming event's timestamp. A bounded create
+// is safe here because any create retry re-asserts via the pending-start
+// path.
+func (o *orchestrator) assertStartReminder(ctx context.Context, startEvent *backend.HistoryEvent) error {
+	start := startEvent.GetTimestamp().AsTime()
+	if ts := startEvent.GetExecutionStarted().GetScheduledStartTimestamp(); ts != nil {
+		start = ts.AsTime()
+	}
+
+	workflowName := startEvent.GetExecutionStarted().GetName()
+	reminderName := events.EventReminderName(reminderPrefixStart, startEvent)
+	return o.createWorkflowReminder(ctx, reminderName, nil, start, o.appID, &workflowName)
+}
+
 // assertNewEventReminder creates (or overwrites by name) the deterministic
 // new-event wake-up reminder for the workflow actor that holds e in its inbox.
 func (o *orchestrator) assertNewEventReminder(ctx context.Context, e *backend.HistoryEvent, state *wfenginestate.State) error {

--- a/tests/integration/suite/actors/reminders/scheduler/durable.go
+++ b/tests/integration/suite/actors/reminders/scheduler/durable.go
@@ -101,12 +101,18 @@ func (d *durable) Run(t *testing.T, ctx context.Context) {
 		require.NoError(t, err)
 	}
 
-	exp := []string{
-		"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
-		"10", "11", "12", "13", "14", "15", "16", "17", "18", "19",
-	}
+	// The second repetition (R2, 3s apart) can legitimately fire before the
+	// handover on a slow runner, so only "every reminder fired at least
+	// once" is asserted here; the exact per-reminder count is asserted
+	// after the handover below.
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.ElementsMatch(c, exp, d.triggered.Slice())
+		seen := make(map[string]bool)
+		for _, name := range d.triggered.Slice() {
+			seen[name] = true
+		}
+		for i := range 20 {
+			assert.Truef(c, seen[strconv.Itoa(i)], "reminder %d must have fired", i)
+		}
 	}, time.Second*20, time.Millisecond*10)
 
 	d.daprd1.Cleanup(t)
@@ -115,7 +121,7 @@ func (d *durable) Run(t *testing.T, ctx context.Context) {
 	t.Cleanup(func() { d.daprd2.Cleanup(t) })
 	d.daprd2.WaitUntilRunning(t, ctx)
 
-	exp = []string{
+	exp := []string{
 		"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
 		"0", "1", "2", "3", "4", "5", "6", "7", "8", "9",
 		"10", "11", "12", "13", "14", "15", "16", "17", "18", "19",

--- a/tests/integration/suite/daprd/workflow/chaos/startreassert.go
+++ b/tests/integration/suite/daprd/workflow/chaos/startreassert.go
@@ -1,0 +1,107 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(startreassert))
+}
+
+type startreassert struct {
+	workflow *workflow.Workflow
+	sched    *scheduler.Scheduler
+}
+
+func (s *startreassert) Setup(t *testing.T) []framework.Option {
+	s.sched = scheduler.New(t)
+	s.workflow = workflow.New(t,
+		workflow.WithSchedulerInstance(s.sched),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(s.sched, s.workflow),
+	}
+}
+
+func (s *startreassert) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	const wfID = "startreassert-wf"
+
+	r := s.workflow.Registry()
+	require.NoError(t, r.AddWorkflowN("wf", func(octx *task.WorkflowContext) (any, error) {
+		var in string
+		if err := octx.GetInput(&in); err != nil {
+			return nil, err
+		}
+		return "Hello, " + in + "!", nil
+	}))
+
+	client := s.workflow.BackendClient(t, ctx)
+
+	startTime := time.Now().Add(10 * time.Second)
+	id, err := client.ScheduleNewWorkflow(ctx, "wf",
+		api.WithInstanceID(wfID),
+		api.WithInput("Dapr"),
+		api.WithStartTime(startTime),
+	)
+	require.NoError(t, err)
+
+	ns := s.workflow.Dapr().Namespace()
+	appID := s.workflow.Dapr().AppID()
+	prefix := fmt.Sprintf(
+		"dapr/jobs/actorreminder||%s||dapr.internal.%s.%s.workflow||%s||start-",
+		ns, ns, appID, wfID,
+	)
+
+	keys := s.sched.ListAllKeys(t, ctx, prefix)
+	require.Len(t, keys, 1, "expected exactly one start reminder after create")
+
+	_, err = s.sched.ETCDClient(t, ctx).Delete(ctx, keys[0])
+	require.NoError(t, err)
+	assert.Empty(t, s.sched.ListAllKeys(t, ctx, prefix))
+
+	_, err = client.ScheduleNewWorkflow(ctx, "wf",
+		api.WithInstanceID(wfID),
+		api.WithInput("Dapr"),
+		api.WithStartTime(startTime),
+	)
+	require.NoError(t, err, "create retry must re-assert the missing start reminder")
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, s.sched.ListAllKeys(t, ctx, prefix), 1)
+	}, 10*time.Second, 10*time.Millisecond)
+
+	metadata, err := client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.True(t, api.WorkflowMetadataIsComplete(metadata))
+	assert.Equal(t, `"Hello, Dapr!"`, metadata.GetOutput().GetValue())
+}

--- a/tests/integration/suite/daprd/workflow/disk/diskfull.go
+++ b/tests/integration/suite/daprd/workflow/disk/diskfull.go
@@ -74,17 +74,32 @@ func (d *diskfull) Run(t *testing.T, ctx context.Context) {
 
 	d.wf.WaitUntilRunning(t, ctx)
 
-	padPath := filepath.Join(d.mount, "pad")
-	fwos.FillDisk(t, padPath)
-
 	sched := d.wf.Scheduler()
-	defCtx, cancelDef := context.WithTimeout(ctx, 5*time.Second)
-	_, err := sched.ETCDClient(t, ctx).Defragment(defCtx,
-		"127.0.0.1:"+strconv.Itoa(sched.EtcdClientPort()))
-	cancelDef()
-	require.Error(t, err, "defragment must fail on full disk")
 
-	require.NoError(t, os.Remove(padPath))
+	// etcd reclaims space concurrently (WAL segment pruning, snapshot
+	// cleanup), so a single fill can be undone between the fill and the
+	// defragment call. Re-fill and retry until the defragment observes the
+	// full disk.
+	var pads []string
+	var defragErr error
+	for i := range 5 {
+		pad := filepath.Join(d.mount, "pad-"+strconv.Itoa(i))
+		fwos.FillDisk(t, pad)
+		pads = append(pads, pad)
+
+		defCtx, cancelDef := context.WithTimeout(ctx, 5*time.Second)
+		_, defragErr = sched.ETCDClient(t, ctx).Defragment(defCtx,
+			"127.0.0.1:"+strconv.Itoa(sched.EtcdClientPort()))
+		cancelDef()
+		if defragErr != nil {
+			break
+		}
+	}
+	require.Error(t, defragErr, "defragment must fail on full disk")
+
+	for _, pad := range pads {
+		require.NoError(t, os.Remove(pad))
+	}
 
 	sched.Restart(t, ctx)
 	sched.WaitUntilRunning(t, ctx)

--- a/tests/integration/suite/daprd/workflow/disk/quota.go
+++ b/tests/integration/suite/daprd/workflow/disk/quota.go
@@ -72,21 +72,17 @@ func (q *quota) Run(t *testing.T, ctx context.Context) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "database space exceeded")
 
-	// The create saves state first, then retries the start-reminder create
-	// until the caller's context dies, so under a full quota the schedule call
-	// blocks instead of surfacing the etcd error.
+	// State saves first; the start-reminder create surfaces the quota error.
 	const wfID = "quota-wf"
 	cl := q.wf.BackendClient(t, ctx)
-	blockedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
-	_, err = cl.ScheduleNewWorkflow(blockedCtx, "timerFlow", api.WithInstanceID(wfID))
-	cancel()
+	_, err = cl.ScheduleNewWorkflow(ctx, "timerFlow", api.WithInstanceID(wfID))
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "context deadline exceeded")
+	require.Contains(t, err.Error(), "database space exceeded")
 
 	sched.RecoverQuota(t, ctx, "quota-test/")
 
 	// Retrying the same instance ID lands in the pending-start path, which
-	// re-asserts the reminder from the state saved by the blocked create.
+	// re-asserts the reminder from the state saved by the failed create.
 	id, err := cl.ScheduleNewWorkflow(ctx, "timerFlow", api.WithInstanceID(wfID))
 	require.NoError(t, err)
 	meta, err := cl.WaitForWorkflowCompletion(ctx, id)

--- a/tests/integration/suite/daprd/workflow/disk/quota.go
+++ b/tests/integration/suite/daprd/workflow/disk/quota.go
@@ -35,8 +35,11 @@ func init() {
 }
 
 // quota fills the scheduler's embedded etcd past its storage quota before the
-// workflow starts. Asserts the scheduler RPC and workflow-engine layers
-// surface the error, then reclaims quota and runs the workflow to completion.
+// workflow starts. Asserts the scheduler RPC surfaces the error and the
+// workflow create blocks on the start-reminder create (state is saved first,
+// the reminder create retries until the caller's context dies), then reclaims
+// quota and re-drives the same instance to completion via the pending-start
+// path.
 type quota struct {
 	wf *workflow.Workflow
 }
@@ -69,14 +72,22 @@ func (q *quota) Run(t *testing.T, ctx context.Context) {
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "database space exceeded")
 
+	// The create saves state first, then retries the start-reminder create
+	// until the caller's context dies, so under a full quota the schedule call
+	// blocks instead of surfacing the etcd error.
+	const wfID = "quota-wf"
 	cl := q.wf.BackendClient(t, ctx)
-	_, err = cl.ScheduleNewWorkflow(ctx, "timerFlow")
+	blockedCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	_, err = cl.ScheduleNewWorkflow(blockedCtx, "timerFlow", api.WithInstanceID(wfID))
+	cancel()
 	require.Error(t, err)
-	require.Contains(t, err.Error(), "database space exceeded")
+	require.Contains(t, err.Error(), "context deadline exceeded")
 
 	sched.RecoverQuota(t, ctx, "quota-test/")
 
-	id, err := cl.ScheduleNewWorkflow(ctx, "timerFlow")
+	// Retrying the same instance ID lands in the pending-start path, which
+	// re-asserts the reminder from the state saved by the blocked create.
+	id, err := cl.ScheduleNewWorkflow(ctx, "timerFlow", api.WithInstanceID(wfID))
 	require.NoError(t, err)
 	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)


### PR DESCRIPTION
The create path armed the start reminder before persisting the ExecutionStarted inbox event, under a random name. Under placement rebalance concurrent with scheduler disruption the reminder can fire on another host before the save commits: the empty inbox is acked SUCCESS, the scheduler deletes the one-shot, and once the save lands the workflow is stranded PENDING forever with no driver, no error above debug, and no recovery path; create retries only ever see AlreadyExists.

Save first and derive the reminder name deterministically from the saved event. A create whose reminder create fails now surfaces the error, and any retry lands in the pending-start path which re-asserts the reminder from the saved inbox event. The new chaos/startreassert test pins the recovery by deleting the armed start reminder from the scheduler and requiring a create retry to revive the instance; on the previous ordering that retry fails with AlreadyExists.