### PR TITLE
[1.18] workflow: stamp synthesized child and activity failures with their source app

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -11,6 +11,7 @@ This update contains the following bug fixes:
 - [Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled](#workflow-schedule-and-status-waits-failed-with-a-stalled-actor-error-while-a-workflow-was-stalled)
 - [Workflow NewGuid and other SDK-derived deterministic values repeated after ContinueAsNew](#workflow-newguid-and-other-sdk-derived-deterministic-values-repeated-after-continueasnew)
 - [Hot-reloaded workflow access policy listed in metadata before it was enforced](#hot-reloaded-workflow-access-policy-listed-in-metadata-before-it-was-enforced)
+- [Workflow wrongly failed as tampered when a child workflow creation was rejected under history signing](#workflow-wrongly-failed-as-tampered-when-a-child-workflow-creation-was-rejected-under-history-signing)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -286,3 +287,27 @@ Compiling the policy expressions takes a small amount of time, and the metadata 
 ### Solution
 
 The reconciler now compiles the prospective policy set and swaps it into enforcement before it updates the resource store, for both updates and deletes, so a policy listed by the metadata endpoint is always one that is already enforced.
+
+## Workflow wrongly failed as tampered when a child workflow creation was rejected under history signing
+
+### Problem
+
+With `WorkflowHistorySigning` enabled, a parent workflow whose child workflow creation was rejected by the runtime was terminally failed with error type `DAPR_WORKFLOW_HISTORY_TAMPERED` and the message `child failure missing required attestation for task <n>`.
+Two rejections trigger it: creating a child under an instance ID still held by a running child of a previous execution of the same parent (the `already exists` failure introduced in this release), and a child creation denied by a `WorkflowAccessPolicy`.
+Once tombstoned, the instance was unrecoverable: its reminders were deleted and the old child's later completion was dropped with `no such instance exists`.
+
+### Impact
+
+You were affected if you ran with `WorkflowHistorySigning` enabled and a workflow used ContinueAsNew and re-created a child whose previous-generation counterpart could still be running, or created children denied by an access policy.
+Without signing the same parent observes an ordinary child workflow failure it can handle; with signing it failed permanently and deterministically on every occurrence.
+An activity denied by an access policy had the same latent defect.
+
+### Root Cause
+
+When the runtime rejects a child workflow creation it synthesizes a `ChildWorkflowInstanceFailed` event for the parent and delivers it through a reminder.
+Such an event carries no attestation by design, so attestation verification exempts it when the event's router names the parent's own application as its source.
+The code that synthesizes the event never set the router, so the exemption never matched and the event was treated as an unattested completion from an untrusted sender.
+
+### Solution
+
+The synthesized child workflow failure and the synthesized activity failure now record the parent's application as their source, so attestation verification recognises them as locally authored and the parent observes the failure as intended.

--- a/pkg/actors/targets/workflow/orchestrator/activity.go
+++ b/pkg/actors/targets/workflow/orchestrator/activity.go
@@ -147,6 +147,7 @@ func (o *orchestrator) failActivityACL(ctx context.Context, e *backend.HistoryEv
 	failedEvent := &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.New(time.Now()),
+		Router:    &protos.TaskRouter{SourceAppID: o.appID},
 		EventType: events.NewTaskFailedEventType(e.GetEventId(), messages.ErrorTypeAccessPolicyDenied, messages.ErrorMessageAccessPolicyDenied, false),
 	}
 

--- a/pkg/actors/targets/workflow/orchestrator/childwf.go
+++ b/pkg/actors/targets/workflow/orchestrator/childwf.go
@@ -127,6 +127,7 @@ func (o *orchestrator) failChildWorkflowTask(ctx context.Context, taskScheduledI
 	failedEvent := &protos.HistoryEvent{
 		EventId:   -1,
 		Timestamp: timestamppb.New(time.Now()),
+		Router:    &protos.TaskRouter{SourceAppID: o.appID},
 		EventType: events.NewChildWorkflowFailedEventType(taskScheduledID, errorType, errorMessage, false),
 	}
 

--- a/tests/integration/suite/daprd/workflow/signing/accesspolicyactivity.go
+++ b/tests/integration/suite/daprd/workflow/signing/accesspolicyactivity.go
@@ -1,0 +1,148 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/placement"
+	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+	"github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(accesspolicyactivity))
+}
+
+type accesspolicyactivity struct {
+	sentry *sentry.Sentry
+	place  *placement.Placement
+	sched  *scheduler.Scheduler
+	db     *sqlite.SQLite
+	caller *daprd.Daprd
+	target *daprd.Daprd
+}
+
+func (a *accesspolicyactivity) Setup(t *testing.T) []framework.Option {
+	a.sentry = sentry.New(t)
+	a.place = placement.New(t, placement.WithSentry(t, a.sentry))
+	a.sched = scheduler.New(t, scheduler.WithSentry(a.sentry), scheduler.WithID("dapr-scheduler-server-0"))
+	a.db = sqlite.New(t, sqlite.WithActorStateStore(true), sqlite.WithCreateStateTables())
+
+	// Only another app is granted access, so the caller is denied.
+	policy := []byte(`
+apiVersion: dapr.io/v1alpha1
+kind: WorkflowAccessPolicy
+metadata:
+  name: sign-acl-activity
+scopes:
+- sign-acl-target
+spec:
+  rules:
+  - callers:
+    - appID: some-other-app
+    activities:
+    - name: "*"
+`)
+	targetResDir := t.TempDir()
+	require.NoError(t, os.WriteFile(filepath.Join(targetResDir, "policy.yaml"), policy, 0o600))
+
+	const signing = `apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: sign-on
+spec:
+  features:
+  - name: WorkflowHistorySigning
+    enabled: true
+`
+	a.caller = daprd.New(t,
+		daprd.WithAppID("sign-acl-caller"),
+		daprd.WithNamespace("default"),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithConfigManifests(t, signing),
+	)
+	a.target = daprd.New(t,
+		daprd.WithAppID("sign-acl-target"),
+		daprd.WithNamespace("default"),
+		daprd.WithResourcesDir(targetResDir),
+		daprd.WithResourceFiles(a.db.GetComponent(t)),
+		daprd.WithPlacementAddresses(a.place.Address()),
+		daprd.WithScheduler(a.sched),
+		daprd.WithSentry(t, a.sentry),
+		daprd.WithConfigManifests(t, signing),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(a.sentry, a.place, a.sched, a.db, a.caller, a.target),
+	}
+}
+
+func (a *accesspolicyactivity) Run(t *testing.T, ctx context.Context) {
+	a.place.WaitUntilRunning(t, ctx)
+	a.sched.WaitUntilRunning(t, ctx)
+	a.caller.WaitUntilRunning(t, ctx)
+	a.target.WaitUntilRunning(t, ctx)
+
+	callerReg := task.NewTaskRegistry()
+	targetReg := task.NewTaskRegistry()
+	require.NoError(t, callerReg.AddWorkflowN("sign-acl-workflow", func(ctx *task.WorkflowContext) (any, error) {
+		// Surface the denial as output so a tombstoned (FAILED) workflow is
+		// distinguishable from one that observed the activity failure.
+		if err := ctx.CallActivity("denied", task.WithActivityAppID(a.target.AppID())).Await(nil); err != nil {
+			return err.Error(), nil //nolint:nilerr
+		}
+		return "no error", nil
+	}))
+	require.NoError(t, targetReg.AddActivityN("denied", func(task.ActivityContext) (any, error) {
+		return "must not run", nil
+	}))
+
+	callerClient := client.NewTaskHubGrpcClient(a.caller.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, callerClient.StartWorkItemListener(ctx, callerReg))
+	targetClient := client.NewTaskHubGrpcClient(a.target.GRPCConn(t, ctx), logger.New(t))
+	require.NoError(t, targetClient.StartWorkItemListener(ctx, targetReg))
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.GreaterOrEqual(c, len(a.caller.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 1)
+		assert.GreaterOrEqual(c, len(a.target.GetMetadata(t, ctx).ActorRuntime.ActiveActors), 1)
+	}, time.Second*20, time.Millisecond*10)
+
+	id, err := callerClient.ScheduleNewWorkflow(ctx, "sign-acl-workflow")
+	require.NoError(t, err)
+
+	meta, err := callerClient.WaitForWorkflowCompletion(ctx, id, api.WithFetchPayloads(true))
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"workflow was tombstoned instead of observing the denied activity; failure details: %v", meta.GetFailureDetails())
+	assert.Contains(t, meta.GetOutput().GetValue(), "denied by workflow access policy")
+}

--- a/tests/integration/suite/daprd/workflow/signing/childidcollide.go
+++ b/tests/integration/suite/daprd/workflow/signing/childidcollide.go
@@ -1,0 +1,123 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(childidcollide))
+}
+
+type childidcollide struct {
+	workflow *workflow.Workflow
+}
+
+func (c *childidcollide) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t, workflow.WithHistorySigning(t))
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *childidcollide) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const parentID = "signing-childid-collide"
+	const pinnedID = parentID + "-pinned"
+
+	var inActivity atomic.Bool
+	releaseCh := make(chan struct{})
+	t.Cleanup(func() {
+		select {
+		case <-releaseCh:
+		default:
+			close(releaseCh)
+		}
+	})
+
+	reg := c.workflow.Registry()
+	reg.AddWorkflowN("blocker", func(ctx *task.WorkflowContext) (any, error) {
+		return nil, ctx.CallActivity("block").Await(nil)
+	})
+	reg.AddActivityN("block", func(actx task.ActivityContext) (any, error) {
+		inActivity.Store(true)
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-releaseCh:
+			return nil, nil
+		}
+	})
+	reg.AddWorkflowN("parent", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 {
+			ctx.CallChildWorkflow("blocker", task.WithChildWorkflowInstanceID(pinnedID))
+			ctx.WaitForSingleEvent("proceed", time.Minute).Await(nil)
+			ctx.ContinueAsNew(1)
+			return nil, nil
+		}
+
+		if err := ctx.CallChildWorkflow("blocker",
+			task.WithChildWorkflowInstanceID(pinnedID),
+		).Await(nil); err != nil {
+			return err.Error(), nil //nolint:nilerr
+		}
+		return "no error", nil
+	})
+
+	client := c.workflow.BackendClient(t, ctx)
+	_, err := client.ScheduleNewWorkflow(ctx, "parent",
+		api.WithInstanceID(parentID),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+
+	require.Eventually(t, inActivity.Load, time.Second*10, time.Millisecond*10)
+	require.NoError(t, client.RaiseEvent(ctx, parentID, "proceed"))
+
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err := client.WaitForWorkflowCompletion(waitCtx, parentID)
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String(),
+		"parent was tombstoned instead of observing the child failure; failure details: %v", meta.GetFailureDetails())
+	assert.Contains(t, meta.GetOutput().GetValue(), "already exists")
+
+	ometa, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(pinnedID))
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), ometa.GetRuntimeStatus().String())
+
+	close(releaseCh)
+	ometa, err = client.WaitForWorkflowCompletion(ctx, pinnedID)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), ometa.GetRuntimeStatus().String())
+}


### PR DESCRIPTION
When a child workflow creation is rejected (instance ID still held by a previous execution of the parent after ContinueAsNew, or denied by a WorkflowAccessPolicy) the parent synthesizes a ChildWorkflowInstanceFailed event and delivers it to itself through a reminder; the same happens with a TaskFailed event for an activity denied by an access policy. These events carry no attestation by design, and under WorkflowHistorySigning the inbox verifier exempts them only when the event's router names this app as the source. The synthesizers on release-1.18 never set the router, so the exemption never matched: the parent logged "child failure missing required attestation for task N", was tombstoned as tampered and its reminders were deleted, stranding the old child's completion as well.

Stamp the router source app on both synthesized events, as master already does since #9884.