### PR TITLE
workflow: recover or terminally fail instances whose committed start was lost

### DIFF
--- a/pkg/actors/targets/workflow/orchestrator/fold.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold.go
@@ -148,7 +148,10 @@ func (o *orchestrator) addWorkflowEventMaybeFold(ctx context.Context, e *backend
 	// child publishes while holding its own turn lock, which can deadlock
 	// against a parent turn dispatching back into the same child.
 	foldable := e.GetTaskCompleted() != nil || e.GetTaskFailed() != nil
-	if state == nil || !foldable || state.HasTamperMarker() || o.rstate.GetStalled() != nil {
+	if state == nil || !foldable || state.HasTamperMarker() || o.rstate.GetStalled() != nil || len(state.History) == 0 {
+		// An empty history is never a healthy running instance: no activity
+		// was legitimately scheduled, and a held fold entry would pin its
+		// sender against a state the unstartable classification must settle.
 		return nil, o.addWorkflowEvent(ctx, e)
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/fold_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/fold_test.go
@@ -31,10 +31,12 @@ import (
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
+	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
 	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/backend/runtimestate"
 )
 
 func eventRaisedEvent(name string) *backend.HistoryEvent {
@@ -64,6 +66,29 @@ func Test_fold_submitHoldsWithoutSave(t *testing.T) {
 	}
 	assert.Len(t, h.orch.foldPending, 1)
 	assert.Empty(t, h.orch.state.Inbox, "the event must not touch the durable inbox")
+}
+
+func Test_fold_emptyHistoryKeepsInboxPath(t *testing.T) {
+	const instanceID = "test-fold-empty-history"
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.primeRunning(t, instanceID, 7)
+	h.orch.state = wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "testapp",
+		Namespace:         "default",
+		WorkflowActorType: "dapr.internal.default.testapp.workflow",
+		ActivityActorType: "dapr.internal.default.testapp.activity",
+	})
+	h.orch.rstate = runtimestate.NewWorkflowRuntimeState(instanceID, nil, nil)
+
+	// A completion against an empty history must not be held: a fold entry
+	// would pin its sender against a state only the unstartable
+	// classification can settle.
+	entry, err := h.orch.addWorkflowEventMaybeFold(t.Context(), taskCompletedEvent(7))
+	require.NoError(t, err)
+	assert.Nil(t, entry)
+	assert.Empty(t, h.orch.foldPending)
+	assert.Len(t, h.orch.state.Inbox, 1, "the completion must take the durable inbox path")
 }
 
 func Test_fold_externalEventKeepsInboxPath(t *testing.T) {

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -1019,7 +1019,6 @@ func (o *orchestrator) failUnstartableWorkflow(ctx context.Context, state *wfeng
 	msg := fmt.Sprintf("workflow instance holds %d inbox event(s) (%s) but an empty history and no pending ExecutionStarted; the committed start event was lost and the instance can never progress",
 		len(state.Inbox), strings.Join(kinds, ", "))
 	log.Errorf("Workflow actor '%s': %s; failing the workflow instance", o.actorID, msg)
-	diag.DefaultWorkflowMonitoring.WorkflowLocalWake(ctx, diag.StatusUnstartableFailed)
 
 	// RuntimeStatus reports PENDING whenever the start event is missing,
 	// so a synthetic ExecutionStarted must precede the FAILED completion
@@ -1052,6 +1051,7 @@ func (o *orchestrator) failUnstartableWorkflow(ctx context.Context, state *wfeng
 	if err := o.signAndSaveState(ctx, state); err != nil {
 		return todo.RunCompletedFalse, err
 	}
+	diag.DefaultWorkflowMonitoring.WorkflowLocalWake(ctx, diag.StatusUnstartableFailed)
 	if err := o.handleRetention(ctx, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED); err != nil {
 		return todo.RunCompletedFalse, wferrors.NewRecoverable(err)
 	}

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -30,6 +30,7 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -100,16 +101,17 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		state.Inbox = append(state.Inbox, &cascadeEvent)
 	}
 
-	if len(state.Inbox) == 0 && len(o.foldPending) == 0 && !runtimestate.IsCompleted(o.rstate) {
+	if len(state.Inbox) == 0 && len(o.foldPending) == 0 {
 		// The in-memory cache may be stale: during a placement cluster failure
 		// daprds will roll over the actor, so a peer host may have written a new
 		// inbox event to the store since our cache was last updated. Drop the
 		// cache and reload from the store before declaring this a no-op. Acking
 		// SUCCESS off a stale empty inbox would tell the scheduler to delete the
 		// job and strand the workflow on the durable event that's actually sitting
-		// in the store. Skip when the cached rstate is terminal: a finished
-		// workflow can't gain new inbox events, and the empty inbox below is just
-		// the retention-recovery path.
+		// in the store. A terminal cached rstate is reloaded too: on
+		// instance-ID reuse the store may already hold the new generation's
+		// pending start, and acking off the stale cache would delete its
+		// reminder.
 		o.invalidateCachedState()
 		state, _, err = o.loadInternalState(ctx)
 		if err != nil {
@@ -176,6 +178,27 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 		log.Warnf("Workflow actor '%s': cached runtime state is terminal but the durable view holds a pending start (history len %d); reloading before running", o.actorID, len(state.History))
 		o.invalidateCachedState()
 		return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("workflow actor '%s': inconsistent cached state (terminal runtime state with pending start), reloaded", o.actorID))
+	}
+
+	// Events but no ExecutionStarted anywhere: the committed start was lost
+	// and the instance would report PENDING forever while its work is
+	// silently dropped. Reclassify against durable truth first (the cache
+	// may trail a peer host's committed start), then fail terminally.
+	if esHistoryEvent == nil && len(state.History) == 0 {
+		o.invalidateCachedState()
+		state, _, err = o.loadInternalState(ctx)
+		if err != nil {
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("failed to reload state to classify unstartable inbox: %w", err))
+		}
+		if state == nil {
+			log.Warnf("No workflow state found for actor '%s' after reload, terminating execution", o.actorID)
+			return todo.RunCompletedTrue, nil
+		}
+		if isUnstartableState(state) {
+			return o.failUnstartableWorkflow(ctx, state)
+		}
+		// Startable after all: retry against the reloaded view.
+		return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("workflow actor '%s': cached state held events with no ExecutionStarted but the durable state is startable; reloaded", o.actorID))
 	}
 
 	// Take any held completions into this turn (WorkflowsFastPath):
@@ -968,4 +991,69 @@ func filterValidInboxEvents(state *wfenginestate.State) []*backend.HistoryEvent 
 	}
 
 	return valid
+}
+
+// isUnstartableState reports whether the durable state can never progress:
+// inbox events with an empty history and no pending ExecutionStarted. The
+// shape only arises when the committed start was lost.
+func isUnstartableState(state *wfenginestate.State) bool {
+	if len(state.Inbox) == 0 || len(state.History) != 0 {
+		return false
+	}
+	for _, e := range state.Inbox {
+		if e.GetExecutionStarted() != nil {
+			return false
+		}
+	}
+	return true
+}
+
+// failUnstartableWorkflow commits a FAILED completion describing the dropped
+// inbox events, drains the inbox, and acks the driving reminder so
+// redelivery stops.
+func (o *orchestrator) failUnstartableWorkflow(ctx context.Context, state *wfenginestate.State) (todo.RunCompleted, error) {
+	kinds := make([]string, 0, len(state.Inbox))
+	for _, e := range state.Inbox {
+		kinds = append(kinds, fmt.Sprintf("%T", e.GetEventType()))
+	}
+	msg := fmt.Sprintf("workflow instance holds %d inbox event(s) (%s) but an empty history and no pending ExecutionStarted; the committed start event was lost and the instance can never progress",
+		len(state.Inbox), strings.Join(kinds, ", "))
+	log.Errorf("Workflow actor '%s': %s; failing the workflow instance", o.actorID, msg)
+	diag.DefaultWorkflowMonitoring.WorkflowLocalWake(ctx, diag.StatusUnstartableFailed)
+
+	// RuntimeStatus reports PENDING whenever the start event is missing,
+	// so a synthetic ExecutionStarted must precede the FAILED completion
+	// for it to surface. The original start is lost; only the ID is known.
+	state.AddToHistory(&backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: o.actorID,
+				},
+			},
+		},
+	})
+	state.AddToHistory(&backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionCompleted{
+			ExecutionCompleted: &protos.ExecutionCompletedEvent{
+				WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED,
+				FailureDetails: &protos.TaskFailureDetails{
+					ErrorType:    staterrors.ErrorTypeUnstartableState,
+					ErrorMessage: msg,
+				},
+			},
+		},
+	})
+	state.ClearInbox()
+	if err := o.signAndSaveState(ctx, state); err != nil {
+		return todo.RunCompletedFalse, err
+	}
+	if err := o.handleRetention(ctx, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED); err != nil {
+		return todo.RunCompletedFalse, wferrors.NewRecoverable(err)
+	}
+	return todo.RunCompletedTrue, nil
 }

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -35,6 +35,7 @@ import (
 	actorstate "github.com/dapr/dapr/pkg/actors/state"
 	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
 	"github.com/dapr/dapr/pkg/config"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
@@ -1103,6 +1104,50 @@ func Test_runWorkflow_emptyInboxStaleTerminalCacheReloads(t *testing.T) {
 // ExecutionCompleted(FAILED) with failure details is committed, the inbox is
 // cleared, the retention reminder is created, and the driving reminder is
 // consumed so redelivery stops.
+// With history signing enabled, the unstartable shape must reach the
+// terminal-FAILED classification, not the inbox-tamper tombstone: with no
+// signed history there is no attestation to violate, and the tombstone
+// appends a completion without a start event, leaving the status PENDING.
+func Test_runWorkflow_unstartableStateFailsTerminallyWithSigning(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = "wf-unstartable-signed"
+
+	inbox := []*backend.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 2},
+		},
+	}}
+
+	h := newWakeHarness(t, instanceID, true)
+	h.fact.fastPath = true
+	h.fact.signer = testAddSigner(t)
+	h.orch.signing = &signing.Signing{
+		Signer:            h.fact.signer,
+		Namespace:         "default",
+		ActorID:           instanceID,
+		ActorType:         h.fact.actorType,
+		ActivityActorType: h.fact.activityActorType,
+		Reminders:         h.fact.reminders,
+	}
+	h.orch.actorState = fakeStoreServingState(t, 0, nil, inbox)
+	h.orch.state = nil
+
+	completed, err := h.orch.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-x"})
+	require.NoError(t, err)
+	assert.Equal(t, todo.RunCompletedTrue, completed)
+
+	require.NotNil(t, h.orch.rstate)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, runtimestate.RuntimeStatus(h.orch.rstate))
+	fd, ferr := runtimestate.FailureDetails(h.orch.rstate)
+	require.NoError(t, ferr, "failure details must surface")
+	assert.Equal(t, staterrors.ErrorTypeUnstartableState, fd.GetErrorType(),
+		"the shape must classify as unstartable, not tampered")
+	assert.Empty(t, h.orch.state.Inbox)
+}
+
 func Test_runWorkflow_unstartableStateFailsTerminally(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -16,6 +16,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"strings"
 	"sync"
 	"testing"
@@ -38,6 +39,7 @@ import (
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
 	wfenginestate "github.com/dapr/dapr/pkg/runtime/wfengine/state"
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
 	"github.com/dapr/dapr/pkg/runtime/wfengine/todo"
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/api/protos"
@@ -395,7 +397,11 @@ func Test_runWorkflow_emptyInboxTerminalCreatesRetentionReminder(t *testing.T) {
 			activityActorType:  "dapr.internal.default.testapp.activity",
 			retentionActorType: "dapr.internal.default.testapp.retentioner",
 			reminders:          reminders,
-			actorTypeBuilder:   common.NewActorTypeBuilder("default"),
+			// The empty-inbox path always reloads from the store before
+			// acting; serve the same terminal state so the recovery path
+			// operates on durable truth.
+			actorState:       fakeStoreServingState(t, 0, history, nil),
+			actorTypeBuilder: common.NewActorTypeBuilder("default"),
 			retentionPolicy: &config.WorkflowStateRetentionPolicy{
 				AnyTerminal: &retentionDur,
 			},
@@ -479,6 +485,7 @@ func Test_runWorkflow_emptyInboxTerminalNoRetentionPolicy(t *testing.T) {
 			activityActorType:  "dapr.internal.default.testapp.activity",
 			retentionActorType: "dapr.internal.default.testapp.retentioner",
 			reminders:          reminders,
+			actorState:         fakeStoreServingState(t, 0, history, nil),
 			actorTypeBuilder:   common.NewActorTypeBuilder("default"),
 			retentionPolicy:    nil,
 		},
@@ -908,4 +915,419 @@ func Test_runWorkflow_canCarryoverSavesBeforeReminderCreate(t *testing.T) {
 		require.NotNil(t, o.state, "the cache must not be invalidated: it is consistent with the store post-save")
 		assert.Len(t, o.state.Inbox, 1, "the carryover must be durable in the inbox")
 	})
+}
+
+// fakeStoreServingState returns an actor-state fake whose Get/GetBulk serve
+// the given history and inbox as the durable workflow state, in the same key
+// layout LoadWorkflowState reads.
+func fakeStoreServingState(t *testing.T, generation uint64, history, inbox []*backend.HistoryEvent) *statefake.Fake {
+	t.Helper()
+
+	meta := &backend.BackendWorkflowStateMetadata{
+		Generation:    generation,
+		InboxLength:   uint64(len(inbox)),
+		HistoryLength: uint64(len(history)),
+	}
+	metaData, err := proto.Marshal(meta)
+	require.NoError(t, err)
+
+	rows := make(map[string][]byte, len(history)+len(inbox))
+	for i, e := range inbox {
+		data, merr := proto.Marshal(e)
+		require.NoError(t, merr)
+		rows[fmt.Sprintf("inbox-%06d", i)] = data
+	}
+	for i, e := range history {
+		data, merr := proto.Marshal(e)
+		require.NoError(t, merr)
+		rows[fmt.Sprintf("history-%06d", i)] = data
+	}
+
+	return statefake.New().
+		WithGetFn(func(_ context.Context, req *actorapi.GetStateRequest, _ bool) (*actorapi.StateResponse, error) {
+			if req.Key == wfenginestate.MetadataKey {
+				return &actorapi.StateResponse{Data: metaData}, nil
+			}
+			return &actorapi.StateResponse{}, nil
+		}).
+		WithGetBulkFn(func(_ context.Context, req *actorapi.GetBulkStateRequest, _ bool) (actorapi.BulkStateResponse, error) {
+			res := make(actorapi.BulkStateResponse, len(req.Keys))
+			for _, k := range req.Keys {
+				res[k] = actorapi.BulkStateEntry{Data: rows[k]}
+			}
+			return res, nil
+		})
+}
+
+// terminalHistory returns a minimal completed-workflow history for tests.
+func terminalHistory(instanceID string) []*backend.HistoryEvent {
+	return []*backend.HistoryEvent{
+		{
+			EventId: -1, Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_WorkflowStarted{
+				WorkflowStarted: &protos.WorkflowStartedEvent{},
+			},
+		},
+		{
+			EventId: -1, Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionStarted{
+				ExecutionStarted: &protos.ExecutionStartedEvent{
+					Name: "TestWorkflow",
+					WorkflowInstance: &protos.WorkflowInstance{
+						InstanceId: instanceID,
+					},
+				},
+			},
+		},
+		{
+			EventId: -1, Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ExecutionCompleted{
+				ExecutionCompleted: &protos.ExecutionCompletedEvent{
+					WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+				},
+			},
+		},
+	}
+}
+
+// Test_runWorkflow_emptyInboxStaleTerminalCacheReloads pins the instance-ID
+// reuse hazard on the empty-inbox path: the cached rstate is terminal from
+// the PREVIOUS generation while the store already holds the NEW generation's
+// pending start (metadata + ExecutionStarted in the inbox, empty history). A
+// terminal cache must not be treated as evidence the stored state is
+// terminal: acking RunCompletedTrue off it would delete the reminder the new
+// generation needs and re-assert retention against the wrong generation. The
+// path must reload from the store and drive the pending start instead.
+func Test_runWorkflow_emptyInboxStaleTerminalCacheReloads(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = "wf-reused-id"
+
+	prevHistory := terminalHistory(instanceID)
+
+	cached := wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	})
+	for _, e := range prevHistory {
+		cached.AddToHistory(e)
+	}
+
+	cachedRstate := runtimestate.NewWorkflowRuntimeState(instanceID, nil, prevHistory)
+	require.True(t, runtimestate.IsCompleted(cachedRstate),
+		"precondition: the cached rstate must be terminal")
+
+	// The store holds the NEW generation: empty history, pending start in the
+	// inbox.
+	newGenInbox := []*backend.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name:  "TestWorkflow",
+				Input: wrapperspb.String(`"gen2"`),
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: instanceID,
+				},
+			},
+		},
+	}}
+
+	var (
+		mu         sync.Mutex
+		gotCreates []string
+	)
+	fakeRems := remindersfake.New().WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotCreates = append(gotCreates, req.Name)
+		return nil
+	})
+
+	schedulerCalled := false
+	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
+		schedulerCalled = true
+		require.Len(t, wi.NewEvents, 1)
+		assert.NotNil(t, wi.NewEvents[0].GetExecutionStarted(),
+			"the turn must run against the reloaded pending start")
+		// Abandon the work item; driving the app is not under test here.
+		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
+		return nil
+	}
+
+	retentionDur := time.Hour
+	fact, err := New(t.Context(), Options{
+		AppID:              "testapp",
+		WorkflowActorType:  "workflow",
+		ActivityActorType:  "activity",
+		RetentionActorType: "retentioner",
+		Scheduler:          scheduler,
+		ActorTypeBuilder:   common.NewActorTypeBuilder("default"),
+		RetentionPolicy: &config.WorkflowStateRetentionPolicy{
+			AnyTerminal: &retentionDur,
+		},
+		Actors: fake.New().
+			WithReminders(func(context.Context) (actorreminders.Interface, error) {
+				return fakeRems, nil
+			}).
+			WithState(func(context.Context) (actorstate.Interface, error) {
+				return fakeStoreServingState(t, 1, nil, newGenInbox), nil
+			}),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+	o.state = cached
+	o.rstate = cachedRstate
+	o.ometa = o.ometaFromState(cachedRstate, nil)
+
+	completed, runErr := o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-recreated"})
+
+	assert.True(t, schedulerCalled,
+		"the reloaded pending start must be driven, not acked away off the stale terminal cache")
+	assert.Equal(t, todo.RunCompletedFalse, completed,
+		"the reminder must not be consumed: the new generation still needs it")
+	require.Error(t, runErr)
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.NotContains(t, gotCreates, "retention",
+		"retention must not be re-asserted off the stale terminal cache")
+}
+
+// Test_runWorkflow_unstartableStateFailsTerminally verifies that a work item
+// against a durable state that can never make progress (inbox events, empty
+// history, no pending ExecutionStarted: the committed start was lost) fails
+// the instance terminally instead of silently dropping the work: an
+// ExecutionCompleted(FAILED) with failure details is committed, the inbox is
+// cleared, the retention reminder is created, and the driving reminder is
+// consumed so redelivery stops.
+func Test_runWorkflow_unstartableStateFailsTerminally(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = "wf-unstartable"
+
+	inbox := []*backend.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 1,
+				Result:          wrapperspb.String(`"orphaned"`),
+			},
+		},
+	}}
+
+	var (
+		mu         sync.Mutex
+		gotCreates []string
+	)
+	fakeRems := remindersfake.New().WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotCreates = append(gotCreates, req.Name)
+		return nil
+	})
+
+	var saves int
+	store := fakeStoreServingState(t, 1, nil, inbox).
+		WithTransactionalStateOperationFn(func(context.Context, bool, *actorapi.TransactionalRequest, bool) error {
+			saves++
+			return nil
+		})
+
+	schedulerCalled := false
+	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
+		schedulerCalled = true
+		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
+		return nil
+	}
+
+	retentionDur := time.Hour
+	fact, err := New(t.Context(), Options{
+		AppID:              "testapp",
+		WorkflowActorType:  "workflow",
+		ActivityActorType:  "activity",
+		RetentionActorType: "retentioner",
+		Scheduler:          scheduler,
+		ActorTypeBuilder:   common.NewActorTypeBuilder("default"),
+		RetentionPolicy: &config.WorkflowStateRetentionPolicy{
+			AnyTerminal: &retentionDur,
+		},
+		Actors: fake.New().
+			WithReminders(func(context.Context) (actorreminders.Interface, error) {
+				return fakeRems, nil
+			}).
+			WithState(func(context.Context) (actorstate.Interface, error) {
+				return store, nil
+			}),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+
+	completed, runErr := o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-orphan"})
+	require.NoError(t, runErr)
+	assert.Equal(t, todo.RunCompletedTrue, completed,
+		"the driving reminder must be consumed so redelivery stops")
+	assert.False(t, schedulerCalled, "an unstartable state must never reach the engine")
+	assert.Equal(t, 1, saves, "the terminal failure must be committed")
+
+	require.NotNil(t, o.state)
+	require.Len(t, o.state.History, 2)
+	assert.NotNil(t, o.state.History[0].GetExecutionStarted(),
+		"a synthetic start must be committed so the FAILED status surfaces (RuntimeStatus reports PENDING without a start event)")
+	ec := o.state.History[1].GetExecutionCompleted()
+	require.NotNil(t, ec)
+	assert.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_FAILED, ec.GetWorkflowStatus())
+	require.NotNil(t, ec.GetFailureDetails())
+	assert.Equal(t, staterrors.ErrorTypeUnstartableState, ec.GetFailureDetails().GetErrorType())
+	assert.Contains(t, ec.GetFailureDetails().GetErrorMessage(), "no pending ExecutionStarted")
+	assert.Empty(t, o.state.Inbox, "the undeliverable inbox must be drained with the failure commit")
+	assert.Equal(t, api.RUNTIME_STATUS_FAILED, runtimestate.RuntimeStatus(o.rstate))
+
+	mu.Lock()
+	defer mu.Unlock()
+	assert.Contains(t, gotCreates, "retention",
+		"a terminally failed instance must get its retention reminder")
+}
+
+// Test_runWorkflow_pendingStartEmptyHistoryRuns pins the healthy-pending
+// shape the unstartable check must never touch: empty history with an
+// ExecutionStarted sitting in the inbox awaiting its start reminder. The turn
+// must reach the engine exactly as today.
+func Test_runWorkflow_pendingStartEmptyHistoryRuns(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = "wf-healthy-pending"
+
+	inbox := []*backend.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name: "TestWorkflow",
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: instanceID,
+				},
+			},
+		},
+	}}
+
+	var saves int
+	store := fakeStoreServingState(t, 1, nil, inbox).
+		WithTransactionalStateOperationFn(func(context.Context, bool, *actorapi.TransactionalRequest, bool) error {
+			saves++
+			return nil
+		})
+
+	schedulerCalled := false
+	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
+		schedulerCalled = true
+		require.Len(t, wi.NewEvents, 1)
+		assert.NotNil(t, wi.NewEvents[0].GetExecutionStarted())
+		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
+		return nil
+	}
+
+	fact, err := New(t.Context(), Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+		Scheduler:         scheduler,
+		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
+		Actors: fake.New().
+			WithState(func(context.Context) (actorstate.Interface, error) {
+				return store, nil
+			}),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+
+	completed, runErr := o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "start"})
+	assert.True(t, schedulerCalled, "a healthy pending start must be driven")
+	assert.Equal(t, todo.RunCompletedFalse, completed)
+	require.Error(t, runErr)
+	assert.Zero(t, saves, "nothing may be committed for the abandoned healthy turn")
+}
+
+// Test_runWorkflow_unstartableCacheButDurableStartableRetries verifies the
+// reclassify-before-acting step: when only the CACHE shows the unstartable
+// shape but the durable state holds a pending start, the instance must not be
+// failed; the turn is retried against the reloaded state.
+func Test_runWorkflow_unstartableCacheButDurableStartableRetries(t *testing.T) {
+	t.Parallel()
+
+	const instanceID = "wf-stale-unstartable-cache"
+
+	cached := wfenginestate.NewState(wfenginestate.Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+	})
+	cached.AddToInbox(&backend.HistoryEvent{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: 1},
+		},
+	})
+
+	durableInbox := []*backend.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name: "TestWorkflow",
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId: instanceID,
+				},
+			},
+		},
+	}}
+
+	var saves int
+	store := fakeStoreServingState(t, 1, nil, durableInbox).
+		WithTransactionalStateOperationFn(func(context.Context, bool, *actorapi.TransactionalRequest, bool) error {
+			saves++
+			return nil
+		})
+
+	schedulerCalled := false
+	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
+		schedulerCalled = true
+		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
+		return nil
+	}
+
+	fact, err := New(t.Context(), Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+		Scheduler:         scheduler,
+		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
+		Actors: fake.New().
+			WithState(func(context.Context) (actorstate.Interface, error) {
+				return store, nil
+			}),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+	o.state = cached
+	o.rstate = runtimestate.NewWorkflowRuntimeState(instanceID, nil, nil)
+	o.ometa = o.ometaFromState(o.rstate, nil)
+
+	completed, runErr := o.runWorkflow(t.Context(), &actorapi.Reminder{Name: "new-event-stale"})
+	assert.Equal(t, todo.RunCompletedFalse, completed)
+	require.Error(t, runErr)
+	assert.True(t, wferrors.IsRecoverable(runErr), "the retry must be recoverable so the reminder refires")
+	assert.False(t, schedulerCalled, "the stale-cache turn must be retried, not run")
+	assert.Zero(t, saves, "the instance must not be failed off a stale cache")
+
+	require.NotNil(t, o.state, "the cache must hold the reloaded durable state")
+	require.Len(t, o.state.Inbox, 1)
+	assert.NotNil(t, o.state.Inbox[0].GetExecutionStarted())
 }

