### PR TITLE
workflow: read instance metadata through the hosting actor

### DIFF
--- a/pkg/runtime/wfengine/backends/actors/actors.go
+++ b/pkg/runtime/wfengine/backends/actors/actors.go
@@ -495,12 +495,25 @@ func (abe *Actors) CreateWorkflowInstance(ctx context.Context, req *backend.Crea
 	return nil
 }
 
-// GetWorkflowMetadata implements backend.Backend
+// GetWorkflowMetadata implements backend.Backend. The read goes through the
+// hosting workflow actor so it serialises behind an in-flight turn: a child
+// dispatches its completion to its parent before committing its own terminal
+// state, so a direct store read could report a child as PENDING after its
+// parent completed. A stalled actor parks holding its turn lock while its
+// state is quiescent; only then is the store read directly.
 func (abe *Actors) GetWorkflowMetadata(ctx context.Context, id api.InstanceID, router *protos.TaskRouter) (*backend.WorkflowMetadata, error) {
-	if target := router.GetTargetAppID(); target != "" && target != abe.appID {
-		return abe.getWorkflowMetadataRemote(ctx, id, target)
+	target := router.GetTargetAppID()
+	if target == "" {
+		target = abe.appID
 	}
+	meta, err := abe.getWorkflowMetadataFromActor(ctx, id, target)
+	if err == nil || !targeterrors.IsStalled(err) {
+		return meta, err
+	}
+	return abe.getWorkflowMetadataFromStore(ctx, id)
+}
 
+func (abe *Actors) getWorkflowMetadataFromStore(ctx context.Context, id api.InstanceID) (*backend.WorkflowMetadata, error) {
 	wstate, err := abe.loadInternalState(ctx, id)
 	if err != nil {
 		return nil, err
@@ -539,12 +552,12 @@ func (abe *Actors) GetWorkflowMetadata(ctx context.Context, id api.InstanceID, r
 	}, nil
 }
 
-// getWorkflowMetadataRemote fetches metadata for an instance owned by another
-// app via a one-shot WaitForRuntimeStatus stream on its workflow actor. The
-// MetadataFetchOnly flag makes the target reply immediately (or with
-// not-found) instead of parking the stream; an older target daprd ignores the
-// flag and this degrades to waiting for the next status change.
-func (abe *Actors) getWorkflowMetadataRemote(ctx context.Context, id api.InstanceID, targetAppID string) (*backend.WorkflowMetadata, error) {
+// getWorkflowMetadataFromActor fetches metadata via a one-shot
+// WaitForRuntimeStatus stream on the instance's workflow actor, local or in
+// another app. The MetadataFetchOnly flag makes the target reply immediately
+// (or with not-found) instead of parking the stream; an older target daprd
+// ignores the flag and this degrades to waiting for the next status change.
+func (abe *Actors) getWorkflowMetadataFromActor(ctx context.Context, id api.InstanceID, targetAppID string) (*backend.WorkflowMetadata, error) {
 	actorType, err := abe.targetWorkflowActorType(targetAppID)
 	if err != nil {
 		return nil, err

--- a/tests/integration/suite/daprd/workflow/chaos/childmetadata.go
+++ b/tests/integration/suite/daprd/workflow/chaos/childmetadata.go
@@ -1,0 +1,147 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package chaos
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
+	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/framework/socket"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/backend"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childmetadata))
+}
+
+// childmetadata verifies a child's metadata is never served from a state older
+// than the completion its parent already observed. A child dispatches its
+// completion to the parent before committing its own terminal state; the hold
+// below parks that commit, so a read that bypassed the child's actor would
+// report the pre-turn shape (PENDING, no name).
+type childmetadata struct {
+	workflow *workflow.Workflow
+	ss       *statestore.StateStore
+	store    *fault.Store
+}
+
+func (c *childmetadata) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	c.store = fault.New(t)
+	sock := socket.New(t)
+	c.ss = statestore.New(t,
+		statestore.WithSocket(sock),
+		statestore.WithStateStore(c.store),
+	)
+
+	c.workflow = workflow.New(t,
+		workflow.WithNoDB(),
+		workflow.WithDaprdOptions(0,
+			daprd.WithSocket(t, sock),
+			daprd.WithResourceFiles(fmt.Sprintf(`
+apiVersion: dapr.io/v1alpha1
+kind: Component
+metadata:
+  name: mystore
+spec:
+  type: state.%s
+  version: v1
+  metadata:
+  - name: actorStateStore
+    value: "true"
+`, c.ss.SocketName())),
+		),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(c.ss, c.workflow),
+	}
+}
+
+func (c *childmetadata) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "cm-parent"
+	const childID = "cm-child"
+
+	reg := c.workflow.Registry()
+	require.NoError(t, reg.AddWorkflowN("quick", func(*task.WorkflowContext) (any, error) {
+		return nil, nil
+	}))
+	require.NoError(t, reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallChildWorkflow("quick", task.WithChildWorkflowInstanceID(childID)).Await(nil)
+	}))
+
+	// The child's terminal commit is the only child Multi deleting its inbox.
+	arrived, release, done := c.store.ArmMultiDeleteHold(childID + "||inbox-")
+	t.Cleanup(release)
+
+	client := c.workflow.BackendClient(t, ctx)
+	_, err := client.ScheduleNewWorkflow(ctx, "parent", api.WithInstanceID(parentID))
+	require.NoError(t, err)
+
+	select {
+	case <-arrived:
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "the child's terminal commit never reached the store")
+	}
+
+	meta, err := client.WaitForWorkflowCompletion(ctx, parentID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus())
+
+	type fetched struct {
+		meta *backend.WorkflowMetadata
+		err  error
+	}
+	fetchCh := make(chan fetched, 1)
+	go func() {
+		m, ferr := client.FetchWorkflowMetadata(ctx, childID)
+		fetchCh <- fetched{m, ferr}
+	}()
+
+	select {
+	case f := <-fetchCh:
+		require.Failf(t, "child metadata served before its terminal commit",
+			"status %s name %q err %v", f.meta.GetRuntimeStatus(), f.meta.GetName(), f.err)
+	case <-time.After(time.Second):
+	}
+
+	release()
+	<-done
+
+	select {
+	case f := <-fetchCh:
+		require.NoError(t, f.err)
+		assert.Equal(t, api.RUNTIME_STATUS_COMPLETED, f.meta.GetRuntimeStatus())
+		assert.Equal(t, "quick", f.meta.GetName())
+	case <-time.After(time.Second * 20):
+		require.Fail(t, "child metadata read did not return after the commit")
+	}
+}


### PR DESCRIPTION
A child dispatches its completion to its parent before committing its own terminal state, and GetWorkflowMetadata read the local app's state straight from the store with no actor lock. A client that observed the parent COMPLETED and then fetched the child could read the child's pre-turn shape while its terminal commit was still queued behind the parent's, and the store read path derives the name from history only, so the child reported PENDING with no name.

Route local reads through the workflow actor's fetch-only status stream, as cross-app reads already are, so the read serialises behind an in-flight turn and observes the committed state. A stalled actor parks holding its turn lock while its state is quiescent, so only that case falls back to the direct store read, mirroring the status watch. Cold reads now activate the actor, like remote reads do today.