### PR TITLE
tests: drop the php extension installer from the actorphp image

### DIFF
--- a/tests/apps/actorphp/Dockerfile
+++ b/tests/apps/actorphp/Dockerfile
@@ -1,8 +1,9 @@
 FROM php:8.0-cli
 
-COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/local/bin/
+# curl, json and mbstring (the only extensions dapr/php-sdk requires) are already
+# built into the official php image. Composer falls back to the unzip binary
+# installed below when ext-zip is absent, so no extension install step is needed.
 RUN apt-get update && apt-get install -y wget git unzip && apt-get clean
-RUN install-php-extensions curl zip
 EXPOSE 3000
 RUN mkdir -p /app
 WORKDIR /app


### PR DESCRIPTION
# Description
The actorphp test app image fails to build, which fails every "E2E tests on KinD" job in the repo before any test runs:

  RUN install-php-extensions curl zip
  E: Failed to fetch http://deb.debian.org/debian-security/pool/updates/
     main/o/openssl/libssl1.1_1.1.1w-0+deb11u8_amd64.deb  404  Not Found

install-php-extensions pulls in libssl-dev, and the deb.debian.org edges that serve the GitHub runners return 404 for that pool file. The package itself is fine: it is still listed in the bullseye-security index and other edges serve it, which is why the build passes off CI.

Neither extension was needed. curl is already compiled into the official php image, and the build log said so ("Module already installed: curl"). zip is only a composer convenience; composer falls back to the unzip binary installed on the line above. dapr/php-sdk requires ext-curl, ext-json and ext-mbstring, all three of which the base image provides.

The resulting vendor tree is byte-identical to before the change: 566 files, same aggregate hash.

Verified by building with the failing edge pinned, --add-host deb.debian.org:151.101.162.132, which reproduces the CI error exactly on master and builds clean with this change. The container boots and GET /dapr/config returns {"entities":["PHPCarActor"]}.

## Issue reference

<!--
We strive to have all PR being opened based on an issue, where the problem or feature have been discussed prior to implementation.
-->

Please reference the issue this PR will close: #_[issue number]_

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [ ] Code compiles correctly
- [ ] Created/updated tests
- [ ] Unit tests passing
- [ ] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