--- a/pkg/actors/targets/workflow/orchestrator/state.go
+++ b/pkg/actors/targets/workflow/orchestrator/state.go
@@ -75,7 +75,12 @@ func (o *orchestrator) loadInternalState(ctx context.Context) (*wfenginestate.St
 	// nothing to validate and the history-index build is pure waste. Skip
 	// when the workflow is already terminal, so we don't re-detect the same
 	// condition on every load.
-	if o.signer != nil && len(state.Inbox) > 0 && !state.IsCompleted() {
+	// The unstartable shape (inbox events, empty history, no pending start)
+	// is exempt: with no signed history there is no attestation for inbox
+	// events to violate, and tombstoning it appends a completion without a
+	// start event, masking the terminal status as PENDING. runWorkflow's
+	// unstartable classification fails it terminally instead.
+	if o.signer != nil && len(state.Inbox) > 0 && !state.IsCompleted() && !isUnstartableState(state) {
 		if filtered := filterValidInboxEvents(state); len(filtered) != len(state.Inbox) {
 			cause := fmt.Errorf("workflow actor '%s': inbox contained %d events that did not match signed history (state store tampering)",
 				o.actorID, len(state.Inbox)-len(filtered))

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -89,6 +89,10 @@ const (
 	// rejected for retry instead of committing a wedged state (the
 	// janitor-livelock stranding source; ~0 in healthy steady state).
 	StatusStaleTurnRejected = "stale_turn_rejected"
+	// An instance whose durable state can never progress (its committed
+	// start was lost) was terminally FAILED instead of silently dropping
+	// its work; ~0 in healthy steady state.
+	StatusUnstartableFailed = "unstartable_failed"
 	// Completions-fold outcomes: a sender-retried completion committed
 	// inside its folding turn (folded), or was nacked back into the
 	// sender's retry chain (turn failure, timeout, deactivation).
@@ -398,7 +402,7 @@ func (w *workflowMetrics) Init(meter view.Meter, appID, namespace string, latenc
 	// lazy registration an absent series is indistinguishable from a rescue
 	// path that never fired. Their views aggregate by Sum, so the zero
 	// record registers the series without changing its value.
-	for _, s := range []string{StatusJanitorRecovered, StatusJanitorFoldRecovered, StatusStaleTurnRejected} {
+	for _, s := range []string{StatusJanitorRecovered, StatusJanitorFoldRecovered, StatusStaleTurnRejected, StatusUnstartableFailed} {
 		stats.RecordWithOptions(context.Background(),
 			stats.WithRecorder(w.meter),
 			stats.WithTags(diagUtils.WithTags(w.localWakeCount.Name(), appIDKey, appID, namespaceKey, namespace, statusKey, s)...),

--- a/pkg/runtime/wfengine/state/errors/errors.go
+++ b/pkg/runtime/wfengine/state/errors/errors.go
@@ -19,6 +19,11 @@ package errors
 // programmatically detect the failure mode.
 const ErrorTypeHistoryTampered = "DAPR_WORKFLOW_HISTORY_TAMPERED"
 
+// ErrorTypeUnstartableState is the FailureDetails.ErrorType set on workflows
+// terminally failed because their committed start event was lost and the
+// instance could never progress; clients can match on it.
+const ErrorTypeUnstartableState = "DAPR_WORKFLOW_UNSTARTABLE_STATE"
+
 // VerificationError is returned by LoadWorkflowState when the persisted
 // workflow state has been tampered with: signature chain verification has
 // failed, signing material is missing, metadata bounds are exceeded, or

--- a/tests/integration/framework/process/workflow/state.go
+++ b/tests/integration/framework/process/workflow/state.go
@@ -31,6 +31,12 @@ func (w *Workflow) WorkflowActorType(index int) string {
 	return "dapr.internal.default." + w.daprds[index].AppID() + ".workflow"
 }
 
+// ActivityActorType returns the activity actor type registered by the daprd
+// at the given index (default namespace).
+func (w *Workflow) ActivityActorType(index int) string {
+	return "dapr.internal.default." + w.daprds[index].AppID() + ".activity"
+}
+
 // WriteWorkflowState writes a fabricated durable workflow state for the given
 // instance straight into the SQLite actor state store: the history and inbox
 // event rows plus the metadata row describing them, in the exact key layout

--- a/tests/integration/framework/process/workflow/state.go
+++ b/tests/integration/framework/process/workflow/state.go
@@ -1,0 +1,68 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package workflow
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/proto"
+
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/backend"
+)
+
+// WorkflowActorType returns the orchestrator actor type registered by the
+// daprd at the given index (default namespace).
+func (w *Workflow) WorkflowActorType(index int) string {
+	return "dapr.internal.default." + w.daprds[index].AppID() + ".workflow"
+}
+
+// WriteWorkflowState writes a fabricated durable workflow state for the given
+// instance straight into the SQLite actor state store: the history and inbox
+// event rows plus the metadata row describing them, in the exact key layout
+// the workflow state loader reads. Existing history and inbox rows for the
+// instance are deleted first so the metadata lengths stay authoritative.
+// daprd in-memory caches are not touched; pair this with a scheduler-driven
+// reminder or a fresh actor activation to make daprd observe the rows.
+func (w *Workflow) WriteWorkflowState(t *testing.T, ctx context.Context, index int, instanceID string, generation uint64, history, inbox []*protos.HistoryEvent) {
+	t.Helper()
+
+	keyPrefix := w.daprds[index].AppID() + "||" + w.WorkflowActorType(index) + "||" + instanceID + "||"
+
+	w.db.DeleteStateKeys(t, ctx, keyPrefix+"history-%")
+	w.db.DeleteStateKeys(t, ctx, keyPrefix+"inbox-%")
+
+	for i, e := range history {
+		raw, err := proto.Marshal(e)
+		require.NoError(t, err)
+		w.db.WriteStateValue(t, ctx, fmt.Sprintf("%shistory-%06d", keyPrefix, i), raw)
+	}
+	for i, e := range inbox {
+		raw, err := proto.Marshal(e)
+		require.NoError(t, err)
+		w.db.WriteStateValue(t, ctx, fmt.Sprintf("%sinbox-%06d", keyPrefix, i), raw)
+	}
+
+	meta := &backend.BackendWorkflowStateMetadata{
+		Generation:    generation,
+		HistoryLength: uint64(len(history)),
+		InboxLength:   uint64(len(inbox)),
+	}
+	raw, err := proto.Marshal(meta)
+	require.NoError(t, err)
+	w.db.WriteStateValue(t, ctx, keyPrefix+"metadata", raw)
+}

--- a/tests/integration/suite/daprd/workflow/reuseid/staleterminalcache.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/staleterminalcache.go
@@ -1,0 +1,116 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reuseid
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(staleterminalcache))
+}
+
+type staleterminalcache struct {
+	workflow *workflow.Workflow
+}
+
+func (s *staleterminalcache) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.New(t, workflow.WithDaprds(2))
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *staleterminalcache) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	var runs atomic.Int64
+	s.workflow.Registry().AddWorkflowN("reused", func(ctx *task.WorkflowContext) (any, error) {
+		runs.Add(1)
+		var in string
+		if err := ctx.GetInput(&in); err != nil {
+			return nil, err
+		}
+		return in, nil
+	})
+
+	client := s.workflow.BackendClient(t, ctx)
+	client2 := s.workflow.BackendClientN(t, ctx, 1)
+
+	const instanceID = "stale-terminal-reuse"
+	id, err := client.ScheduleNewWorkflow(ctx, "reused",
+		api.WithInstanceID(instanceID), api.WithInput("gen1"))
+	require.NoError(t, err)
+
+	meta, err := client.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus())
+	require.Equal(t, int64(1), runs.Load())
+
+	meta, err = client2.FetchWorkflowMetadata(ctx, id,
+		api.WithFetchAppID(s.workflow.Dapr().AppID()))
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus())
+
+	s.workflow.WriteWorkflowState(t, ctx, 0, instanceID, 2, nil, []*protos.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_ExecutionStarted{
+			ExecutionStarted: &protos.ExecutionStartedEvent{
+				Name:  "reused",
+				Input: wrapperspb.String(`"gen2"`),
+				WorkflowInstance: &protos.WorkflowInstance{
+					InstanceId:  instanceID,
+					ExecutionId: wrapperspb.String(uuid.New().String()),
+				},
+			},
+		},
+	}})
+
+	_, err = s.workflow.Scheduler().Client(t, ctx).ScheduleJob(ctx,
+		s.workflow.Scheduler().JobNowActor("new-event-recreated", "default",
+			s.workflow.Dapr().AppID(), s.workflow.WorkflowActorType(0), instanceID))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, int64(2), runs.Load(),
+			"the recreated generation's pending start must be re-driven")
+	}, time.Second*30, time.Millisecond*10)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		meta, ferr := client.FetchWorkflowMetadata(ctx, id)
+		if !assert.NoError(c, ferr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus())
+		assert.Equal(c, `"gen2"`, meta.GetOutput().GetValue(),
+			"the completion must belong to the recreated generation")
+	}, time.Second*30, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/workflow/unstartable/foldpublish.go
+++ b/tests/integration/suite/daprd/workflow/unstartable/foldpublish.go
@@ -1,0 +1,106 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstartable
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/anypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(foldpublish))
+}
+
+type foldpublish struct {
+	workflow *workflow.Workflow
+}
+
+func (u *foldpublish) Setup(t *testing.T) []framework.Option {
+	u.workflow = workflow.New(t,
+		workflow.WithDaprdOptions(0,
+			daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		),
+	)
+	return []framework.Option{
+		framework.WithProcesses(u.workflow),
+	}
+}
+
+func (u *foldpublish) Run(t *testing.T, ctx context.Context) {
+	u.workflow.WaitUntilRunning(t, ctx)
+
+	var activityRuns atomic.Int64
+	require.NoError(t, u.workflow.Registry().AddActivityN("Emit", func(task.ActivityContext) (any, error) {
+		activityRuns.Add(1)
+		return "emitted", nil
+	}))
+	client := u.workflow.BackendClient(t, ctx)
+
+	const instanceID = "lost-start-fold"
+
+	u.workflow.WriteWorkflowState(t, ctx, 0, instanceID, 1, nil, nil)
+
+	invocation, err := anypb.New(&protos.ActivityInvocation{
+		HistoryEvent: &protos.HistoryEvent{
+			EventId:   0,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TaskScheduled{
+				TaskScheduled: &protos.TaskScheduledEvent{Name: "Emit"},
+			},
+		},
+	})
+	require.NoError(t, err)
+	job := u.workflow.Scheduler().JobNowActor("run-activity", "default",
+		u.workflow.Dapr().AppID(), u.workflow.ActivityActorType(0), instanceID+"::0")
+	job.GetJob().Data = invocation
+	_, err = u.workflow.Scheduler().Client(t, ctx).ScheduleJob(ctx, job)
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		fmeta, ferr := client.FetchWorkflowMetadata(ctx, instanceID)
+		if !assert.NoError(c, ferr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_FAILED, fmeta.GetRuntimeStatus())
+	}, time.Second*30, time.Millisecond*10)
+
+	meta, err := client.FetchWorkflowMetadata(ctx, instanceID)
+	require.NoError(t, err)
+	fd := meta.GetFailureDetails()
+	require.NotNil(t, fd)
+	assert.Equal(t, staterrors.ErrorTypeUnstartableState, fd.GetErrorType())
+
+	assert.Equal(t, int64(1), activityRuns.Load())
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Zero(c, u.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
+			"the settled publish must let the activity delete its reminder")
+	}, time.Second*30, time.Millisecond*10)
+}

