### PR TITLE
integration: pin the execution ID contract on workflow work items

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -8,6 +8,7 @@ This update contains the following bug fixes:
 - [Workflow wrongly failed as tampered when a stale completion arrived after ContinueAsNew or a transient state store fault](#workflow-wrongly-failed-as-tampered-when-a-stale-completion-arrived-after-continueasnew-or-a-transient-state-store-fault)
 - [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 - [Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled](#workflow-schedule-and-status-waits-failed-with-a-stalled-actor-error-while-a-workflow-was-stalled)
+- [Workflow NewGuid and other SDK-derived deterministic values repeated after ContinueAsNew](#workflow-newguid-and-other-sdk-derived-deterministic-values-repeated-after-continueasnew)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -212,3 +213,27 @@ A status watch stream registering during that hold was rejected with the stalled
 ### Solution
 
 When a status watch finds the actor stalled, the stored workflow status is read directly from the state store: a wait whose condition the instance already reached, such as a schedule waiting for the workflow to start, resolves immediately, and any other wait re-registers with backoff until the stall clears.
+
+## Workflow NewGuid and other SDK-derived deterministic values repeated after ContinueAsNew
+
+### Problem
+
+Deterministic values that workflow SDKs derive per execution repeated after a workflow called ContinueAsNew.
+Most visibly, the .NET SDK's `WorkflowContext.NewGuid()` returned the same sequence of GUIDs again in the new generation, so code that pinned child workflow instance IDs from those GUIDs re-issued IDs already in use and, from 1.18.4, received `already exists` failures instead of fresh children.
+
+### Impact
+
+You were affected if a workflow used ContinueAsNew together with SDK APIs that derive deterministic values, such as `NewGuid()` or auto-generated child workflow instance IDs in the .NET SDK.
+Every generation reproduced the previous generation's values.
+
+### Root Cause
+
+SDKs seed these derivations from the execution ID carried on each workflow work item, falling back to the instance ID when the field is empty.
+The instance ID is unchanged across ContinueAsNew while the SDK's derivation counters restart with the new history, so with an empty execution ID every generation reproduced the same values.
+The sidecar never populated the field: the workflow engine sent every work item with an empty execution ID, even though each generation's `ExecutionStarted` history event carries a freshly minted one.
+
+### Solution
+
+Workflow work items now carry the execution ID of the generation they belong to, taken from the `ExecutionStarted` event, scanning new events before past events so a continued-as-new or recreated run reports its own execution rather than a stale one.
+Each generation's execution ID is minted fresh on ContinueAsNew and instance recreation but is persisted in history, so SDK-derived values become unique per generation while remaining stable across replays within a generation.
+Workflows in flight across the upgrade re-seed from the execution ID on their next turn; values already recorded in their history replay from history as before.

--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -218,7 +218,7 @@ When a status watch finds the actor stalled, the stored workflow status is read 
 
 ### Problem
 
-Deterministic values that workflow SDKs derive per execution repeated after a workflow called ContinueAsNew.
+Deterministic values that workflow SDKs derive per execution were repeated after a workflow called ContinueAsNew.
 Most visibly, the .NET SDK's `WorkflowContext.NewGuid()` returned the same sequence of GUIDs again in the new generation, so code that pinned child workflow instance IDs from those GUIDs re-issued IDs already in use and, from 1.18.4, received `already exists` failures instead of fresh children.
 
 ### Impact

--- a/tests/integration/suite/daprd/workflow/executionid/continueasnew.go
+++ b/tests/integration/suite/daprd/workflow/executionid/continueasnew.go
@@ -1,0 +1,181 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executionid
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/types/known/emptypb"
+	"google.golang.org/protobuf/types/known/timestamppb"
+	"google.golang.org/protobuf/types/known/wrapperspb"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/client"
+)
+
+func init() {
+	suite.Register(new(continueasnew))
+}
+
+type continueasnew struct {
+	workflow *workflow.Workflow
+}
+
+func (c *continueasnew) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *continueasnew) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		instanceID   = "can-executionid"
+		workflowName = "canner"
+	)
+
+	type turn struct {
+		input  string
+		execID string
+	}
+	var lock sync.Mutex
+	turns := make([]turn, 0, 4)
+
+	conn := c.workflow.Dapr().GRPCConn(t, ctx)
+	thub := protos.NewTaskHubSidecarServiceClient(conn)
+
+	_, err := thub.Hello(ctx, new(emptypb.Empty))
+	require.NoError(t, err)
+
+	stream, err := thub.GetWorkItems(ctx, new(protos.GetWorkItemsRequest))
+	require.NoError(t, err)
+
+	go func() {
+		for {
+			wi, rerr := stream.Recv()
+			if rerr != nil {
+				return
+			}
+
+			req, ok := wi.GetRequest().(*protos.WorkItem_WorkflowRequest)
+			if !ok {
+				continue
+			}
+			wr := req.WorkflowRequest
+
+			var input string
+			timerFired := false
+			for _, e := range append(wr.GetPastEvents(), wr.GetNewEvents()...) {
+				if es := e.GetExecutionStarted(); es != nil {
+					input = es.GetInput().GetValue()
+				}
+				if e.GetTimerFired() != nil {
+					timerFired = true
+				}
+			}
+
+			lock.Lock()
+			turns = append(turns, turn{input: input, execID: wr.GetExecutionId().GetValue()})
+			lock.Unlock()
+
+			resp := &protos.WorkflowResponse{
+				InstanceId:      wr.GetInstanceId(),
+				CompletionToken: wi.GetCompletionToken(),
+			}
+			switch {
+			case input == `"gen0"` && !timerFired:
+				resp.Actions = []*protos.WorkflowAction{{
+					Id: 0,
+					WorkflowActionType: &protos.WorkflowAction_CreateTimer{
+						CreateTimer: &protos.CreateTimerAction{
+							FireAt: timestamppb.New(time.Now().Add(500 * time.Millisecond)),
+						},
+					},
+				}}
+			case input == `"gen0"` && timerFired:
+				resp.Actions = []*protos.WorkflowAction{{
+					Id: 1,
+					WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+						CompleteWorkflow: &protos.CompleteWorkflowAction{
+							WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_CONTINUED_AS_NEW,
+							Result:         wrapperspb.String(`"gen1"`),
+						},
+					},
+				}}
+			default:
+				resp.Actions = []*protos.WorkflowAction{{
+					Id: 0,
+					WorkflowActionType: &protos.WorkflowAction_CompleteWorkflow{
+						CompleteWorkflow: &protos.CompleteWorkflowAction{
+							WorkflowStatus: protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED,
+							Result:         wrapperspb.String(`"done"`),
+						},
+					},
+				}}
+			}
+
+			//nolint:errcheck
+			thub.CompleteWorkflowTask(ctx, resp)
+		}
+	}()
+
+	sched := client.NewTaskHubGrpcClient(conn, logger.New(t))
+
+	id, err := sched.ScheduleNewWorkflow(ctx, workflowName,
+		api.WithInstanceID(instanceID),
+		api.WithInput("gen0"),
+	)
+	require.NoError(t, err)
+
+	meta, err := sched.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	require.Equal(t, protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED, meta.GetRuntimeStatus())
+
+	lock.Lock()
+	seen := append([]turn(nil), turns...)
+	lock.Unlock()
+
+	require.GreaterOrEqual(t, len(seen), 3,
+		"expected at least three workflow turns: generation 0 start, generation 0 timer fired, generation 1 start")
+
+	gens := make(map[string]map[string]struct{})
+	for i, tr := range seen {
+		assert.NotEmpty(t, tr.execID,
+			"turn %d (input %s): every workflow work item must carry the execution ID; SDKs seed deterministic values (NewGuid, TaskExecutionId, child instance IDs) from it and fall back to the instance ID when it is empty, which repeats those values across ContinueAsNew generations", i, tr.input)
+		if gens[tr.input] == nil {
+			gens[tr.input] = make(map[string]struct{})
+		}
+		gens[tr.input][tr.execID] = struct{}{}
+	}
+
+	require.Len(t, gens[`"gen0"`], 1,
+		"the execution ID must be stable across turns and replays within generation 0: %v", gens[`"gen0"`])
+	require.Len(t, gens[`"gen1"`], 1,
+		"the execution ID must be stable across turns and replays within generation 1: %v", gens[`"gen1"`])
+	assert.NotEqual(t, gens[`"gen0"`], gens[`"gen1"`],
+		"ContinueAsNew must mint a fresh execution ID so SDK-side deterministic values differ per generation")
+}


### PR DESCRIPTION
Assert that every workflow work item sent to SDK workers carries the execution ID of the generation it belongs to: never empty, stable across turns and replays within a generation, and freshly minted after ContinueAsNew.