### PR TITLE
Fix typos in comments and a test name

### DIFF
--- a/pkg/components/crypto/registry_test.go
+++ b/pkg/components/crypto/registry_test.go
@@ -33,7 +33,7 @@ type mockCryptoProvider struct {
 func TestRegistry(t *testing.T) {
 	testRegistry := crypto.NewRegistry()
 
-	t.Run("cryto provider is registered", func(t *testing.T) {
+	t.Run("crypto provider is registered", func(t *testing.T) {
 		const (
 			cryptoProviderName   = "mockCrypto"
 			cryptoProviderNameV2 = "mockCrypto/v2"

--- a/pkg/components/state/pluggable.go
+++ b/pkg/components/state/pluggable.go
@@ -596,7 +596,7 @@ func concurrencyOf(value string) proto.StateOptions_StateConcurrency {
 	return concurrency
 }
 
-// stateStoreClient wrapps the conventional stateStoreClient and the transactional stateStore client.
+// stateStoreClient wraps the conventional stateStoreClient and the transactional stateStore client.
 type stateStoreClient struct {
 	proto.StateStoreClient
 	proto.TransactionalStateStoreClient

--- a/pkg/config/configuration.go
+++ b/pkg/config/configuration.go
@@ -507,7 +507,7 @@ func (m MetricSpec) GetHTTPIncreasedCardinality(log logger.Logger) bool {
 	return *m.HTTP.IncreasedCardinality
 }
 
-// GetLatencyDistribution returns a *view.Aggregration to be used for latency histograms
+// GetLatencyDistribution returns a *view.Aggregation to be used for latency histograms
 func (m MetricSpec) GetLatencyDistribution(log logger.Logger) *view.Aggregation {
 	defaultLatencyDistribution := []float64{1, 2, 3, 4, 5, 6, 8, 10, 13, 16, 20, 25, 30, 40, 50, 65, 80, 100, 130, 160, 200, 250, 300, 400, 500, 650, 800, 1_000, 2_000, 5_000, 10_000, 20_000, 50_000, 100_000}
 	metricSpecBytes, err := json.Marshal(m)

--- a/pkg/runtime/config.go
+++ b/pkg/runtime/config.go
@@ -288,7 +288,7 @@ func FromConfig(ctx context.Context, cfg *Config) (*DaprRuntime, error) {
 		// using the default meter which relies on
 		// global state which can be problematic in tests
 		// or when decoupling the runtimes lifecycle from
-		// the proccesses lifecycle.
+		// the processes lifecycle.
 		var meter view.Meter
 
 		if cfg.Metrics.Meter == nil {

--- a/pkg/security/security_test.go
+++ b/pkg/security/security_test.go
@@ -146,7 +146,7 @@ func Test_Start(t *testing.T) {
 
 		assert.Eventually(t, func() bool {
 			// We put the write file inside this assert loop since we have to wait
-			// for the fsnotify go rountine to warm up.
+			// for the fsnotify go routine to warm up.
 			assert.NoError(t, os.WriteFile(tdFile, root2, 0o600))
 
 			curr, err := prov.sec.trustAnchors.CurrentTrustAnchors(ctx)


### PR DESCRIPTION
## Description

Typo fixes found with codespell. No functional changes.

- `view.Aggregration` -> `view.Aggregation` in the `GetLatencyDistribution` doc comment — the referenced type is actually `view.Aggregation`, so the comment named a type that does not exist
- `proccesses` -> `processes` (pkg/runtime/config.go)
- `wrapps` -> `wraps` (pkg/components/state/pluggable.go)
- `rountine` -> `routine` (pkg/security/security_test.go)
- `cryto` -> `crypto` in a subtest name (pkg/components/crypto/registry_test.go)

Identifiers were left alone, and `.proto` comments were deliberately not touched since those would require regenerating the pb.go files.

## Issue reference

N/A — drive-by typo cleanup.

## Checklist

- [x] Code compiles correctly
- [x] Created/updated tests (n/a — comment-only)
- [x] Extended the documentation