--- a/tests/integration/suite/daprd/workflow/unstartable/signed.go
+++ b/tests/integration/suite/daprd/workflow/unstartable/signed.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstartable
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(signed))
+}
+
+type signed struct {
+	workflow *workflow.Workflow
+}
+
+func (u *signed) Setup(t *testing.T) []framework.Option {
+	u.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+	return []framework.Option{
+		framework.WithProcesses(u.workflow),
+	}
+}
+
+func (u *signed) Run(t *testing.T, ctx context.Context) {
+	u.workflow.WaitUntilRunning(t, ctx)
+
+	var runs atomic.Int64
+	u.workflow.Registry().AddWorkflowN("unstartable", func(ctx *task.WorkflowContext) (any, error) {
+		runs.Add(1)
+		return nil, nil
+	})
+
+	client := u.workflow.BackendClient(t, ctx)
+
+	const instanceID = "lost-start-signed"
+
+	u.workflow.WriteWorkflowState(t, ctx, 0, instanceID, 1, nil, []*protos.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`"orphaned"`),
+			},
+		},
+	}})
+
+	meta, err := client.FetchWorkflowMetadata(ctx, instanceID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_PENDING, meta.GetRuntimeStatus(),
+		"precondition: the fabricated shape reads as PENDING")
+
+	_, err = u.workflow.Scheduler().ClientMTLS(t, ctx, u.workflow.Dapr().AppID()).ScheduleJob(ctx,
+		u.workflow.Scheduler().JobNowActor("new-event-orphan", "default",
+			u.workflow.Dapr().AppID(), u.workflow.WorkflowActorType(0), instanceID))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		fmeta, ferr := client.FetchWorkflowMetadata(ctx, instanceID)
+		if !assert.NoError(c, ferr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_FAILED, fmeta.GetRuntimeStatus())
+	}, time.Second*30, time.Millisecond*10)
+
+	meta, err = client.FetchWorkflowMetadata(ctx, instanceID)
+	require.NoError(t, err)
+	fd := meta.GetFailureDetails()
+	require.NotNil(t, fd)
+	assert.Equal(t, staterrors.ErrorTypeUnstartableState, fd.GetErrorType())
+	assert.Contains(t, fd.GetErrorMessage(), "no pending ExecutionStarted")
+
+	assert.Zero(t, u.workflow.DB().CountStateKeys(t, ctx, instanceID+"||inbox"))
+	assert.Zero(t, runs.Load())
+}

