### PR TITLE
fix(messaging): dedupe trace headers when proxying gRPC calls to a remote sidecar

### DIFF
--- a/pkg/messaging/grpc_proxy.go
+++ b/pkg/messaging/grpc_proxy.go
@@ -153,7 +153,17 @@ func (p *proxy) intercept(ctx context.Context, fullName string) (context.Context
 		return outCtx, appClient.(*grpc.ClientConn), nil, teardown, nil
 	}
 
-	outCtx := metadata.NewOutgoingContext(ctx, md.Copy())
+	// Drop any trace headers the caller already set (e.g. a gRPC client
+	// whose HTTP transport auto-instruments its own traceparent) before
+	// forwarding to the remote daprd. telemetryFn below appends this
+	// sidecar's own span context as the trace header for the next hop;
+	// leaving the caller's raw header in place would result in two
+	// comma-joined values for the same metadata key on the wire.
+	mdCopy := md.Copy()
+	delete(mdCopy, diagConsts.TraceparentHeader)
+	delete(mdCopy, diagConsts.TracestateHeader)
+	delete(mdCopy, diagConsts.GRPCTraceContextKey)
+	outCtx := metadata.NewOutgoingContext(ctx, mdCopy)
 
 	// proxy to a remote daprd
 	conn, teardown, cErr := p.connectionFactory(outCtx, target.address, target.id, target.namespace,

--- a/pkg/messaging/grpc_proxy_test.go
+++ b/pkg/messaging/grpc_proxy_test.go
@@ -242,6 +242,46 @@ func TestIntercept(t *testing.T) {
 		assert.NotContains(t, md, securityConsts.APITokenHeader)
 	})
 
+	t.Run("proxy to a remote app strips caller-supplied trace headers", func(t *testing.T) {
+		p := NewProxy(ProxyOpts{
+			ConnectionFactory: connectionFn,
+			AppClientFn:       appClientFn,
+			AppID:             "a",
+			Resiliency:        resiliency.New(nil),
+		})
+		p.SetTelemetryFn(func(ctx context.Context) context.Context {
+			return metadata.AppendToOutgoingContext(ctx, diagConsts.TraceparentHeader, "00-daprspan-daprspan-01")
+		})
+
+		p.SetRemoteAppFn(func(_ context.Context, s string) (remoteApp, error) {
+			return remoteApp{
+				id: "b",
+			}, nil
+		})
+
+		ctx := metadata.NewIncomingContext(t.Context(), metadata.MD{
+			diagConsts.GRPCProxyAppIDKey:   []string{"b"},
+			diagConsts.TraceparentHeader:   []string{"00-callerspan-callerspan-01"},
+			diagConsts.TracestateHeader:    []string{"caller-state"},
+			diagConsts.GRPCTraceContextKey: []string{"caller-bin"},
+		})
+		proxy := p.(*proxy)
+		ctx, conn, _, teardown, err := proxy.intercept(ctx, "/test")
+		defer teardown(true)
+
+		require.NoError(t, err)
+		assert.NotNil(t, conn)
+
+		md, _ := metadata.FromOutgoingContext(ctx)
+		// Only the sidecar's own trace header set by telemetryFn should be
+		// forwarded: the caller-supplied traceparent must not survive
+		// alongside it as a second, comma-joined value.
+		require.Len(t, md[diagConsts.TraceparentHeader], 1)
+		assert.Equal(t, "00-daprspan-daprspan-01", md[diagConsts.TraceparentHeader][0])
+		assert.NotContains(t, md, diagConsts.TracestateHeader)
+		assert.NotContains(t, md, diagConsts.GRPCTraceContextKey)
+	})
+
 	t.Run("access policies applied", func(t *testing.T) {
 		acl := &config.AccessControlList{
 			DefaultAction: "deny",


### PR DESCRIPTION
# Description

When the gRPC transparent proxy (used for gRPC service invocation) forwards a call to a remote sidecar, it copies the caller's incoming gRPC metadata verbatim into the outgoing context and then appends this sidecar's own trace-context headers on top via `AppendToOutgoingContext`. `AppendToOutgoingContext` does not replace existing values for a key, it adds to them. If the caller already sent a `traceparent` header on its call to the local sidecar (for example, a gRPC client library whose underlying HTTP transport auto-instruments outbound calls with a W3C `traceparent`, even calls to the local sidecar), the outgoing metadata to the remote sidecar ends up with two values for `traceparent` (and potentially `tracestate` / `grpc-trace-bin`). Multiple values for the same gRPC metadata key are sent as separate header lines, which some HTTP/gRPC stacks fold into a single comma-joined header value when read back, producing a malformed, unparsable trace-context header at the target app and breaking trace propagation across the hop.

This fix strips any caller-supplied `traceparent`, `tracestate`, and `grpc-trace-bin` entries from the copied metadata before this sidecar's own span context is appended for the remote-daprd hop, so exactly one, well-formed set of trace headers is forwarded. The "proxy locally to the app" branch is untouched since it does not append sidecar-managed trace headers and was not part of the bug.

## Issue reference

Please reference the issue this PR will close: #10462

## Validation

- `go build ./pkg/messaging/...` passes.
- `go test -tags="allcomponents unit" ./pkg/messaging/...` passes, including a new regression subtest `TestIntercept/proxy_to_a_remote_app_strips_caller-supplied_trace_headers` in `pkg/messaging/grpc_proxy_test.go`.
- Confirmed the regression test is meaningful: reverting only the fix in `grpc_proxy.go` and re-running the same test command makes the new subtest fail with `"[00-callerspan-callerspan-01 00-daprspan-daprspan-01]" should have 1 item(s), but has 2` — reproducing the exact reported symptom (two comma-joined trace header values) — and it passes again once the fix is reapplied.
- `go vet -tags="allcomponents unit" ./pkg/messaging/...` is clean.
- `golangci-lint run --build-tags="allcomponents unit" ./pkg/messaging/...` reports no new findings; the only findings are pre-existing `goconst` warnings in files this change does not touch.
- Not run: a live end-to-end reproduction with an actual gRPC client and two sidecars/apps. The defect and fix are demonstrated at the unit level: the failing-then-passing test above directly reproduces the duplicated-header mechanism described in the issue (same underlying `AppendToOutgoingContext`-onto-forwarded-metadata code path), so a live cluster reproduction was not necessary to confirm the fix.

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_

Fixes #10462