### PR TITLE
[1.18] workflow: persist an abandoned continue-as-new generation as a pending start

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -10,6 +10,7 @@ This update contains the following bug fixes:
 - [Workflow terminate silently dropped when delivered in the same batch as other events](#workflow-terminate-silently-dropped-when-delivered-in-the-same-batch-as-other-events)
 - [Workflow schedule and status waits failed with a stalled-actor error while a workflow was stalled](#workflow-schedule-and-status-waits-failed-with-a-stalled-actor-error-while-a-workflow-was-stalled)
 - [Workflow NewGuid and other SDK-derived deterministic values repeated after ContinueAsNew](#workflow-newguid-and-other-sdk-derived-deterministic-values-repeated-after-continueasnew)
+- [Workflow stuck RUNNING after ContinueAsNew when the new generation's first execution was lost](#workflow-stuck-running-after-continueasnew-when-the-new-generations-first-execution-was-lost)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -264,3 +265,27 @@ The sidecar never populated the field: the workflow engine sent every work item 
 Workflow work items now carry the execution ID of the generation they belong to, taken from the `ExecutionStarted` event, scanning new events before past events so a continued-as-new or recreated run reports its own execution rather than a stale one.
 Each generation's execution ID is minted fresh on ContinueAsNew and instance recreation but is persisted in history, so SDK-derived values become unique per generation while remaining stable across replays within a generation.
 Workflows in flight across the upgrade re-seed from the execution ID on their next turn; values already recorded in their history replay from history as before.
+
+## Workflow stuck RUNNING after ContinueAsNew when the new generation's first execution was lost
+
+### Problem
+
+A workflow that called ContinueAsNew could get stuck `RUNNING` forever with `WorkflowsClusteredDeployment` enabled.
+The runtime logged `failed before receiving workflow result` and `aborting workflow execution` for the ContinueAsNew turn, and the new generation's first execution then received the previous generation's events, for example the timer that triggered the ContinueAsNew and the completion of a child workflow started by the previous generation.
+When the new generation created a child workflow under the same task ID, the stale completion was recorded ahead of the creation, the new child's genuine completion was dropped as a duplicate (`dropping duplicate completion event already present in history/inbox`), and the parent never advanced.
+
+### Impact
+
+You were affected if you ran with `WorkflowsClusteredDeployment` enabled and used ContinueAsNew; workflows that also created child workflows or timers in each generation were the most likely to strand, at a rate of several percent per ContinueAsNew under load or during pod restarts.
+The same defect could be reached on any deployment when a workflow exceeded the engine's tight-loop ContinueAsNew limit.
+
+### Root Cause
+
+When the workflow engine abandons a work item after the workflow has already continued-as-new, the runtime persists the new generation so that progress is not lost.
+It wrote the new generation's start events to history but replaced the consumed inbox only when the previous generation left unprocessed external events to carry over.
+Without carryover the previous generation's consumed events stayed in the inbox and were delivered again as the new generation's first work item, where the task ID sequence has restarted, so a previous generation's completion could take over a task ID of the new generation.
+
+### Solution
+
+An abandoned continued-as-new generation is now persisted exactly like a freshly created workflow: an empty history, its start event leading the inbox followed by any carried-over events, and a start reminder that drives it, created after the state is saved.
+The previous generation's consumed events are discarded, and the new generation always runs on its own.

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -25,7 +25,6 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
-	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/events"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/orchestrator/signing"
 	diag "github.com/dapr/dapr/pkg/diagnostics"
 	wferrors "github.com/dapr/dapr/pkg/runtime/wfengine/errors"
@@ -227,49 +226,58 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	case completed := <-callback:
 		if !completed {
 			// The engine abandoned this work item (e.g. MaxContinueAsNewCount
-			// exceeded). The engine's ContinueAsNew tight-loop may have
-			// overwritten o.rstate via the shared wi.State pointer
-			// (*s = *newState in the applier). If CAN progress was made,
-			// persist it to the state store so it survives actor
-			// deactivation. Carryover events (unprocessed EventRaised
-			// events from the CAN state) are moved to the Inbox so they
-			// become NewEvents on retry. The stale inbox (which contained
-			// ALL original events including those already consumed) is
-			// replaced to prevent duplicate event delivery.
+			// exceeded, or the execution result was lost). The engine's
+			// ContinueAsNew tight-loop may have overwritten o.rstate via the
+			// shared wi.State pointer (*s = *newState in the applier). If CAN
+			// progress was made, persist the newest generation as a pending
+			// start, exactly like a fresh creation: empty history, its
+			// ExecutionStarted in the inbox followed by any carryover
+			// (unprocessed EventRaised events from the CAN state), and a start
+			// reminder to drive it. The consumed inbox is discarded: it holds
+			// the previous generation's events, and re-delivering those into
+			// the new generation lets a stale resolution be persisted ahead of
+			// an operation of the new generation that reuses its event ID.
+			// Keeping the generation's ExecutionStarted in history instead
+			// would leave the retry with an empty inbox and nothing to run.
 			// If no CAN progress was made (non-CAN failure), restore the
 			// pre-engine snapshot so the cached state stays consistent.
 			if wi.State.GetContinuedAsNew() {
-				// Separate carryover EventRaised events from the CAN
-				// execution events (WorkflowStarted, ExecutionStarted).
-				// Carryover events must go into the Inbox so they become
-				// NewEvents on retry. If they stay in History (as
-				// OldEvents) alongside the original Inbox events
-				// (NewEvents), the engine would buffer both sets and the
-				// workflow would process duplicate events.
 				canNewEvents := wi.State.GetNewEvents()
-				filtered := make([]*backend.HistoryEvent, 0, len(canNewEvents))
+				var startEvent *backend.HistoryEvent
 				var carryover []*backend.HistoryEvent
 				for _, e := range canNewEvents {
-					if e.GetEventRaised() != nil {
+					switch {
+					case e.GetExecutionStarted() != nil:
+						startEvent = e
+					case e.GetEventRaised() != nil:
 						carryover = append(carryover, e)
-					} else {
-						filtered = append(filtered, e)
 					}
 				}
-
-				// Temporarily swap NewEvents so ApplyRuntimeStateChanges
-				// only writes the CAN execution events to History.
-				if len(carryover) > 0 {
-					wi.State.NewEvents = filtered
-					state.ApplyRuntimeStateChanges(wi.State)
-					wi.State.NewEvents = canNewEvents
-
-					state.ClearInbox()
-					for _, e := range carryover {
-						state.AddToInbox(e)
+				if startEvent == nil && wi.State.GetStartEvent() != nil {
+					startEvent = &protos.HistoryEvent{
+						EventId:   -1,
+						Timestamp: timestamppb.Now(),
+						EventType: &protos.HistoryEvent_ExecutionStarted{
+							ExecutionStarted: wi.State.GetStartEvent(),
+						},
 					}
-				} else {
-					state.ApplyRuntimeStateChanges(wi.State)
+				}
+				if startEvent == nil {
+					o.rstate = rstateSnapshot
+					return todo.RunCompletedFalse, errors.New("continued-as-new runtime state has no ExecutionStarted event")
+				}
+
+				// Apply the CAN reset (history, certificates, signatures)
+				// without writing any of the new generation's events to
+				// history: they are re-created when the pending start runs.
+				wi.State.NewEvents = nil
+				state.ApplyRuntimeStateChanges(wi.State)
+				wi.State.NewEvents = canNewEvents
+
+				state.ClearInbox()
+				state.AddToInbox(startEvent)
+				for _, e := range carryover {
+					state.AddToInbox(e)
 				}
 
 				state.Generation++
@@ -281,16 +289,15 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 					state.SetIncomingHistory(wi.IncomingHistory)
 				}
 
-				if len(carryover) > 0 {
-					reminderName := events.EventReminderName(reminderPrefixNewEvent, carryover[0])
-					if err = o.createWorkflowReminder(ctx, reminderName, nil, time.Now(), o.appID, &workflowName); err != nil {
-						o.invalidateCachedState()
-						return todo.RunCompletedFalse, err
-					}
-				}
-
+				// Save BEFORE creating the wake-up reminder, mirroring
+				// scheduleWorkflowStart: a reminder created first can fire on
+				// another host before the save commits, ack SUCCESS off the
+				// old state and be deleted, stranding the pending start.
 				if err = o.signAndSaveState(ctx, state); err != nil {
 					o.rstate = rstateSnapshot
+					return todo.RunCompletedFalse, err
+				}
+				if err = o.assertStartReminder(ctx, startEvent); err != nil {
 					return todo.RunCompletedFalse, err
 				}
 			} else {

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -15,6 +15,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -27,6 +28,7 @@ import (
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/fake"
+	"github.com/dapr/dapr/pkg/actors/reminders"
 	remindersfake "github.com/dapr/dapr/pkg/actors/reminders/fake"
 	statefake "github.com/dapr/dapr/pkg/actors/state/fake"
 	"github.com/dapr/dapr/pkg/actors/targets/workflow/common"
@@ -184,8 +186,12 @@ func Test_runWorkflow_stateIsolation(t *testing.T) {
 // event delivery on retry: without the move, the retry would pass all
 // original inbox events as NewEvents alongside the carryover OldEvents,
 // causing the workflow to see and process duplicate events.
-func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
-	const instanceID = "test-can-carryover"
+// abandonedCANRun drives runWorkflow with a scheduler that overwrites the
+// work item state with canState (a continued-as-new runtime state) and then
+// abandons the work item, returning the orchestrator and every reminder
+// Create request issued. inbox is the consumed inbox of the abandoned turn.
+func abandonedCANRun(t *testing.T, instanceID string, inbox []*backend.HistoryEvent, canState *protos.WorkflowRuntimeState) (*orchestrator, []*actorapi.CreateReminderRequest) {
+	t.Helper()
 
 	startEvent := &protos.HistoryEvent{
 		EventId:   -1,
@@ -200,7 +206,6 @@ func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
 			},
 		},
 	}
-
 	history := []*backend.HistoryEvent{
 		{
 			EventId: -1, Timestamp: timestamppb.Now(),
@@ -209,19 +214,6 @@ func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
 			},
 		},
 		startEvent,
-	}
-
-	inbox := make([]*backend.HistoryEvent, 5)
-	for i := range inbox {
-		inbox[i] = &protos.HistoryEvent{
-			EventId:   int32(i),
-			Timestamp: timestamppb.Now(),
-			EventType: &protos.HistoryEvent_EventRaised{
-				EventRaised: &protos.EventRaisedEvent{
-					Name: "incr",
-				},
-			},
-		}
 	}
 
 	state := wfenginestate.NewState(wfenginestate.Options{
@@ -235,16 +227,62 @@ func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
 	for _, e := range history {
 		state.AddToHistory(e)
 	}
-
 	rstate := runtimestate.NewWorkflowRuntimeState(instanceID, nil, history)
 
-	carryover := inbox[3:]
-	canState := &protos.WorkflowRuntimeState{
+	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
+		proto.Reset(wi.State)
+		proto.Merge(wi.State, canState)
+		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
+		return nil
+	}
+
+	var (
+		mu         sync.Mutex
+		gotCreates []*actorapi.CreateReminderRequest
+	)
+	remFake := remindersfake.New().WithCreate(func(_ context.Context, req *actorapi.CreateReminderRequest) error {
+		mu.Lock()
+		defer mu.Unlock()
+		gotCreates = append(gotCreates, req)
+		return nil
+	})
+
+	fact, err := New(t.Context(), Options{
+		AppID:             "testapp",
+		WorkflowActorType: "workflow",
+		ActivityActorType: "activity",
+		Scheduler:         scheduler,
+		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
+		Actors: fake.New().WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remFake, nil
+		}),
+	})
+	require.NoError(t, err)
+
+	o := fact.GetOrCreate(instanceID).(*orchestrator)
+	o.state = state
+	o.rstate = rstate
+	o.ometa = o.ometaFromState(rstate, startEvent.GetExecutionStarted())
+
+	reminder := &actorapi.Reminder{Name: "new-event-test"}
+	generation := state.Generation
+	completed, runErr := o.runWorkflow(t.Context(), reminder)
+	assert.Equal(t, generation+1, o.state.Generation)
+	assert.Equal(t, todo.RunCompletedFalse, completed)
+	require.Error(t, runErr)
+
+	mu.Lock()
+	defer mu.Unlock()
+	return o, gotCreates
+}
+
+func canRuntimeState(instanceID, input string, extra ...*protos.HistoryEvent) *protos.WorkflowRuntimeState {
+	return &protos.WorkflowRuntimeState{
 		InstanceId:     instanceID,
 		ContinuedAsNew: true,
 		StartEvent: &protos.ExecutionStartedEvent{
 			Name:  "TestWorkflow",
-			Input: wrapperspb.String(`3`),
+			Input: wrapperspb.String(input),
 			WorkflowInstance: &protos.WorkflowInstance{
 				InstanceId: instanceID,
 			},
@@ -263,60 +301,94 @@ func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
 				EventType: &protos.HistoryEvent_ExecutionStarted{
 					ExecutionStarted: &protos.ExecutionStartedEvent{
 						Name:  "TestWorkflow",
-						Input: wrapperspb.String(`3`),
+						Input: wrapperspb.String(input),
 						WorkflowInstance: &protos.WorkflowInstance{
 							InstanceId: instanceID,
 						},
 					},
 				},
 			},
-		}, carryover...),
+		}, extra...),
 	}
+}
 
-	scheduler := func(_ context.Context, wi *backend.WorkflowWorkItem) error {
-		proto.Reset(wi.State)
-		proto.Merge(wi.State, canState)
-		wi.Properties[todo.CallbackChannelProperty].(chan bool) <- false
-		return nil
-	}
+// Test_runWorkflow_canSaveMovesCarryoverToInbox verifies that when the
+// engine abandons a work item after continuing-as-new, the newest generation
+// is persisted as a pending start: its ExecutionStarted leads the inbox,
+// followed by the carryover EventRaised events, history is empty, and a
+// start reminder drives the retry. The consumed inbox is discarded.
+func Test_runWorkflow_canSaveMovesCarryoverToInbox(t *testing.T) {
+	const instanceID = "test-can-carryover"
 
-	fact, err := New(t.Context(), Options{
-		AppID:             "testapp",
-		WorkflowActorType: "workflow",
-		ActivityActorType: "activity",
-		Scheduler:         scheduler,
-		ActorTypeBuilder:  common.NewActorTypeBuilder("default"),
-		Actors:            fake.New(),
-	})
-	require.NoError(t, err)
-
-	o := fact.GetOrCreate(instanceID).(*orchestrator)
-	o.state = state
-	o.rstate = rstate
-	o.ometa = o.ometaFromState(rstate, startEvent.GetExecutionStarted())
-
-	reminder := &actorapi.Reminder{Name: "new-event-test"}
-	completed, runErr := o.runWorkflow(t.Context(), reminder)
-
-	assert.Equal(t, todo.RunCompletedFalse, completed)
-	require.Error(t, runErr)
-
-	assert.Len(t, o.state.Inbox, len(carryover))
-
-	for _, e := range o.state.History {
-		assert.Nil(t, e.GetEventRaised())
-	}
-
-	hasExecutionStarted := false
-	for _, e := range o.state.History {
-		if e.GetExecutionStarted() != nil {
-			hasExecutionStarted = true
-			break
+	inbox := make([]*backend.HistoryEvent, 5)
+	for i := range inbox {
+		inbox[i] = &protos.HistoryEvent{
+			EventId:   int32(i),
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_EventRaised{
+				EventRaised: &protos.EventRaisedEvent{
+					Name: "incr",
+				},
+			},
 		}
 	}
-	assert.True(t, hasExecutionStarted)
+	carryover := inbox[3:]
 
-	assert.Equal(t, `3`, o.rstate.GetStartEvent().GetInput().GetValue())
+	o, creates := abandonedCANRun(t, instanceID, inbox, canRuntimeState(instanceID, `3`, carryover...))
+
+	require.Len(t, o.state.Inbox, len(carryover)+1)
+	assert.Equal(t, `3`, o.state.Inbox[0].GetExecutionStarted().GetInput().GetValue())
+	for i, e := range carryover {
+		assert.NotNil(t, o.state.Inbox[i+1].GetEventRaised())
+		assert.Equal(t, e.GetEventId(), o.state.Inbox[i+1].GetEventId())
+	}
+	assert.Empty(t, o.state.History)
+
+	require.Len(t, creates, 1)
+	assert.True(t, strings.HasPrefix(creates[0].Name, reminderPrefixStart), creates[0].Name)
+	assert.Equal(t, instanceID, creates[0].ActorID)
+}
+
+// Test_runWorkflow_canAbandonWithoutCarryoverDiscardsConsumedInbox verifies
+// that the consumed inbox of an abandoned continued-as-new turn is not
+// re-delivered into the new generation even when there is no carryover: the
+// previous generation's resolutions would otherwise land ahead of operations
+// of the new generation that reuse their event IDs.
+func Test_runWorkflow_canAbandonWithoutCarryoverDiscardsConsumedInbox(t *testing.T) {
+	const instanceID = "test-can-no-carryover"
+
+	inbox := []*backend.HistoryEvent{
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_TimerFired{
+				TimerFired: &protos.TimerFiredEvent{TimerId: 1},
+			},
+		},
+		{
+			EventId:   -1,
+			Timestamp: timestamppb.Now(),
+			EventType: &protos.HistoryEvent_ChildWorkflowInstanceCompleted{
+				ChildWorkflowInstanceCompleted: &protos.ChildWorkflowInstanceCompletedEvent{
+					TaskScheduledId: 0,
+				},
+			},
+		},
+	}
+
+	o, creates := abandonedCANRun(t, instanceID, inbox, canRuntimeState(instanceID, `1`))
+
+	require.Len(t, o.state.Inbox, 1)
+	assert.Equal(t, `1`, o.state.Inbox[0].GetExecutionStarted().GetInput().GetValue())
+	assert.Empty(t, o.state.History)
+	assert.Empty(t, o.rstate.GetOldEvents())
+
+	names := make([]string, 0, len(creates))
+	for _, c := range creates {
+		names = append(names, c.Name)
+	}
+	require.Len(t, creates, 1, "%v", names)
+	assert.True(t, strings.HasPrefix(creates[0].Name, reminderPrefixStart), creates[0].Name)
 }
 
 // Test_runWorkflow_emptyInboxTerminalCreatesRetentionReminder verifies the

--- a/tests/integration/suite/daprd/workflow/continueasnew/abandoned.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/abandoned.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package continueasnew
+
+import (
+	"context"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/api/protos"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(abandoned))
+}
+
+// abandoned verifies that when the engine abandons a work item after
+// continuing-as-new (here by exceeding its tight-loop limit), the events the
+// previous generation consumed are not re-delivered to the generation that is
+// persisted, and that this generation still runs. A leaked event would ride
+// the kept-events carryover to the final generation and satisfy its wait
+// before the test raises the event again.
+type abandoned struct {
+	workflow *workflow.Workflow
+}
+
+func (a *abandoned) Setup(t *testing.T) []framework.Option {
+	a.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(a.workflow),
+	}
+}
+
+func (a *abandoned) Run(t *testing.T, ctx context.Context) {
+	a.workflow.WaitUntilRunning(t, ctx)
+
+	// The engine abandons a work item after 20 tight-loop generations, so this
+	// crosses that limit more than once.
+	const lastGen = 50
+	const id = "can-abandoned"
+
+	reg := a.workflow.Registry()
+	reg.AddWorkflowN("can-abandoned", func(ctx *task.WorkflowContext) (any, error) {
+		var gen int
+		if err := ctx.GetInput(&gen); err != nil {
+			return nil, err
+		}
+		if gen == 0 || gen == lastGen {
+			if err := ctx.WaitForSingleEvent("go", time.Hour).Await(nil); err != nil {
+				return nil, err
+			}
+			if gen == lastGen {
+				return "done", nil
+			}
+		}
+		ctx.ContinueAsNew(gen+1, task.WithKeepUnprocessedEvents())
+		return nil, nil
+	})
+
+	client := a.workflow.BackendClient(t, ctx)
+	_, err := client.ScheduleNewWorkflow(ctx, "can-abandoned",
+		api.WithInstanceID(id),
+		api.WithInput(0),
+	)
+	require.NoError(t, err)
+	_, err = client.WaitForWorkflowStart(ctx, id)
+	require.NoError(t, err)
+	require.NoError(t, client.RaiseEvent(ctx, id, "go"))
+
+	isLastGenStart := func(e *protos.HistoryEvent) bool {
+		return e.GetExecutionStarted().GetInput().GetValue() == strconv.Itoa(lastGen)
+	}
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Equal(c, 1, fworkflow.CountHistoryEventsMatching(t, ctx, client, api.InstanceID(id), isLastGenStart))
+	}, time.Second*60, time.Millisecond*10)
+
+	meta, err := client.FetchWorkflowMetadata(ctx, api.InstanceID(id))
+	require.NoError(t, err)
+	require.Equal(t, api.RUNTIME_STATUS_RUNNING.String(), meta.GetRuntimeStatus().String(),
+		"the event consumed by generation 0 was re-delivered to a later generation")
+
+	require.NoError(t, client.RaiseEvent(ctx, id, "go"))
+	waitCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	t.Cleanup(cancel)
+	meta, err = client.WaitForWorkflowCompletion(waitCtx, id)
+	require.NoError(t, err, "the generation persisted by the abandoned work item never ran")
+	require.Equal(t, api.RUNTIME_STATUS_COMPLETED.String(), meta.GetRuntimeStatus().String())
+	assert.Equal(t, `"done"`, meta.GetOutput().GetValue())
+}


### PR DESCRIPTION
When the engine abandons a work item after the workflow continued-as-new (the new generation's execution result was lost, or the tight-loop limit was hit), runWorkflow persisted the new generation's WorkflowStarted and ExecutionStarted to history but only replaced the consumed inbox when EventRaised carryover existed. Without carryover the previous generation's consumed events stayed in the inbox and were re-delivered as the new generation's first work item, where the event ID sequence has restarted.

Persist the newest generation as a pending start instead, exactly like a fresh creation: empty history, its ExecutionStarted leading the inbox followed by any carryover, and a start reminder to drive it, created after the save so a reminder firing elsewhere cannot ack SUCCESS off the old state. Keeping the ExecutionStarted in history with an empty inbox would leave the retry with nothing to run; the previous shape only worked when a stale inbox happened to drive it.