--- a/tests/integration/suite/daprd/workflow/unstartable/terminal.go
+++ b/tests/integration/suite/daprd/workflow/unstartable/terminal.go
@@ -1,0 +1,102 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package unstartable
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	staterrors "github.com/dapr/dapr/pkg/runtime/wfengine/state/errors"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(terminal))
+}
+
+type terminal struct {
+	workflow *workflow.Workflow
+}
+
+func (u *terminal) Setup(t *testing.T) []framework.Option {
+	u.workflow = workflow.New(t)
+	return []framework.Option{
+		framework.WithProcesses(u.workflow),
+	}
+}
+
+func (u *terminal) Run(t *testing.T, ctx context.Context) {
+	u.workflow.WaitUntilRunning(t, ctx)
+
+	var runs atomic.Int64
+	u.workflow.Registry().AddWorkflowN("unstartable", func(ctx *task.WorkflowContext) (any, error) {
+		runs.Add(1)
+		return nil, nil
+	})
+
+	client := u.workflow.BackendClient(t, ctx)
+
+	const instanceID = "lost-start"
+
+	u.workflow.WriteWorkflowState(t, ctx, 0, instanceID, 1, nil, []*protos.HistoryEvent{{
+		EventId:   -1,
+		Timestamp: timestamppb.Now(),
+		EventType: &protos.HistoryEvent_TaskCompleted{
+			TaskCompleted: &protos.TaskCompletedEvent{
+				TaskScheduledId: 0,
+				Result:          wrapperspb.String(`"orphaned"`),
+			},
+		},
+	}})
+
+	meta, err := client.FetchWorkflowMetadata(ctx, instanceID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_PENDING, meta.GetRuntimeStatus(),
+		"precondition: the fabricated shape reads as PENDING")
+
+	_, err = u.workflow.Scheduler().Client(t, ctx).ScheduleJob(ctx,
+		u.workflow.Scheduler().JobNowActor("new-event-orphan", "default",
+			u.workflow.Dapr().AppID(), u.workflow.WorkflowActorType(0), instanceID))
+	require.NoError(t, err)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		fmeta, ferr := client.FetchWorkflowMetadata(ctx, instanceID)
+		if !assert.NoError(c, ferr) {
+			return
+		}
+		assert.Equal(c, api.RUNTIME_STATUS_FAILED, fmeta.GetRuntimeStatus())
+	}, time.Second*30, time.Millisecond*10)
+
+	meta, err = client.FetchWorkflowMetadata(ctx, instanceID)
+	require.NoError(t, err)
+	fd := meta.GetFailureDetails()
+	require.NotNil(t, fd)
+	assert.Equal(t, staterrors.ErrorTypeUnstartableState, fd.GetErrorType())
+	assert.Contains(t, fd.GetErrorMessage(), "no pending ExecutionStarted")
+
+	assert.Zero(t, u.workflow.DB().CountStateKeys(t, ctx, instanceID+"||inbox"))
+	assert.Zero(t, runs.Load())
+}

