### PR TITLE
ci: open the post-release tasks with the Copilot agent

### DIFF
--- a/.github/scripts/post-release/open-tasks.sh
+++ b/.github/scripts/post-release/open-tasks.sh
@@ -11,20 +11,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-# Open the post-release-day tasks for a Dapr release.
+# Start the post-release-day tasks for a Dapr release.
 #
-# The tasks live in tasks.json. For each task this script opens one issue in
-# the target repository and assigns the Copilot coding agent where the
-# repository supports it.
+# For each task in tasks.json this script starts a Copilot cloud agent task in
+# the target repository. The agent makes the change and opens the pull request.
 #
-# The script is safe to run again. It searches for an open issue with the same
-# title before it creates one.
+# The agent tasks API needs a user-to-server token, and the account behind that
+# token needs a Copilot seat. When the call fails, the script opens a normal
+# issue instead, so the task is never lost.
 #
 # Usage: open-tasks.sh <version>
 #   version   the released Dapr version, without a leading v, for example 1.18.4
 #
 # Environment:
-#   GITHUB_TOKEN   a token that can open issues in every target repository
+#   GITHUB_TOKEN   a user-to-server token that can reach every target repository
 #   DRY_RUN        set to true to print the plan and change nothing
 
 set -euo pipefail
@@ -36,30 +36,32 @@ DRY_RUN="${DRY_RUN:-false}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 TASKS="${SCRIPT_DIR}/tasks.json"
 
