### PR TITLE
hotreload: swap compiled workflow access policies before the store lists them

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -9,6 +9,7 @@ This update contains the following bug fixes:
 - [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 - [Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled](#workflow-schedule-and-status-waits-failed-with-a-stalled-actor-error-while-a-workflow-was-stalled)
 - [Workflow NewGuid and other SDK-derived deterministic values repeated after ContinueAsNew](#workflow-newguid-and-other-sdk-derived-deterministic-values-repeated-after-continueasnew)
+- [Hot-reloaded workflow access policy listed in metadata before it was enforced](#hot-reloaded-workflow-access-policy-listed-in-metadata-before-it-was-enforced)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -237,3 +238,24 @@ The sidecar never populated the field: the workflow engine sent every work item 
 Workflow work items now carry the execution ID of the generation they belong to, taken from the `ExecutionStarted` event, scanning new events before past events so a continued-as-new or recreated run reports its own execution rather than a stale one.
 Each generation's execution ID is minted fresh on ContinueAsNew and instance recreation but is persisted in history, so SDK-derived values become unique per generation while remaining stable across replays within a generation.
 Workflows in flight across the upgrade re-seed from the execution ID on their next turn; values already recorded in their history replay from history as before.
+
+## Hot-reloaded workflow access policy listed in metadata before it was enforced
+
+### Problem
+
+When a `WorkflowAccessPolicy` resource was created, updated or deleted at runtime, the sidecar's metadata endpoint listed the new set of policies a small amount of time before the new set was actually enforced.
+A caller that waited for metadata to report a tightened policy and then invoked a workflow operation could still be authorized against the previous, more permissive policy set; the reverse held for a policy that had just been deleted.
+
+### Impact
+
+Operators or automation using the metadata endpoint as the signal that a policy change is live could observe a brief window in which the reported and the enforced policies disagreed.
+Steady-state enforcement was unaffected: the window closed as soon as the new set finished compiling.
+
+### Root Cause
+
+The hot-reload reconciler added the policy to the resource store first and only then compiled the full set and swapped it into the workflow API.
+Compiling the policy expressions takes a small amount of time, and the metadata endpoint lists the resource store rather than the compiled set.
+
+### Solution
+
+The reconciler now compiles the prospective policy set and swaps it into enforcement before it updates the resource store, for both updates and deletes, so a policy listed by the metadata endpoint is always one that is already enforced.

--- a/pkg/runtime/hotreload/reconciler/workflowaccesspolicies.go
+++ b/pkg/runtime/hotreload/reconciler/workflowaccesspolicies.go
@@ -15,6 +15,7 @@ package reconciler
 
 import (
 	"context"
+	"sync"
 
 	"k8s.io/utils/clock"
 
@@ -42,6 +43,7 @@ type workflowAccessPolicies struct {
 	appID      string
 	store      *compstore.ComponentStore
 	recompiler PolicyRecompiler
+	lock       sync.Mutex
 	loader.Loader[wfaclapi.WorkflowAccessPolicy]
 }
 
@@ -83,6 +85,9 @@ func (w *workflowAccessPolicies) update(ctx context.Context, policy wfaclapi.Wor
 		return nil
 	}
 
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
 	all := w.store.ListWorkflowAccessPolicies()
 	replaced := false
 	for i, p := range all {
@@ -100,6 +105,9 @@ func (w *workflowAccessPolicies) update(ctx context.Context, policy wfaclapi.Wor
 }
 
 func (w *workflowAccessPolicies) delete(_ context.Context, policy wfaclapi.WorkflowAccessPolicy) error {
+	w.lock.Lock()
+	defer w.lock.Unlock()
+
 	all := w.store.ListWorkflowAccessPolicies()
 	remaining := make([]wfaclapi.WorkflowAccessPolicy, 0, len(all))
 	for _, p := range all {

--- a/pkg/runtime/hotreload/reconciler/workflowaccesspolicies.go
+++ b/pkg/runtime/hotreload/reconciler/workflowaccesspolicies.go
@@ -61,12 +61,11 @@ func NewWorkflowAccessPolicies(opts WorkflowAccessPolicyOptions) *Reconciler[wfa
 	return r
 }
 
-// recompileAll fetches all policies from the compstore, filters by app scope,
-// compiles them, and atomically swaps them on the gRPC API.
-//
-//nolint:unused
-func (w *workflowAccessPolicies) recompileAll() {
-	all := w.store.ListWorkflowAccessPolicies()
+// recompile filters the given policies by app scope, compiles them and
+// atomically swaps them on the gRPC API. Callers pass the prospective policy
+// set and mutate the compstore only afterwards: metadata lists the compstore,
+// and a policy listed there must already be enforced.
+func (w *workflowAccessPolicies) recompile(all []wfaclapi.WorkflowAccessPolicy) {
 	var scoped []wfaclapi.WorkflowAccessPolicy
 	for _, p := range all {
 		if p.IsAppScoped(w.appID) {
@@ -78,24 +77,37 @@ func (w *workflowAccessPolicies) recompileAll() {
 	log.Infof("Recompiled %d workflow access policy resource(s) (of %d total)", len(scoped), len(all))
 }
 
-// The go linter does not yet understand that these functions are being used by
-// the generic reconciler.
-//
-//nolint:unused
 func (w *workflowAccessPolicies) update(ctx context.Context, policy wfaclapi.WorkflowAccessPolicy) error {
 	if err := validate.WorkflowAccessPolicy(ctx, &policy); err != nil {
 		log.Warnf("WorkflowAccessPolicy %q failed validation, skipping: %s", policy.Name, err)
 		return nil
 	}
 
+	all := w.store.ListWorkflowAccessPolicies()
+	replaced := false
+	for i, p := range all {
+		if p.Name == policy.Name {
+			all[i] = policy
+			replaced = true
+		}
+	}
+	if !replaced {
+		all = append(all, policy)
+	}
+	w.recompile(all)
 	w.store.AddWorkflowAccessPolicy(policy)
-	w.recompileAll()
 	return nil
 }
 
-//nolint:unused
 func (w *workflowAccessPolicies) delete(_ context.Context, policy wfaclapi.WorkflowAccessPolicy) error {
+	all := w.store.ListWorkflowAccessPolicies()
+	remaining := make([]wfaclapi.WorkflowAccessPolicy, 0, len(all))
+	for _, p := range all {
+		if p.Name != policy.Name {
+			remaining = append(remaining, p)
+		}
+	}
+	w.recompile(remaining)
 	w.store.DeleteWorkflowAccessPolicy(policy.Name)
-	w.recompileAll()
 	return nil
 }

--- a/pkg/runtime/hotreload/reconciler/workflowaccesspolicies_test.go
+++ b/pkg/runtime/hotreload/reconciler/workflowaccesspolicies_test.go
@@ -1,0 +1,72 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reconciler
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	workflowacl "github.com/dapr/dapr/pkg/acl/workflow"
+	wfaclapi "github.com/dapr/dapr/pkg/apis/workflowaccesspolicy/v1alpha1"
+	"github.com/dapr/dapr/pkg/runtime/compstore"
+)
+
+// The metadata API lists the compstore, and tests treat a listed policy as
+// enforced: the compiled set must be swapped before the store changes.
+func Test_workflowAccessPolicies_recompileBeforeStore(t *testing.T) {
+	t.Parallel()
+
+	store := compstore.New()
+	names := func() []string {
+		listed := store.ListWorkflowAccessPolicies()
+		out := make([]string, 0, len(listed))
+		for _, p := range listed {
+			out = append(out, p.Name)
+		}
+		return out
+	}
+
+	var listedAtSwap [][]string
+	var callerListed []bool
+	w := &workflowAccessPolicies{
+		appID: "target",
+		store: store,
+		recompiler: func(cp *workflowacl.CompiledPolicies) {
+			listedAtSwap = append(listedAtSwap, names())
+			callerListed = append(callerListed, cp.ListsCaller("caller"))
+		},
+	}
+
+	policy := wfaclapi.WorkflowAccessPolicy{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "WorkflowAccessPolicy"},
+		ObjectMeta: metav1.ObjectMeta{Name: "p1"},
+		Spec: wfaclapi.WorkflowAccessPolicySpec{Rules: []wfaclapi.WorkflowAccessPolicyRule{{
+			Callers:   []wfaclapi.WorkflowCaller{{AppID: "caller"}},
+			Workflows: []wfaclapi.WorkflowRule{{Name: "wf", Operations: []wfaclapi.WorkflowOperation{wfaclapi.WorkflowOperationSchedule}}},
+		}}},
+	}
+
+	require.NoError(t, w.update(t.Context(), policy))
+	assert.Equal(t, []string{"p1"}, names())
+	require.NoError(t, w.delete(t.Context(), policy))
+	assert.Empty(t, names())
+
+	require.Len(t, listedAtSwap, 2)
+	assert.Empty(t, listedAtSwap[0], "the policy must be enforced before the store lists it")
+	assert.Equal(t, []string{"p1"}, listedAtSwap[1], "the store must list the policy until it is no longer enforced")
+	assert.Equal(t, []bool{true, false}, callerListed)
+}

--- a/pkg/runtime/hotreload/reconciler/workflowaccesspolicies_test.go
+++ b/pkg/runtime/hotreload/reconciler/workflowaccesspolicies_test.go
@@ -14,6 +14,8 @@ limitations under the License.
 package reconciler
 
 import (
+	"fmt"
+	"sync"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -51,14 +53,7 @@ func Test_workflowAccessPolicies_recompileBeforeStore(t *testing.T) {
 		},
 	}
 
-	policy := wfaclapi.WorkflowAccessPolicy{
-		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "WorkflowAccessPolicy"},
-		ObjectMeta: metav1.ObjectMeta{Name: "p1"},
-		Spec: wfaclapi.WorkflowAccessPolicySpec{Rules: []wfaclapi.WorkflowAccessPolicyRule{{
-			Callers:   []wfaclapi.WorkflowCaller{{AppID: "caller"}},
-			Workflows: []wfaclapi.WorkflowRule{{Name: "wf", Operations: []wfaclapi.WorkflowOperation{wfaclapi.WorkflowOperationSchedule}}},
-		}}},
-	}
+	policy := testPolicy("p1", "caller")
 
 	require.NoError(t, w.update(t.Context(), policy))
 	assert.Equal(t, []string{"p1"}, names())
@@ -69,4 +64,48 @@ func Test_workflowAccessPolicies_recompileBeforeStore(t *testing.T) {
 	assert.Empty(t, listedAtSwap[0], "the policy must be enforced before the store lists it")
 	assert.Equal(t, []string{"p1"}, listedAtSwap[1], "the store must list the policy until it is no longer enforced")
 	assert.Equal(t, []bool{true, false}, callerListed)
+}
+
+// Reconciles of a batch run concurrently; every policy of the batch must be
+// in the enforced set once the batch is done.
+func Test_workflowAccessPolicies_concurrentUpdates(t *testing.T) {
+	t.Parallel()
+
+	store := compstore.New()
+	var mu sync.Mutex
+	var last *workflowacl.CompiledPolicies
+	w := &workflowAccessPolicies{
+		appID: "target",
+		store: store,
+		recompiler: func(cp *workflowacl.CompiledPolicies) {
+			mu.Lock()
+			defer mu.Unlock()
+			last = cp
+		},
+	}
+
+	const n = 8
+	var wg sync.WaitGroup
+	for i := range n {
+		wg.Go(func() {
+			assert.NoError(t, w.update(t.Context(), testPolicy(fmt.Sprintf("p%d", i), fmt.Sprintf("caller%d", i))))
+		})
+	}
+	wg.Wait()
+
+	require.Len(t, store.ListWorkflowAccessPolicies(), n)
+	for i := range n {
+		assert.Truef(t, last.ListsCaller(fmt.Sprintf("caller%d", i)), "caller%d missing from the enforced set", i)
+	}
+}
+
+func testPolicy(name, caller string) wfaclapi.WorkflowAccessPolicy {
+	return wfaclapi.WorkflowAccessPolicy{
+		TypeMeta:   metav1.TypeMeta{APIVersion: "dapr.io/v1alpha1", Kind: "WorkflowAccessPolicy"},
+		ObjectMeta: metav1.ObjectMeta{Name: name},
+		Spec: wfaclapi.WorkflowAccessPolicySpec{Rules: []wfaclapi.WorkflowAccessPolicyRule{{
+			Callers:   []wfaclapi.WorkflowCaller{{AppID: caller}},
+			Workflows: []wfaclapi.WorkflowRule{{Name: "wf", Operations: []wfaclapi.WorkflowOperation{wfaclapi.WorkflowOperationSchedule}}},
+		}}},
+	}
 }

--- a/tests/integration/suite/daprd/workflow/accesspolicy/reloadenforced.go
+++ b/tests/integration/suite/daprd/workflow/accesspolicy/reloadenforced.go
@@ -1,0 +1,176 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package accesspolicy
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	runtimev1pb "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(reloadenforced))
+}
+
+type reloadenforced struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	caller *daprd.Daprd
+	target *daprd.Daprd
+	resDir string
+}
+
+const (
+	reloadTargetAppID = "reload-target"
+	reloadCallerAppID = "reload-caller"
+)
+
+func (r *reloadenforced) Setup(t *testing.T) []framework.Option {
+	r.sentry = sentry.New(t)
+	r.place = placement.New(t, placement.WithSentry(t, r.sentry))
+	r.sched = scheduler.New(t, scheduler.WithSentry(r.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+	r.db = sqlite.New(t, sqlite.WithActorStateStore(true), sqlite.WithCreateStateTables())
+
+	configFile := filepath.Join(t.TempDir(), "config.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: reloadconfig
+spec:
+  features:
+  - name: HotReload
+    enabled: true`), 0o600))
+
+	r.resDir = t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(r.resDir, "reload-init.yaml"), r.policy("reload-init", "schedule"), 0o600))
+
+	r.caller = daprd.New(t,
+		daprd.WithAppID(reloadCallerAppID),
+		daprd.WithNamespace("default"),
+		daprd.WithConfigs(configFile),
+		daprd.WithResourceFiles(r.db.GetComponent(t)),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithSchedulerAddresses(r.sched.Address()),
+		daprd.WithSentry(t, r.sentry),
+	)
+	r.target = daprd.New(t,
+		daprd.WithAppID(reloadTargetAppID),
+		daprd.WithNamespace("default"),
+		daprd.WithConfigs(configFile),
+		daprd.WithResourcesDir(r.resDir),
+		daprd.WithResourceFiles(r.db.GetComponent(t)),
+		daprd.WithPlacementAddresses(r.place.Address()),
+		daprd.WithSchedulerAddresses(r.sched.Address()),
+		daprd.WithSentry(t, r.sentry),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(r.sentry, r.place, r.sched, r.db, r.caller, r.target),
+	}
+}
+
+func (r *reloadenforced) policy(name, op string) []byte {
+	return []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: WorkflowAccessPolicy
+metadata:
+  name: ` + name + `
+scopes:
+- ` + reloadTargetAppID + `
+spec:
+  rules:
+  - callers:
+    - appID: ` + reloadCallerAppID + `
+    workflows:
+    - name: "ReloadWF"
+      operations: [` + op + `]
+`)
+}
+
+func (r *reloadenforced) Run(t *testing.T, ctx context.Context) {
+	r.place.WaitUntilRunning(t, ctx)
+	r.sched.WaitUntilRunning(t, ctx)
+	r.caller.WaitUntilRunning(t, ctx)
+	r.target.WaitUntilRunning(t, ctx)
+
+	reg := task.NewTaskRegistry()
+	require.NoError(t, reg.AddWorkflowN("ReloadWF", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.WaitForSingleEvent("done", time.Hour).Await(nil)
+	}))
+	targetClient := client.NewTaskHubGrpcClient(r.target.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, targetClient.StartWorkItemListener(ctx, reg))
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, len(r.target.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 1)
+	}, time.Second*20, time.Millisecond*10)
+
+	callerActorClient := runtimev1pb.NewDaprClient(r.caller.GRPCConn(t, ctx))
+	targetActorType := "dapr.internal.default." + reloadTargetAppID + ".workflow"
+
+	for i := range 30 {
+		allow := i%2 == 1
+		op := "terminate"
+		if allow {
+			op = "schedule"
+		}
+		name := fmt.Sprintf("reload-%d", i)
+
+		entries, err := os.ReadDir(r.resDir)
+		require.NoError(t, err)
+		for _, e := range entries {
+			if filepath.Ext(e.Name()) == ".yaml" {
+				require.NoError(t, os.Remove(filepath.Join(r.resDir, e.Name())))
+			}
+		}
+		require.NoError(t, os.WriteFile(filepath.Join(r.resDir, name+".yaml"), r.policy(name, op), 0o600))
+		require.Eventually(t, func() bool {
+			policies := r.target.GetMetadata(t, ctx).WorkflowAccessPolicies
+			return len(policies) == 1 && policies[0].GetName() == name
+		}, time.Second*20, time.Microsecond)
+
+		id := fmt.Sprintf("reload-wf-%d", i)
+		_, err = callerActorClient.InvokeActor(ctx, &runtimev1pb.InvokeActorRequest{
+			ActorType: targetActorType,
+			ActorId:   id,
+			Method:    "CreateWorkflowInstance",
+			Data:      mustMarshalCreate(t, "ReloadWF", id),
+		})
+		if allow {
+			require.NoError(t, err, "round %d: policy %s allows schedule", i, name)
+		} else {
+			require.Error(t, err, "round %d: policy %s listed by metadata must already deny schedule", i, name)
+			assert.Contains(t, err.Error(), "access denied by workflow access policy")
+		}
+	}
+}


### PR DESCRIPTION
The reconciler added a policy to the compstore and only then compiled and swapped the enforced set. The metadata API lists the compstore, so a caller that waited for metadata to report a tightened policy could still be authorized against the previous set while the swap waited on the compstore lock: accesspolicy/peroperation observed a schedule allowed after metadata listed the deny policy and before its "Recompiled 1" landed. Compile the prospective set and swap it first, then mutate the store, so a listed policy is always an enforced one; the same order applies to deletes.