--- a/tests/integration/suite/daprd/workflow/workflow.go
+++ b/tests/integration/suite/daprd/workflow/workflow.go
@@ -62,5 +62,6 @@ import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/terminate/batched"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/timer"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/tracing"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/unstartable"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/workflow/versioning"
 )


### PR DESCRIPTION
A field-reported stranding class leaves an instance with committed metadata but no driver: the status API reports PENDING forever, arriving activity results are durably added to the inbox and then silently dropped, and no recovery path ever touches the instance again. Two weaknesses in runWorkflow allow it.

First, the empty-inbox path reloaded durable state before acking SUCCESS only when the cached runtime state was non-terminal. Under instance-ID reuse a peer host can recreate the instance in the store (new generation metadata plus a pending ExecutionStarted, empty history) while this host still caches the previous generation's terminal state; a reminder firing against that stale cache was acked RunCompletedTrue, deleting the wake-up job the new generation needs. Drop the terminal-cache exemption so the path always reloads: genuinely terminal stored state behaves as before (retention re-create, cascade-terminate retry, ack), a stored pending start is driven, and the fastpath residency arm keeps its semantics against the reloaded state.

Second, an instance holding inbox events with an empty history and no ExecutionStarted anywhere can never progress, yet its work items were dropped with a single warning while PENDING kept being reported. Detect the shape before the work item reaches the engine, re-verify it against durable truth (a startable reloaded state retries recoverably), and fail a durably unstartable instance terminally: an ExecutionCompleted(FAILED) with failure details describing the dropped events is committed together with a synthetic ExecutionStarted (RuntimeStatus reports PENDING without a start event, so the FAILED status would otherwise never surface), the inbox is drained in the same transaction, the retention reminder is created, and the driving reminder is acked so redelivery stops. The failure details carry the new well-known error type DAPR_WORKFLOW_UNSTARTABLE_STATE, mirroring
DAPR_WORKFLOW_HISTORY_TAMPERED, and each occurrence is counted under the new pre-registered rescue-evidence status "unstartable_failed". The healthy pending shape is untouched.