-# The Copilot coding agent is a bot. It can only be assigned through GraphQL,
-# and only in repositories where the organisation enabled it.
-copilot_bot_id() {
-    local owner="$1" name="$2"
-    gh api graphql -f query='
-        query($owner:String!,$name:String!){
-          repository(owner:$owner,name:$name){
-            suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){
-              nodes{ login ... on Bot { id } }
-            }
-          }
-        }' -F owner="$owner" -F name="$name" \
-        --jq '.data.repository.suggestedActors.nodes[]
-              | select(.login=="copilot-swe-agent") | .id' 2>/dev/null || true
+API_VERSION_HEADER="X-GitHub-Api-Version: 2022-11-28"
+
+# True when the repository already has an agent task or an open pull request
+# for this version. Keeps a re-run from starting the work twice.
+already_started() {
+    local repo="$1" version="$2"
+
+    if gh api "/agents/repos/${repo}/tasks" -H "$API_VERSION_HEADER" \
+        --jq ".tasks[]? | select(.state != \"failed\" and .state != \"cancelled\")
+              | select(.name | test(\"${version}\"; \"x\")) | .id" 2>/dev/null | grep -q .; then
+        return 0
+    fi
+
+    if gh pr list --repo "$repo" --state open --search "$version in:title" \
+        --json number --jq 'length' 2>/dev/null | grep -qv '^0$'; then
+        return 0
+    fi
+
+    return 1
 }
 
-assign_copilot() {
-    local repo="$1" issue_id="$2" bot_id="$3"
-    gh api graphql -f query='
-        mutation($assignable:ID!,$actor:ID!){
-          replaceActorsForAssignable(input:{assignableId:$assignable,actorIds:[$actor]}){
-            assignable { ... on Issue { number } }
-          }
-        }' -F assignable="$issue_id" -F actor="$bot_id" >/dev/null
+start_agent_task() {
+    local repo="$1" base="$2" prompt="$3"
+    jq -n --arg p "$prompt" --arg b "$base" \
+        '{prompt:$p, base_ref:$b, create_pull_request:true}' \
+    | gh api -X POST "/agents/repos/${repo}/tasks" -H "$API_VERSION_HEADER" --input - 2>&1
 }
 
 failed=0
@@ -67,56 +69,43 @@ total=$(jq 'length' "$TASKS")
 
 for i in $(seq 0 $((total - 1))); do
     repo=$(jq -r ".[$i].repo" "$TASKS")
-    want_copilot=$(jq -r ".[$i].assign_copilot" "$TASKS")
+    base=$(jq -r ".[$i].base" "$TASKS")
     title=$(jq -r ".[$i].title" "$TASKS" | sed "s/VERSION/${VERSION}/g")
     body=$(jq -r ".[$i].body" "$TASKS" | sed "s/VERSION/${VERSION}/g")
-    owner="${repo%%/*}"
-    name="${repo##*/}"
+    prompt="${title}"$'\n\n'"${body}"
 
     echo "::group::${repo}"
 
-    # Do not open a second issue when one already exists for this version.
-    existing=$(gh issue list --repo "$repo" --state open --search "\"$title\" in:title" \
-        --json number,title --jq "[.[] | select(.title==\"$title\") | .number] | first // empty" 2>/dev/null || true)
-    if [ -n "$existing" ]; then
-        echo "issue already open: ${repo}#${existing}"
+    if already_started "$repo" "$VERSION"; then
+        echo "a task or pull request for ${VERSION} already exists, skipping"
         echo "::endgroup::"
         continue
     fi
 
     if [ "$DRY_RUN" = "true" ]; then
-        echo "would open: ${title}"
-        echo "would assign copilot: ${want_copilot}"
+        echo "would start a Copilot agent task on ${repo} (base ${base})"
+        echo "prompt starts: ${title}"
         echo "::endgroup::"
         continue
     fi
 
-    if ! url=$(gh issue create --repo "$repo" --title "$title" --body "$body" 2>&1); then
-        echo "::error::could not open an issue in ${repo}: ${url}"
-        failed=1
-        echo "::endgroup::"
-        continue
-    fi
-    echo "opened ${url}"
-
-    if [ "$want_copilot" != "true" ]; then
+    if out=$(start_agent_task "$repo" "$base" "$prompt"); then
+        url=$(echo "$out" | jq -r '.html_url // empty' 2>/dev/null || true)
+        echo "started a Copilot agent task${url:+: $url}"
         echo "::endgroup::"
         continue
     fi
 
-    bot_id=$(copilot_bot_id "$owner" "$name")
-    if [ -z "$bot_id" ]; then
-        echo "::warning::the Copilot coding agent is not available in ${repo}, the issue stays unassigned"
-        echo "::endgroup::"
-        continue
-    fi
+    # The agent could not be started. Common causes are a repository without
+    # the Copilot coding agent, or a token that is not user-to-server.
+    echo "::warning::could not start a Copilot agent task on ${repo}, opening an issue instead"
+    echo "$out" | head -3
 
-    number="${url##*/}"
-    issue_id=$(gh api "repos/${repo}/issues/${number}" --jq '.node_id')
-    if assign_copilot "$repo" "$issue_id" "$bot_id"; then
-        echo "assigned the Copilot coding agent"
+    if issue=$(gh issue create --repo "$repo" --title "$title" --body "$body" 2>&1); then
+        echo "opened ${issue}"
     else
-        echo "::warning::could not assign the Copilot coding agent in ${repo}"
+        echo "::error::could not open an issue in ${repo} either: ${issue}"
+        failed=1
     fi
     echo "::endgroup::"
 done

--- a/.github/scripts/post-release/open-tasks.sh
+++ b/.github/scripts/post-release/open-tasks.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Open the post-release-day tasks for a Dapr release.
+#
+# The tasks live in tasks.json. For each task this script opens one issue in
+# the target repository and assigns the Copilot coding agent where the
+# repository supports it.
+#
+# The script is safe to run again. It searches for an open issue with the same
+# title before it creates one.
+#
+# Usage: open-tasks.sh <version>
+#   version   the released Dapr version, without a leading v, for example 1.18.4
+#
+# Environment:
+#   GITHUB_TOKEN   a token that can open issues in every target repository
+#   DRY_RUN        set to true to print the plan and change nothing
+
+set -euo pipefail
+
+VERSION="${1:?version is required, for example 1.18.4}"
+VERSION="${VERSION#v}"
+DRY_RUN="${DRY_RUN:-false}"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TASKS="${SCRIPT_DIR}/tasks.json"
+
+# The Copilot coding agent is a bot. It can only be assigned through GraphQL,
+# and only in repositories where the organisation enabled it.
+copilot_bot_id() {
+    local owner="$1" name="$2"
+    gh api graphql -f query='
+        query($owner:String!,$name:String!){
+          repository(owner:$owner,name:$name){
+            suggestedActors(capabilities:[CAN_BE_ASSIGNED],first:100){
+              nodes{ login ... on Bot { id } }
+            }
+          }
+        }' -F owner="$owner" -F name="$name" \
+        --jq '.data.repository.suggestedActors.nodes[]
+              | select(.login=="copilot-swe-agent") | .id' 2>/dev/null || true
+}
+
+assign_copilot() {
+    local repo="$1" issue_id="$2" bot_id="$3"
+    gh api graphql -f query='
+        mutation($assignable:ID!,$actor:ID!){
+          replaceActorsForAssignable(input:{assignableId:$assignable,actorIds:[$actor]}){
+            assignable { ... on Issue { number } }
+          }
+        }' -F assignable="$issue_id" -F actor="$bot_id" >/dev/null
+}
+
+failed=0
+total=$(jq 'length' "$TASKS")
+
+for i in $(seq 0 $((total - 1))); do
+    repo=$(jq -r ".[$i].repo" "$TASKS")
+    want_copilot=$(jq -r ".[$i].assign_copilot" "$TASKS")
+    title=$(jq -r ".[$i].title" "$TASKS" | sed "s/VERSION/${VERSION}/g")
+    body=$(jq -r ".[$i].body" "$TASKS" | sed "s/VERSION/${VERSION}/g")
+    owner="${repo%%/*}"
+    name="${repo##*/}"
+
+    echo "::group::${repo}"
+
+    # Do not open a second issue when one already exists for this version.
+    existing=$(gh issue list --repo "$repo" --state open --search "\"$title\" in:title" \
+        --json number,title --jq "[.[] | select(.title==\"$title\") | .number] | first // empty" 2>/dev/null || true)
+    if [ -n "$existing" ]; then
+        echo "issue already open: ${repo}#${existing}"
+        echo "::endgroup::"
+        continue
+    fi
+
+    if [ "$DRY_RUN" = "true" ]; then
+        echo "would open: ${title}"
+        echo "would assign copilot: ${want_copilot}"
+        echo "::endgroup::"
+        continue
+    fi
+
+    if ! url=$(gh issue create --repo "$repo" --title "$title" --body "$body" 2>&1); then
+        echo "::error::could not open an issue in ${repo}: ${url}"
+        failed=1
+        echo "::endgroup::"
+        continue
+    fi
+    echo "opened ${url}"
+
+    if [ "$want_copilot" != "true" ]; then
+        echo "::endgroup::"
+        continue
+    fi
+
+    bot_id=$(copilot_bot_id "$owner" "$name")
+    if [ -z "$bot_id" ]; then
+        echo "::warning::the Copilot coding agent is not available in ${repo}, the issue stays unassigned"
+        echo "::endgroup::"
+        continue
+    fi
+
+    number="${url##*/}"
+    issue_id=$(gh api "repos/${repo}/issues/${number}" --jq '.node_id')
+    if assign_copilot "$repo" "$issue_id" "$bot_id"; then
+        echo "assigned the Copilot coding agent"
+    else
+        echo "::warning::could not assign the Copilot coding agent in ${repo}"
+    fi
+    echo "::endgroup::"
+done
+
+exit "$failed"

--- a/.github/scripts/post-release/tasks.json
+++ b/.github/scripts/post-release/tasks.json
@@ -2,22 +2,22 @@
   {
     "key": "kubernetes-operator",
     "repo": "dapr/kubernetes-operator",
-    "assign_copilot": true,
+    "base": "main",
     "title": "Update the vendored Dapr Helm chart to VERSION",
-    "body": "Dapr VERSION is released. The operator vendors the Dapr Helm chart, so it needs the new version.\n\n### Steps\n\n1. Set `HELM_CHART_VERSION` to `VERSION` in the `Makefile`.\n2. Run `make update/dapr`. The script replaces `helm-charts/dapr/` with the new chart.\n3. Commit the `Makefile` and every file under `helm-charts/`.\n\n### Notes\n\n- `HELM_CHART_VERSION` is the only place that holds the Dapr version. The e2e tests read it through `DAPR_HELM_CHART_VERSION`, so no other file needs a version edit.\n- `make update/dapr` deletes and recreates `helm-charts/dapr/`. Include any file that upstream adds or removes, and do not hand-edit the result.\n- A new Dapr minor version can add CRDs under `helm-charts/dapr/crds/`. Add them.\n\n### Verification\n\n```\ngo build ./...\nmake check\nhelm lint helm-charts/dapr\nhelm template test helm-charts/dapr\n```\n\nThe commit needs a DCO sign-off.\n\nAfter this merges, a maintainer must tag a `v0.0.N` release, then submit the new bundle to [OperatorHub](https://github.com/k8s-operatorhub/community-operators/tree/main/operators/dapr-kubernetes-operator)."
+    "body": "Dapr VERSION is released. The operator vendors the Dapr Helm chart, so it needs the new version.\n\n### Steps\n\n1. Set `HELM_CHART_VERSION` to `VERSION` in the `Makefile`.\n2. Run `make update/dapr`. The script replaces `helm-charts/dapr/` with the new chart.\n3. Commit the `Makefile` and every file under `helm-charts/`.\n\n### Notes\n\n- `HELM_CHART_VERSION` is the only place that holds the Dapr version. The e2e tests read it through `DAPR_HELM_CHART_VERSION`, so no other file needs a version edit.\n- `make update/dapr` deletes and recreates `helm-charts/dapr/`. Include any file that upstream adds or removes, and do not hand-edit the result.\n- A new Dapr minor version can add CRDs under `helm-charts/dapr/crds/`. Add them.\n\n### Verification\n\n```\ngo build ./...\nmake check\nhelm lint helm-charts/dapr\nhelm template test helm-charts/dapr\n```\n\nThe commit needs a DCO sign-off.\n\nAfter this merges, a maintainer must tag a `v0.0.N` release, then submit the new bundle to [OperatorHub](https://github.com/k8s-operatorhub/community-operators/tree/main/operators/dapr-kubernetes-operator).\n\nOpen the change as a pull request against `main`. Sign off the commit for DCO."
   },
   {
     "key": "dapr-shared",
     "repo": "dapr/dapr-shared",
-    "assign_copilot": true,
+    "base": "main",
     "title": "Update Dapr version to VERSION",
-    "body": "Dapr VERSION is released. The chart still points at the previous version.\n\n### Steps\n\n1. In `chart/dapr-shared/Chart.yaml`, set `appVersion` to `VERSION` and raise the chart `version`.\n2. In `chart/dapr-shared/values.yaml`, set the Dapr image tag to `VERSION`.\n3. In `docs/tutorial/README.md`, replace the old version with `VERSION`.\n\nSee PR #66 for the shape of this change.\n\n### Verification\n\n```\nhelm lint chart/dapr-shared\nhelm template test chart/dapr-shared\n```\n\nThe commit needs a DCO sign-off."
+    "body": "Dapr VERSION is released. The chart still points at the previous version.\n\n### Steps\n\n1. In `chart/dapr-shared/Chart.yaml`, set `appVersion` to `VERSION` and raise the chart `version`.\n2. In `chart/dapr-shared/values.yaml`, set the Dapr image tag to `VERSION`.\n3. In `docs/tutorial/README.md`, replace the old version with `VERSION`.\n\nSee PR #66 for the shape of this change.\n\n### Verification\n\n```\nhelm lint chart/dapr-shared\nhelm template test chart/dapr-shared\n```\n\nThe commit needs a DCO sign-off.\n\nOpen the change as a pull request against `main`. Sign off the commit for DCO."
   },
   {
     "key": "testcontainers-dapr",
     "repo": "diagridio/testcontainers-dapr",
-    "assign_copilot": false,
+    "base": "main",
     "title": "Update the default Dapr version to VERSION",
-    "body": "Dapr VERSION is released. The module still starts the previous version by default.\n\n### Steps\n\n1. Update the default Dapr image tag in `src/main/java/io/diagrid/dapr/DaprContainer.java`.\n2. Update the default placement image tag in `src/main/java/io/diagrid/dapr/DaprPlacementContainer.java`.\n3. Update the expected versions in `src/test/java/io/diagrid/dapr/`: `DaprComponentTest.java`, `DaprContainerTest.java` and `DaprPlacementContainerTest.java`.\n\nSee PR #56 for the shape of this change.\n\n### Verification\n\n```\nmvn test\n```\n\nNote: the Copilot coding agent is not enabled on the diagridio organisation, so this one needs a person."
+    "body": "Dapr VERSION is released. The module still starts the previous version by default.\n\n### Steps\n\n1. Update the default Dapr image tag in `src/main/java/io/diagrid/dapr/DaprContainer.java`.\n2. Update the default placement image tag in `src/main/java/io/diagrid/dapr/DaprPlacementContainer.java`.\n3. Update the expected versions in `src/test/java/io/diagrid/dapr/`: `DaprComponentTest.java`, `DaprContainerTest.java` and `DaprPlacementContainerTest.java`.\n\nSee PR #56 for the shape of this change.\n\n### Verification\n\n```\nmvn test\n```\n\nOpen the change as a pull request against `main`. Sign off the commit for DCO."
   }
 ]

--- a/.github/scripts/post-release/tasks.json
+++ b/.github/scripts/post-release/tasks.json
@@ -1,0 +1,23 @@
+[
+  {
+    "key": "kubernetes-operator",
+    "repo": "dapr/kubernetes-operator",
+    "assign_copilot": true,
+    "title": "Update the vendored Dapr Helm chart to VERSION",
+    "body": "Dapr VERSION is released. The operator vendors the Dapr Helm chart, so it needs the new version.\n\n### Steps\n\n1. Set `HELM_CHART_VERSION` to `VERSION` in the `Makefile`.\n2. Run `make update/dapr`. The script replaces `helm-charts/dapr/` with the new chart.\n3. Commit the `Makefile` and every file under `helm-charts/`.\n\n### Notes\n\n- `HELM_CHART_VERSION` is the only place that holds the Dapr version. The e2e tests read it through `DAPR_HELM_CHART_VERSION`, so no other file needs a version edit.\n- `make update/dapr` deletes and recreates `helm-charts/dapr/`. Include any file that upstream adds or removes, and do not hand-edit the result.\n- A new Dapr minor version can add CRDs under `helm-charts/dapr/crds/`. Add them.\n\n### Verification\n\n```\ngo build ./...\nmake check\nhelm lint helm-charts/dapr\nhelm template test helm-charts/dapr\n```\n\nThe commit needs a DCO sign-off.\n\nAfter this merges, a maintainer must tag a `v0.0.N` release, then submit the new bundle to [OperatorHub](https://github.com/k8s-operatorhub/community-operators/tree/main/operators/dapr-kubernetes-operator)."
+  },
+  {
+    "key": "dapr-shared",
+    "repo": "dapr/dapr-shared",
+    "assign_copilot": true,
+    "title": "Update Dapr version to VERSION",
+    "body": "Dapr VERSION is released. The chart still points at the previous version.\n\n### Steps\n\n1. In `chart/dapr-shared/Chart.yaml`, set `appVersion` to `VERSION` and raise the chart `version`.\n2. In `chart/dapr-shared/values.yaml`, set the Dapr image tag to `VERSION`.\n3. In `docs/tutorial/README.md`, replace the old version with `VERSION`.\n\nSee PR #66 for the shape of this change.\n\n### Verification\n\n```\nhelm lint chart/dapr-shared\nhelm template test chart/dapr-shared\n```\n\nThe commit needs a DCO sign-off."
+  },
+  {
+    "key": "testcontainers-dapr",
+    "repo": "diagridio/testcontainers-dapr",
+    "assign_copilot": false,
+    "title": "Update the default Dapr version to VERSION",
+    "body": "Dapr VERSION is released. The module still starts the previous version by default.\n\n### Steps\n\n1. Update the default Dapr image tag in `src/main/java/io/diagrid/dapr/DaprContainer.java`.\n2. Update the default placement image tag in `src/main/java/io/diagrid/dapr/DaprPlacementContainer.java`.\n3. Update the expected versions in `src/test/java/io/diagrid/dapr/`: `DaprComponentTest.java`, `DaprContainerTest.java` and `DaprPlacementContainerTest.java`.\n\nSee PR #56 for the shape of this change.\n\n### Verification\n\n```\nmvn test\n```\n\nNote: the Copilot coding agent is not enabled on the diagridio organisation, so this one needs a person."
+  }
+]

--- a/.github/workflows/post-release-tasks.yml
+++ b/.github/workflows/post-release-tasks.yml
@@ -14,8 +14,8 @@
 name: Post release tasks
 
 # The post-release-day list sits at the bottom of the endgame issue, so it is
-# easy to miss. This workflow opens one issue per task in the target repository
-# and assigns the Copilot coding agent where the organisation enabled it.
+# easy to miss. This workflow starts a Copilot cloud agent task in each target
+# repository. The agent makes the change and opens the pull request.
 on:
   release:
     types: [published]
@@ -35,7 +35,7 @@ permissions: {}
 
 jobs:
   open-tasks:
-    name: Open the post-release tasks
+    name: Start the post-release tasks
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
@@ -101,12 +101,14 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "run=true" >> "$GITHUB_OUTPUT"
 
-      - name: Open the tasks
+      - name: Start the tasks
         if: steps.version.outputs.run == 'true'
         env:
-          # The issues land in other repositories, so the built-in token is not
-          # enough. DAPR_BOT_TOKEN must be able to open issues in every
-          # repository named in tasks.json.
+          # The agent tasks API only accepts a user-to-server token, so the
+          # built-in GITHUB_TOKEN cannot be used. DAPR_BOT_TOKEN must belong to
+          # an account that holds a Copilot seat and can reach every repository
+          # named in tasks.json. Without a seat the script falls back to
+          # opening an issue.
           GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
           DRY_RUN: ${{ inputs.dry_run || 'false' }}
         run: ./.github/scripts/post-release/open-tasks.sh "${{ steps.version.outputs.version }}"

--- a/.github/workflows/post-release-tasks.yml
+++ b/.github/workflows/post-release-tasks.yml
@@ -1,0 +1,120 @@
+#
+# Copyright 2026 The Dapr Authors
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#     http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Post release tasks
+
+# The post-release-day list sits at the bottom of the endgame issue, so it is
+# easy to miss. This workflow opens one issue per task in the target repository
+# and assigns the Copilot coding agent where the organisation enabled it.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      rel_version:
+        description: 'Released Dapr version, without a leading v (example: 1.18.4)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Print the plan and change nothing'
+        required: false
+        default: false
+        type: boolean
+
+permissions: {}
+
+jobs:
+  open-tasks:
+    name: Open the post-release tasks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v6
+
+      - name: Work out the version
+        id: version
+        env:
+          EVENT: ${{ github.event_name }}
+          TAG: ${{ github.event.release.tag_name }}
+          PRERELEASE: ${{ github.event.release.prerelease }}
+          INPUT_VERSION: ${{ inputs.rel_version }}
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "$EVENT" = "workflow_dispatch" ]; then
+            echo "version=${INPUT_VERSION#v}" >> "$GITHUB_OUTPUT"
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # A release candidate is not a released version. Skip it.
+          if [ "$PRERELEASE" = "true" ]; then
+            echo "::notice::${TAG} is a pre-release, no tasks to open"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Guard against a tag that still carries an rc suffix.
+          case "$TAG" in
+            *-rc.*|*-alpha*|*-beta*)
+              echo "::notice::${TAG} is a pre-release tag, no tasks to open"
+              echo "run=false" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+          esac
+
+          VERSION="${TAG#v}"
+
+          # Dapr keeps several minor lines alive at once, so a patch for an
+          # older line can publish after a newer minor. The downstream repos
+          # track the newest version only. Opening tasks for an older line
+          # would ask for a downgrade, so run only for the highest stable
+          # version.
+          LATEST=$(gh api 'repos/${{ github.repository }}/releases?per_page=100' \
+            --jq '.[] | select(.prerelease==false and .draft==false) | .tag_name' \
+            | sed 's/^v//' \
+            | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' \
+            | sort -V | tail -1)
+
+          if [ -z "$LATEST" ]; then
+            echo "::error::could not work out the latest stable version"
+            exit 1
+          fi
+
+          if [ "$VERSION" != "$LATEST" ]; then
+            echo "::notice::${TAG} is not the highest stable version (${LATEST}), no tasks to open"
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "run=true" >> "$GITHUB_OUTPUT"
+
+      - name: Open the tasks
+        if: steps.version.outputs.run == 'true'
+        env:
+          # The issues land in other repositories, so the built-in token is not
+          # enough. DAPR_BOT_TOKEN must be able to open issues in every
+          # repository named in tasks.json.
+          GITHUB_TOKEN: ${{ secrets.DAPR_BOT_TOKEN }}
+          DRY_RUN: ${{ inputs.dry_run || 'false' }}
+        run: ./.github/scripts/post-release/open-tasks.sh "${{ steps.version.outputs.version }}"
+
+      - name: Remind about the tasks that stay manual
+        if: steps.version.outputs.run == 'true'
+        run: |
+          echo "### Post-release tasks that stay manual" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Kratix Marketplace. Set \`VERSION\` in \`dapr/internal/scripts/fetch-deps\`, run it, then open a PR at syntasso/kratix-marketplace. It is a third-party repository, so this workflow does not file issues there." >> "$GITHUB_STEP_SUMMARY"
+          echo "- OperatorHub. This one follows a \`dapr/kubernetes-operator\` release, not a Dapr release. Tag the operator first, then submit the bundle to k8s-operatorhub/community-operators." >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Why

The `POST RELEASE DAY` list sits near the bottom of the endgame issue, around line 337 of 371 in #9856. It is easy to miss.

It was missed for 1.18. The Kubernetes operator step was skipped, and `dapr/kubernetes-operator` then sat on the Dapr 1.17.4 chart while 1.18.3 shipped, a gap of one minor and nine patch releases. The fix is in dapr/kubernetes-operator#413.

## What this does

On a published release, start a Copilot cloud agent task in each target repository. The agent makes the change and opens the pull request.

```
POST /agents/repos/{owner}/{repo}/tasks
{ "prompt": "...", "base_ref": "main", "create_pull_request": true }
```

| Task | Repository |
|---|---|
| Vendored Helm chart | `dapr/kubernetes-operator` |
| Chart and image tag | `dapr/dapr-shared` |
| Default container version | `diagridio/testcontainers-dapr` |

Each prompt names the exact files to change. The instructions come from the PRs that did this by hand for 1.18.1: dapr/dapr-shared#66 and diagridio/testcontainers-dapr#56. A precise prompt is what makes the agent useful rather than a one-line reminder.

Two tasks stay manual, and the workflow writes them to the job summary instead:

- **Kratix Marketplace.** `syntasso/kratix-marketplace` belongs to another organisation. The change itself is one line, `VERSION` in `dapr/internal/scripts/fetch-deps`, then re-run the script.
- **OperatorHub.** This one follows a `dapr/kubernetes-operator` release, not a Dapr release, so a Dapr tag is the wrong trigger.

## Token requirement

The agent tasks API accepts **user-to-server tokens only**. The built-in `GITHUB_TOKEN` cannot drive it.

`DAPR_BOT_TOKEN` must belong to an account that holds a Copilot seat and can reach all three repositories. If the call fails for any reason, including a missing seat, the script opens a normal issue in that repository instead, so a task is never lost.

## Guards

**Release candidates are skipped.** Checked twice: the `prerelease` flag on the release event, and the tag suffix (`-rc.`, `-alpha`, `-beta`).

**Only the highest stable version runs.** Dapr keeps several minor lines alive at once, and a patch for an older line can publish after a newer minor. Today `v1.16.19` and `v1.17.13` are both more recent publications than `v1.18.3`. Without this guard, releasing `v1.16.20` would ask the agent to downgrade `dapr-shared` and `testcontainers-dapr` from 1.18.x. The workflow computes the highest stable version and exits when the released tag is not it.

**Re-runs are safe.** A repository is skipped when it already has a live agent task or an open pull request for the version.

## Testing

Run against the live API.

| Test | Result |
|---|---|
| `GET /agents/repos/dapr/dapr/tasks` | 200, 12 existing tasks, so the endpoint is live |
| Same for all 3 target repos | 200 |
| Dry run for 1.18.4 | starts the 3 expected tasks, version substituted, base `main` |
| Skip check, `dapr/kubernetes-operator` at 1.18.3 | skips, finds the open PR #413 |
| Skip check, same repo at 1.18.4 | proceeds |
| Guard on `v1.18.3` | run |
| Guard on `v1.16.19`, `v1.17.13` | skip, not the highest stable |
| Guard on `v1.18.4-rc.3` | skip, by flag and by tag suffix |
| `bash -n` | clean |

I did not fire a live `POST`, because that starts a real agent session and opens a real pull request. `workflow_dispatch` takes a version and a `dry_run` input, so a maintainer can try it safely first.

The agent tasks API is in public preview and subject to change.
