### PR TITLE
fix(runtime): log error when subscribing to unregistered pubsub component

### DIFF
--- a/pkg/runtime/processor/subscriber/subscriber.go
+++ b/pkg/runtime/processor/subscriber/subscriber.go
@@ -597,6 +597,9 @@ func (s *Subscriber) initProgrammaticSubscriptions(ctx context.Context) error {
 
 	for pubsubName, topics := range subbedTopics {
 		log.Infof("app is subscribed to the following topics: [%s] through pubsub=%s", topics, pubsubName)
+		if _, ok := s.compStore.GetPubSub(pubsubName); !ok {
+			log.Errorf("app is subscribed to topics [%s] through pubsub=%s, but no pubsub component with that name was found", topics, pubsubName)
+		}
 	}
 
 	s.compStore.SetProgramaticSubscriptions(subscriptions...)

--- a/pkg/runtime/processor/subscriber/subscriber_test.go
+++ b/pkg/runtime/processor/subscriber/subscriber_test.go
@@ -14,8 +14,10 @@ limitations under the License.
 package subscriber
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
 	"slices"
 	"sync/atomic"
 	"testing"
@@ -293,6 +295,46 @@ func Test_initProgrammaticSubscriptions(t *testing.T) {
 		require.NoError(t, subs.initProgrammaticSubscriptions(t.Context()))
 		require.NoError(t, subs.initProgrammaticSubscriptions(t.Context()))
 		assert.Len(t, compStore.ListProgramaticSubscriptions(), 1)
+	})
+
+	t.Run("logs an error when subscribed pubsub component is not registered", func(t *testing.T) {
+		mockAppChannel := new(channelt.MockAppChannel)
+		compStore := compstore.New()
+		compStore.AddPubSub(TestPubsubName, new(rtpubsub.PubsubItem))
+		subs := New(Options{
+			CompStore:                       compStore,
+			IsHTTP:                          true,
+			Resiliency:                      resiliency.New(logger.NewLogger("test")),
+			Namespace:                       "ns1",
+			AppID:                           TestRuntimeConfigID,
+			Channels:                        new(channels.Channels).WithAppChannel(mockAppChannel),
+			ProgrammaticSubscriptionEnabled: true,
+		})
+
+		b, err := json.Marshal([]rtpubsub.SubscriptionJSON{
+			{
+				PubsubName: "missing-pubsub",
+				Topic:      "topic1",
+				Routes: rtpubsub.RoutesJSON{
+					Default: "/",
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		fakeResp := invokev1.NewInvokeMethodResponse(200, "OK", nil).
+			WithRawDataBytes(b).
+			WithContentType("application/json")
+		defer fakeResp.Close()
+
+		mockAppChannel.On("InvokeMethod", mock.AnythingOfType("*context.cancelCtx"), mock.AnythingOfType("*v1.InvokeMethodRequest")).Return(fakeResp, nil)
+
+		var buf bytes.Buffer
+		log.SetOutput(&buf)
+		defer log.SetOutput(os.Stderr)
+
+		require.NoError(t, subs.initProgrammaticSubscriptions(t.Context()))
+		assert.Contains(t, buf.String(), "no pubsub component with that name was found")
 	})
 
 	t.Run("skip programmatic subscription loading when disabled", func(t *testing.T) {


### PR DESCRIPTION
# Description

When an app declares a programmatic pub/sub subscription (via app.subscribe or the gRPC/HTTP subscription endpoint) for a pubsub component name that does not exist in the component store, the sidecar silently drops the subscription. Subscriptions are only started for pubsub names that are present in the loaded components, so a typo or a component that failed to load results in no error, no log, and no exception, the app simply never receives messages with no indication why.

This PR adds an error log when the app subscribes to a pubsub name that has no matching loaded component, so the misconfiguration is visible in the logs instead of failing silently.

## Issue reference

Please reference the issue this PR will close: #2895

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
