### PR TITLE
[1.18] workflow: register clustered work-item waiters before dispatch

### DIFF
--- a/docs/release_notes/v1.18.4.md
+++ b/docs/release_notes/v1.18.4.md
@@ -17,6 +17,7 @@ This update contains the following bug fixes:
 - [Force purge left the workflow actor serving and writing its stale in-memory state](#force-purge-left-the-workflow-actor-serving-and-writing-its-stale-in-memory-state)
 - [A child workflow that continued as new could not report its completion under history signing](#a-child-workflow-that-continued-as-new-could-not-report-its-completion-under-history-signing)
 - [Workflow stuck RUNNING after ContinueAsNew when the new generation's first execution was lost](#workflow-stuck-running-after-continueasnew-when-the-new-generations-first-execution-was-lost)
+- [Workflow stuck RUNNING under WorkflowsClusteredDeployment when a turn was answered with the previous turn's result](#workflow-stuck-running-under-workflowsclustereddeployment-when-a-turn-was-answered-with-the-previous-turns-result)
 
 ## Workflow left permanently PENDING when its start reminder fails during a scheduler restart
 
@@ -432,3 +433,30 @@ Without carryover the previous generation's consumed events stayed in the inbox 
 
 An abandoned continued-as-new generation is now persisted exactly like a freshly created workflow: an empty history, its start event leading the inbox followed by any carried-over events, and a start reminder that drives it, created after the state is saved.
 The previous generation's consumed events are discarded, and the new generation always runs on its own.
+
+## Workflow stuck RUNNING under WorkflowsClusteredDeployment when a turn was answered with the previous turn's result
+
+### Problem
+
+With the `WorkflowsClusteredDeployment` feature enabled, a workflow that used ContinueAsNew and ran an activity in each generation could stop making progress and report `RUNNING` forever.
+The last committed history of a stuck instance ended with a duplicate `TaskScheduled` for an activity that had already completed, its inbox was empty, and no reminder was left to drive it.
+
+### Impact
+
+You were affected if you ran daprd behind a load balancer with `WorkflowsClusteredDeployment` enabled and your workflows continued as new, in particular in a loop that ran activities or child workflows per generation.
+Affected instances looked healthy (`RUNNING`) but never completed, raised no error, and could only be recovered by terminating or purging and recreating them.
+
+### Root Cause
+
+Under `WorkflowsClusteredDeployment` the application's execution results travel through a per-instance rendezvous actor, because the completion RPC can land on any daprd in the cluster.
+That actor matched a response to a waiting execution by instance ID only: a response arriving while no execution was waiting was parked, and the next execution of the same instance took whatever was parked.
+The ContinueAsNew tight loop runs two executions of one instance back to back; the rendezvous actor was deactivated asynchronously after the first one, so the second execution's wait raced the deactivation and failed instantly.
+The workflow actor correctly recovered the new generation as a pending start, but the response of the lost execution still arrived from the application and was parked.
+From then on every turn of the instance was answered with the previous turn's response: the turn that delivered the activity result received a stale `ScheduleTask` action, the actor skipped the dispatch as already resolved and persisted a duplicate `TaskScheduled`, the real completion was parked with no consumer, and the instance never advanced.
+
+### Solution
+
+The execution now registers with the rendezvous before its work item is dispatched to the application, and the registration discards any response left behind by a previous execution, so a stale response can no longer be handed to the next turn.
+The actor is no longer deactivated while a registration or a waiting execution is present, and a call that lands on an actor closed by a concurrent deactivation is retried on a fresh one, so back-to-back executions of a ContinueAsNew loop no longer lose their result.
+As defence in depth, the workflow actor rejects a turn whose response re-creates an operation that already exists in committed history (the signature of a stale response) and retries the turn instead of persisting the duplicate.
+The change is compatible with a rolling upgrade: executions waiting on a pre-fix daprd keep the previous behaviour against a fixed daprd, and a fixed daprd whose registration is rejected by a pre-fix daprd falls back to the previous behaviour for that work item.

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -17,37 +17,57 @@ import (
 	"context"
 	"errors"
 	"sync"
-	"sync/atomic"
 
 	"github.com/cenkalti/backoff/v4"
 	"google.golang.org/grpc/codes"
 
 	actorapi "github.com/dapr/dapr/pkg/actors/api"
 	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
-	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
 	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
 	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/kit/logger"
 )
 
+var log = logger.NewLogger("dapr.runtime.actors.targets.executor")
+
 const (
+	// MethodRegister arms the actor for the next work item; called before the
+	// work item is dispatched so an early completion is parked for the
+	// watcher and an unregistered one is dropped.
+	MethodRegister      = "Register"
 	MethodComplete      = "Complete"
 	MethodCancel        = "Cancel"
 	MethodWatchComplete = "WatchComplete"
 )
 
+// executor rendezvouses a work item's waiter with the completion the app
+// reports, which may arrive on any daprd. Completions carry only the instance
+// ID, so a waiter registers before its work item is dispatched: the
+// registration discards any completion left behind by a superseded execution
+// and the next completion is held for it. A watcher that attaches without
+// registering (a daprd predating Register) takes whatever is parked, as
+// before.
 type executor struct {
 	*factory
 	actorID string
-	lock    *lock.Lock
 
-	closeCh    chan struct{}
-	completeCh chan *internalsv1pb.InternalInvokeResponse
-	cancelCh   chan struct{}
+	// mu guards the fields below except watchLock and wg.
+	mu sync.Mutex
+
+	closed  bool
+	closeCh chan struct{}
+
+	// epoch changes on every Register so a superseded watcher does not tear
+	// down the newer registration on exit.
+	epoch     uint64
+	armed     bool
+	parked    *internalsv1pb.InternalInvokeResponse
+	cancelled bool
+	// watcher is the attached WatchComplete stream's delivery channel.
+	watcher chan *internalsv1pb.InternalInvokeResponse
 
 	watchLock chan struct{}
-
-	closed atomic.Bool
-	wg     sync.WaitGroup
+	wg        sync.WaitGroup
 }
 
 func (e *executor) InvokeMethod(ctx context.Context, req *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
@@ -55,8 +75,10 @@ func (e *executor) InvokeMethod(ctx context.Context, req *internalsv1pb.Internal
 	defer e.wg.Done()
 
 	switch req.GetMessage().GetMethod() {
+	case MethodRegister:
+		return nil, e.register()
 	case MethodComplete:
-		return nil, e.complete(ctx, req)
+		return nil, e.complete(req)
 	case MethodCancel:
 		return nil, e.cancel()
 	default:
@@ -64,7 +86,27 @@ func (e *executor) InvokeMethod(ctx context.Context, req *internalsv1pb.Internal
 	}
 }
 
-func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvokeRequest) error {
+func (e *executor) register() error {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return targeterrors.NewClosed("executor")
+	}
+
+	if e.parked != nil {
+		log.Warnf("Executor actor '%s': discarding a parked completion that no waiter collected before a new registration", e.actorID)
+		e.parked = nil
+	}
+
+	e.epoch++
+	e.armed = true
+	e.cancelled = false
+
+	return nil
+}
+
+func (e *executor) complete(req *internalsv1pb.InternalInvokeRequest) error {
 	d := &internalsv1pb.InternalInvokeResponse{
 		Status: &internalsv1pb.Status{
 			Code: int32(codes.OK),
@@ -74,20 +116,52 @@ func (e *executor) complete(ctx context.Context, req *internalsv1pb.InternalInvo
 		},
 	}
 
-	select {
-	case e.completeCh <- d:
-		return nil
-	case <-e.cancelCh:
-		return errors.New("canceled before completion result was sent")
-	case <-e.closeCh:
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
 		return targeterrors.NewClosed("executor")
-	case <-ctx.Done():
-		return errors.New("context cancelled before completion result was sent")
 	}
+
+	switch {
+	case e.watcher != nil:
+		select {
+		case e.watcher <- d:
+		default:
+			log.Warnf("Executor actor '%s': dropping duplicate completion, the attached waiter already holds one", e.actorID)
+		}
+	case e.parked != nil:
+		log.Warnf("Executor actor '%s': dropping duplicate completion, one is already parked", e.actorID)
+	case e.armed:
+		e.parked = d
+	default:
+		// Nothing registered: a superseded execution's completion, which the
+		// next registration discards, or one for a watcher that does not
+		// register, which takes it.
+		log.Warnf("Executor actor '%s': parking completion with no registered waiter", e.actorID)
+		e.parked = d
+	}
+
+	return nil
 }
 
 func (e *executor) cancel() error {
-	close(e.cancelCh)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed {
+		return targeterrors.NewClosed("executor")
+	}
+
+	if e.watcher != nil {
+		select {
+		case e.watcher <- abortedResponse():
+		default:
+		}
+	} else {
+		e.cancelled = true
+	}
+
 	return nil
 }
 
@@ -99,15 +173,54 @@ func (e *executor) InvokeTimer(ctx context.Context, reminder *actorapi.Reminder)
 	return errors.New("timers are not implemented")
 }
 
+// Deactivate closes the actor unconditionally (halt or rebalance); an attached
+// watcher aborts its turn.
 func (e *executor) Deactivate(_ context.Context) error {
-	if !e.closed.CompareAndSwap(false, true) {
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
 		return nil
 	}
+	e.close()
+	e.mu.Unlock()
 
-	close(e.closeCh)
-	e.table.Delete(e.actorID)
 	e.wg.Wait()
 	return nil
+}
+
+// deactivateIfIdle closes the actor unless a waiter is armed or attached or a
+// completion is parked. A caller that loaded the actor just before the close
+// gets a closed error and is retried onto a fresh one by the router.
+func (e *executor) deactivateIfIdle() {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	if e.closed || e.armed || e.watcher != nil || e.parked != nil {
+		return
+	}
+	e.close()
+}
+
+// close must be called with mu held.
+func (e *executor) close() {
+	e.closed = true
+	close(e.closeCh)
+	e.table.CompareAndDelete(e.actorID, e)
+}
+
+func (e *executor) isClosed() bool {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	return e.closed
+}
+
+// tryDeactivate requests an idle deactivation without blocking; a full queue
+// leaves the actor in the table until the next request or a halt.
+func (e *executor) tryDeactivate() {
+	select {
+	case e.deactivateCh <- e:
+	default:
+	}
 }
 
 func (e *executor) InvokeStream(ctx context.Context,
@@ -126,14 +239,10 @@ func (e *executor) InvokeStream(ctx context.Context,
 }
 
 func (e *executor) watchComplete(ctx context.Context, stream func(*internalsv1pb.InternalInvokeResponse) (bool, error)) error {
-	defer func() {
-		e.deactivateCh <- e
-	}()
-
 	select {
 	case e.watchLock <- struct{}{}:
 	case <-e.closeCh:
-		return backoff.Permanent(errors.New("closed"))
+		return targeterrors.NewClosed("executor")
 	case <-ctx.Done():
 		return ctx.Err()
 	}
@@ -141,21 +250,78 @@ func (e *executor) watchComplete(ctx context.Context, stream func(*internalsv1pb
 		<-e.watchLock
 	}()
 
+	e.mu.Lock()
+	if e.closed {
+		e.mu.Unlock()
+		return targeterrors.NewClosed("executor")
+	}
+
+	// Attaching arms the actor, so a watcher that never called Register works
+	// as before.
+	e.armed = true
+	epoch := e.epoch
+
+	var ch chan *internalsv1pb.InternalInvokeResponse
+	defer func() {
+		e.mu.Lock()
+		if e.epoch == epoch {
+			e.watcher = nil
+			e.armed = false
+			e.parked = nil
+			e.cancelled = false
+		} else if e.watcher == ch {
+			// Superseded by a Register while still attached: a completion that
+			// landed on this stream in the meantime belongs to the new
+			// registration.
+			e.watcher = nil
+			select {
+			case d := <-ch:
+				if e.parked == nil {
+					e.parked = d
+				}
+			default:
+			}
+		}
+		e.mu.Unlock()
+		e.tryDeactivate()
+	}()
+
+	if e.cancelled {
+		e.cancelled = false
+		e.mu.Unlock()
+		_, err := stream(abortedResponse())
+		return err
+	}
+
+	if d := e.parked; d != nil {
+		e.parked = nil
+		e.mu.Unlock()
+		_, err := stream(d)
+		return err
+	}
+
+	ch = make(chan *internalsv1pb.InternalInvokeResponse, 1)
+	e.watcher = ch
+	e.mu.Unlock()
+
 	select {
 	case <-ctx.Done():
 		return ctx.Err()
 	case <-e.closeCh:
+		// Only a halt closes an actor with an attached watcher; abort the turn
+		// rather than retry against a moved actor.
 		return backoff.Permanent(errors.New("closed"))
-	case <-e.cancelCh:
-		_, err := stream(&internalsv1pb.InternalInvokeResponse{
-			Status: &internalsv1pb.Status{
-				Code: int32(codes.Aborted),
-			},
-		})
-		return err
-	case d := <-e.completeCh:
+	case d := <-ch:
 		_, err := stream(d)
 		return err
+	}
+}
+
+func abortedResponse() *internalsv1pb.InternalInvokeResponse {
+	return &internalsv1pb.InternalInvokeResponse{
+		Status: &internalsv1pb.Status{
+			Code: int32(codes.Aborted),
+		},
 	}
 }
 

--- a/pkg/actors/targets/workflow/executor/executor.go
+++ b/pkg/actors/targets/workflow/executor/executor.go
@@ -214,13 +214,11 @@ func (e *executor) isClosed() bool {
 	return e.closed
 }
 
-// tryDeactivate requests an idle deactivation without blocking; a full queue
-// leaves the actor in the table until the next request or a halt.
-func (e *executor) tryDeactivate() {
-	select {
-	case e.deactivateCh <- e:
-	default:
-	}
+// requestDeactivate queues an idle deactivation. The send blocks on a full
+// queue so every idle actor is examined; the drain goroutine never waits on
+// the caller, so this cannot deadlock.
+func (e *executor) requestDeactivate() {
+	e.deactivateCh <- e
 }
 
 func (e *executor) InvokeStream(ctx context.Context,
@@ -283,7 +281,7 @@ func (e *executor) watchComplete(ctx context.Context, stream func(*internalsv1pb
 			}
 		}
 		e.mu.Unlock()
-		e.tryDeactivate()
+		e.requestDeactivate()
 	}()
 
 	if e.cancelled {

--- a/pkg/actors/targets/workflow/executor/executor_test.go
+++ b/pkg/actors/targets/workflow/executor/executor_test.go
@@ -1,0 +1,491 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package executor
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+
+	targeterrors "github.com/dapr/dapr/pkg/actors/targets/errors"
+	invokev1 "github.com/dapr/dapr/pkg/messaging/v1"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+)
+
+const (
+	testActorType = "dapr.internal.default.test.executor"
+	testActorID   = "abc"
+)
+
+// newTestFactory builds a factory without placement and drains its
+// deactivation queue like New does.
+func newTestFactory(t *testing.T) *factory {
+	t.Helper()
+	f := &factory{
+		actorType:    testActorType,
+		deactivateCh: make(chan *executor, 100),
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for e := range f.deactivateCh {
+			e.deactivateIfIdle()
+		}
+	}()
+	t.Cleanup(func() {
+		close(f.deactivateCh)
+		<-done
+	})
+	return f
+}
+
+func methodReq(method string) *internalsv1pb.InternalInvokeRequest {
+	return internalsv1pb.NewInternalInvokeRequest(method).
+		WithActor(testActorType, testActorID).
+		WithContentType(invokev1.ProtobufContentType)
+}
+
+func completeReq(data []byte) *internalsv1pb.InternalInvokeRequest {
+	return methodReq(MethodComplete).WithData(data)
+}
+
+type watchResult struct {
+	res *internalsv1pb.InternalInvokeResponse
+	err error
+}
+
+// watch attaches a WatchComplete stream and reports its single response or
+// error.
+func watch(ctx context.Context, e *executor) <-chan watchResult {
+	out := make(chan watchResult, 1)
+	go func() {
+		var got *internalsv1pb.InternalInvokeResponse
+		err := e.InvokeStream(ctx, methodReq(MethodWatchComplete), func(r *internalsv1pb.InternalInvokeResponse) (bool, error) {
+			got = r
+			return true, nil
+		})
+		out <- watchResult{res: got, err: err}
+	}()
+	return out
+}
+
+func waitAttached(t *testing.T, e *executor) {
+	t.Helper()
+	require.Eventually(t, func() bool {
+		e.mu.Lock()
+		defer e.mu.Unlock()
+		return e.watcher != nil
+	}, 5*time.Second, time.Millisecond)
+}
+
+func register(t *testing.T, e *executor) {
+	t.Helper()
+	_, err := e.InvokeMethod(t.Context(), methodReq(MethodRegister))
+	require.NoError(t, err)
+}
+
+func complete(t *testing.T, e *executor, data string) {
+	t.Helper()
+	_, err := e.InvokeMethod(t.Context(), completeReq([]byte(data)))
+	require.NoError(t, err)
+}
+
+func payload(res *internalsv1pb.InternalInvokeResponse) string {
+	return string(res.GetMessage().GetData().GetValue())
+}
+
+func Test_unregisteredCompletionNeverAnswersRegisteredWaiter(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	complete(t, e, "orphan")
+
+	e.mu.Lock()
+	assert.NotNil(t, e.parked)
+	e.mu.Unlock()
+
+	register(t, e)
+	e.mu.Lock()
+	assert.Nil(t, e.parked, "a registration discards the unregistered completion")
+	e.mu.Unlock()
+
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	res := <-watch(ctx, e)
+	require.ErrorIs(t, res.err, context.DeadlineExceeded)
+	assert.Nil(t, res.res, "the orphan completion must not answer the next waiter")
+}
+
+func Test_unregisteredWatcherTakesUnregisteredCompletion(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	// A pre-Register daprd: completion first, then a bare watch.
+	complete(t, e, "legacy")
+	e.deactivateIfIdle()
+	assert.False(t, e.isClosed(), "a parked completion keeps the actor alive")
+
+	res := <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, "legacy", payload(res.res))
+
+	require.Eventually(t, e.isClosed, 5*time.Second, time.Millisecond)
+}
+
+func Test_registerParkedThenWatch(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	complete(t, e, "one")
+
+	res := <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, "one", payload(res.res))
+}
+
+func Test_registerWatchThenComplete(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	out := watch(t.Context(), e)
+	waitAttached(t, e)
+	complete(t, e, "live")
+
+	res := <-out
+	require.NoError(t, res.err)
+	assert.Equal(t, "live", payload(res.res))
+}
+
+func Test_watchWithoutRegisterStillReceives(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	out := watch(t.Context(), e)
+	waitAttached(t, e)
+	complete(t, e, "legacy")
+
+	res := <-out
+	require.NoError(t, res.err)
+	assert.Equal(t, "legacy", payload(res.res))
+}
+
+func Test_duplicateCompletionIsDropped(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	complete(t, e, "first")
+	complete(t, e, "second")
+
+	res := <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, "first", payload(res.res))
+
+	// Nothing is left for a later waiter.
+	e = next(t, f, e)
+	register(t, e)
+	ctx, cancel := context.WithTimeout(t.Context(), 200*time.Millisecond)
+	defer cancel()
+	res = <-watch(ctx, e)
+	require.ErrorIs(t, res.err, context.DeadlineExceeded)
+}
+
+// e2 returns the live executor for the test actor ID.
+func e2(t *testing.T, f *factory) *executor {
+	t.Helper()
+	return f.GetOrCreate(testActorID).(*executor)
+}
+
+// next waits for prev's idle deactivation and returns its successor, so the
+// test does not race the deactivation queue the way the router's closed-actor
+// retry absorbs in production.
+func next(t *testing.T, f *factory, prev *executor) *executor {
+	t.Helper()
+	require.Eventually(t, prev.isClosed, 5*time.Second, time.Millisecond)
+	return e2(t, f)
+}
+
+func Test_watcherDepartureDiscardsLateCompletion(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	ctx, cancel := context.WithCancel(t.Context())
+	out := watch(ctx, e)
+	waitAttached(t, e)
+	cancel()
+	res := <-out
+	require.ErrorIs(t, res.err, context.Canceled)
+
+	// The aborted execution's late response lands on the successor, where it
+	// is parked with no registration.
+	live := next(t, f, e)
+	complete(t, live, "late")
+
+	// The retried turn's registration discards it and gets only its own.
+	register(t, live)
+	live.mu.Lock()
+	assert.Nil(t, live.parked)
+	live.mu.Unlock()
+	complete(t, live, "fresh")
+	res = <-watch(t.Context(), live)
+	require.NoError(t, res.err)
+	assert.Equal(t, "fresh", payload(res.res))
+}
+
+func Test_registerDiscardsStaleParked(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	// A registration whose watcher never came leaves a stale parked payload.
+	register(t, e)
+	complete(t, e, "stale")
+
+	register(t, e)
+	e.mu.Lock()
+	assert.Nil(t, e.parked)
+	e.mu.Unlock()
+
+	complete(t, e, "fresh")
+	res := <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, "fresh", payload(res.res))
+}
+
+func Test_idleDeactivation(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	// Armed: an idle deactivation request is a no-op.
+	register(t, e)
+	e.deactivateIfIdle()
+	assert.False(t, e.isClosed())
+	assert.Same(t, e, f.GetOrCreate(testActorID))
+
+	// Attached: still a no-op.
+	out := watch(t.Context(), e)
+	waitAttached(t, e)
+	e.deactivateIfIdle()
+	assert.False(t, e.isClosed())
+
+	complete(t, e, "one")
+	res := <-out
+	require.NoError(t, res.err)
+
+	// The watcher's exit deactivates the idle actor.
+	require.Eventually(t, e.isClosed, 5*time.Second, time.Millisecond)
+	require.Eventually(t, func() bool { return !f.Exists(testActorID) }, 5*time.Second, time.Millisecond)
+
+	_, err := e.InvokeMethod(t.Context(), methodReq(MethodRegister))
+	require.True(t, targeterrors.IsClosed(err), "a call landing on the closed actor must be retriable: %v", err)
+	_, err = e.InvokeMethod(t.Context(), completeReq([]byte("x")))
+	require.True(t, targeterrors.IsClosed(err))
+	err = e.InvokeStream(t.Context(), methodReq(MethodWatchComplete), func(*internalsv1pb.InternalInvokeResponse) (bool, error) { return true, nil })
+	require.True(t, targeterrors.IsClosed(err))
+
+	fresh := f.GetOrCreate(testActorID).(*executor)
+	assert.NotSame(t, e, fresh)
+	assert.False(t, fresh.isClosed())
+}
+
+func Test_getOrCreateSkipsClosedEntry(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	// Closed but still in the table, as a load racing the close observes.
+	e.mu.Lock()
+	e.closed = true
+	close(e.closeCh)
+	e.mu.Unlock()
+
+	fresh := f.GetOrCreate(testActorID).(*executor)
+	assert.NotSame(t, e, fresh)
+	assert.False(t, fresh.isClosed())
+	assert.Same(t, fresh, f.GetOrCreate(testActorID))
+}
+
+func Test_forcedDeactivateAbortsAttachedWatcher(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	out := watch(t.Context(), e)
+	waitAttached(t, e)
+
+	require.NoError(t, e.Deactivate(t.Context()))
+	res := <-out
+	var perm *backoff.PermanentError
+	require.ErrorAs(t, res.err, &perm, "a halt must abort the turn, not retry it")
+	assert.False(t, f.Exists(testActorID))
+}
+
+func Test_cancel(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	// Cancel is idempotent and a no-op with nothing armed.
+	_, err := e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+	_, err = e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+
+	// Cancel before the watcher attaches.
+	register(t, e)
+	_, err = e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+	res := <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, int32(codes.Aborted), res.res.GetStatus().GetCode())
+
+	// Cancel with the watcher attached.
+	e = next(t, f, e)
+	register(t, e)
+	out := watch(t.Context(), e)
+	waitAttached(t, e)
+	_, err = e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+	res = <-out
+	require.NoError(t, res.err)
+	assert.Equal(t, int32(codes.Aborted), res.res.GetStatus().GetCode())
+
+	// A cancel with nothing registered aborts the next unregistered watcher,
+	// as before, and is reset by a registration.
+	e = next(t, f, e)
+	_, err = e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+	res = <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, int32(codes.Aborted), res.res.GetStatus().GetCode())
+
+	e = next(t, f, e)
+	_, err = e.InvokeMethod(t.Context(), methodReq(MethodCancel))
+	require.NoError(t, err)
+	register(t, e)
+	complete(t, e, "after-cancel")
+	res = <-watch(t.Context(), e)
+	require.NoError(t, res.err)
+	assert.Equal(t, "after-cancel", payload(res.res))
+}
+
+func Test_registerWithAttachedWatcherKeepsSerialization(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	register(t, e)
+	first := watch(t.Context(), e)
+	waitAttached(t, e)
+
+	// A registration for the same key while a watcher is attached (an
+	// activity of a previous generation still in flight) neither aborts it
+	// nor lets a later watcher jump the queue.
+	register(t, e)
+	second := watch(t.Context(), e)
+
+	complete(t, e, "one")
+	res := <-first
+	require.NoError(t, res.err)
+	assert.Equal(t, "one", payload(res.res))
+
+	waitAttached(t, e)
+	complete(t, e, "two")
+	res = <-second
+	require.NoError(t, res.err)
+	assert.Equal(t, "two", payload(res.res))
+}
+
+// Test_tightLoopTurns models the ContinueAsNew tight loop: back-to-back
+// exchanges on one key, each racing the previous turn's idle deactivation.
+func Test_tightLoopTurns(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+
+	for i := range 5_000 {
+		want := []byte{byte(i), byte(i >> 8)}
+
+		var e *executor
+		for {
+			e = f.GetOrCreate(testActorID).(*executor)
+			_, err := e.InvokeMethod(t.Context(), methodReq(MethodRegister))
+			if err == nil {
+				break
+			}
+			require.True(t, targeterrors.IsClosed(err), "iteration %d: %v", i, err)
+		}
+
+		// The completion races the watcher attaching, as in production.
+		go func() {
+			for {
+				_, err := e.InvokeMethod(t.Context(), completeReq(want))
+				if err == nil || !targeterrors.IsClosed(err) {
+					return
+				}
+				e = f.GetOrCreate(testActorID).(*executor)
+			}
+		}()
+
+		select {
+		case res := <-watch(t.Context(), e):
+			require.NoError(t, res.err, "iteration %d", i)
+			require.Equal(t, want, res.res.GetMessage().GetData().GetValue(), "iteration %d received another turn's completion", i)
+		case <-time.After(10 * time.Second):
+			t.Fatalf("iteration %d: completion neither parked nor delivered", i)
+		}
+	}
+}
+
+func Test_unknownMethod(t *testing.T) {
+	t.Parallel()
+
+	f := newTestFactory(t)
+	e := f.GetOrCreate(testActorID).(*executor)
+
+	_, err := e.InvokeMethod(t.Context(), methodReq("Nope"))
+	require.Error(t, err)
+	assert.False(t, targeterrors.IsClosed(err))
+	assert.NotErrorIs(t, err, context.Canceled)
+}

--- a/pkg/actors/targets/workflow/executor/factory.go
+++ b/pkg/actors/targets/workflow/executor/factory.go
@@ -21,15 +21,7 @@ import (
 	"github.com/dapr/dapr/pkg/actors/api"
 	"github.com/dapr/dapr/pkg/actors/internal/placement"
 	"github.com/dapr/dapr/pkg/actors/targets"
-	"github.com/dapr/dapr/pkg/actors/targets/workflow/common/lock"
-	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
 )
-
-func newExecutor() *executor {
-	return &executor{
-		lock: lock.New(),
-	}
-}
 
 type Options struct {
 	Actors actors.Interface
@@ -56,7 +48,7 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 	deactivateCh := make(chan *executor, 100)
 	go func() {
 		for executor := range deactivateCh {
-			executor.Deactivate(ctx)
+			executor.deactivateIfIdle()
 		}
 	}()
 
@@ -67,29 +59,29 @@ func New(ctx context.Context, opts Options) (targets.Factory, error) {
 	}, nil
 }
 
+// GetOrCreate replaces a closed entry that has not yet left the table.
 func (f *factory) GetOrCreate(actorID string) targets.Interface {
-	a, ok := f.table.Load(actorID)
-	if !ok {
-		fresh := f.initExecutor(newExecutor(), actorID)
-		a, _ = f.table.LoadOrStore(actorID, fresh)
-	}
+	for {
+		a, ok := f.table.Load(actorID)
+		if !ok {
+			a, _ = f.table.LoadOrStore(actorID, f.newExecutor(actorID))
+		}
 
-	return a.(*executor)
+		e := a.(*executor)
+		if !e.isClosed() {
+			return e
+		}
+		f.table.CompareAndDelete(actorID, e)
+	}
 }
 
-func (f *factory) initExecutor(a any, actorID string) *executor {
-	act := a.(*executor)
-
-	act.factory = f
-	act.actorID = actorID
-
-	act.closed.Store(false)
-	act.completeCh = make(chan *internalsv1pb.InternalInvokeResponse, 1)
-	act.cancelCh = make(chan struct{})
-	act.closeCh = make(chan struct{})
-	act.watchLock = make(chan struct{}, 1)
-
-	return act
+func (f *factory) newExecutor(actorID string) *executor {
+	return &executor{
+		factory:   f,
+		actorID:   actorID,
+		closeCh:   make(chan struct{}),
+		watchLock: make(chan struct{}, 1),
+	}
 }
 
 func (f *factory) HaltAll(ctx context.Context) error {
@@ -114,7 +106,6 @@ func (f *factory) HaltNonHosted(ctx context.Context, fn func(*api.LookupActorReq
 			ActorID:   key.(string),
 		}) {
 			val.(*executor).Deactivate(ctx)
-			f.table.Delete(key)
 		}
 		return true
 	})

--- a/pkg/actors/targets/workflow/orchestrator/run.go
+++ b/pkg/actors/targets/workflow/orchestrator/run.go
@@ -18,6 +18,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strconv"
 	"strings"
 	"time"
 
@@ -327,6 +328,19 @@ func (o *orchestrator) runWorkflow(ctx context.Context, reminder *actorapi.Remin
 	compactPatches(rs)
 	o.stripUnmatchedResolutions(state, rs)
 
+	// Reject a turn answered by a stale completion before any side effect;
+	// the recoverable error retries the turn. ContinueAsNew turns are exempt
+	// since their history was replaced and IDs restart.
+	if !rs.GetContinuedAsNew() {
+		if kind, id, stale := staleTurnDuplicate(state, rs); stale {
+			log.Warnf("Workflow actor '%s': rejecting turn whose response re-creates committed %s operation '%d' (stale completion delivery adopted across turns); retrying the turn", o.actorID, kind, id)
+			diag.DefaultWorkflowMonitoring.WorkflowLocalWake(ctx, diag.StatusStaleTurnRejected)
+			o.invalidateCachedState()
+			diagnoseStatus = diag.StatusRecoverable
+			return todo.RunCompletedFalse, wferrors.NewRecoverable(fmt.Errorf("turn response re-creates committed %s operation %d; stale completion delivery rejected", kind, id))
+		}
+	}
+
 	runtimeStatus := runtimestate.RuntimeStatus(rs)
 	log.Debugf("Workflow actor '%s': workflow execution returned with status '%s' instanceId '%s'", o.actorID, runtimeStatus.String(), wi.InstanceID)
 
@@ -613,6 +627,46 @@ func (o *orchestrator) handleRetention(ctx context.Context, status protos.Orches
 	log.Debugf("Workflow actor '%s': setting retention reminder for status '%s' with due time '%v'", o.actorID, status.String(), dueTime)
 	_, err := o.createRetentionReminder(ctx, retentionReminderName, completedAt.Add(*dueTime))
 	return err
+}
+
+// staleTurnDuplicate reports whether rs.NewEvents re-creates a task, timer or
+// child operation already present in committed history with the same ID.
+func staleTurnDuplicate(state *wfenginestate.State, rs *backend.WorkflowRuntimeState) (string, int32, bool) {
+	kindOf := func(e *backend.HistoryEvent) string {
+		switch {
+		case e.GetTaskScheduled() != nil:
+			return "task"
+		case e.GetTimerCreated() != nil:
+			return "timer"
+		case e.GetChildWorkflowInstanceCreated() != nil:
+			return "child"
+		default:
+			return ""
+		}
+	}
+
+	created := make(map[string]struct{})
+	var have bool
+	for _, e := range rs.GetNewEvents() {
+		if k := kindOf(e); k != "" {
+			created[k+"/"+strconv.FormatInt(int64(e.GetEventId()), 10)] = struct{}{}
+			have = true
+		}
+	}
+	if !have {
+		return "", 0, false
+	}
+
+	for _, e := range state.History {
+		k := kindOf(e)
+		if k == "" {
+			continue
+		}
+		if _, ok := created[k+"/"+strconv.FormatInt(int64(e.GetEventId()), 10)]; ok {
+			return k, e.GetEventId(), true
+		}
+	}
+	return "", 0, false
 }
 
 // stripUnmatchedResolutions removes from rs.NewEvents any task or child

--- a/pkg/actors/targets/workflow/orchestrator/run_test.go
+++ b/pkg/actors/targets/workflow/orchestrator/run_test.go
@@ -1097,3 +1097,76 @@ func Test_runWorkflow_pendingStartEmptyHistoryRuns(t *testing.T) {
 	require.Error(t, runErr)
 	assert.Zero(t, saves, "nothing may be committed for the abandoned healthy turn")
 }
+
+func Test_staleTurnDuplicate(t *testing.T) {
+	t.Parallel()
+
+	task := func(id int32) *backend.HistoryEvent {
+		return &protos.HistoryEvent{EventId: id, EventType: &protos.HistoryEvent_TaskScheduled{TaskScheduled: &protos.TaskScheduledEvent{Name: "act"}}}
+	}
+	timer := func(id int32) *backend.HistoryEvent {
+		return &protos.HistoryEvent{EventId: id, EventType: &protos.HistoryEvent_TimerCreated{TimerCreated: &protos.TimerCreatedEvent{}}}
+	}
+	child := func(id int32) *backend.HistoryEvent {
+		return &protos.HistoryEvent{EventId: id, EventType: &protos.HistoryEvent_ChildWorkflowInstanceCreated{ChildWorkflowInstanceCreated: &protos.ChildWorkflowInstanceCreatedEvent{Name: "child"}}}
+	}
+	completed := func(id int32) *backend.HistoryEvent {
+		return &protos.HistoryEvent{EventId: -1, EventType: &protos.HistoryEvent_TaskCompleted{TaskCompleted: &protos.TaskCompletedEvent{TaskScheduledId: id}}}
+	}
+	started := &protos.HistoryEvent{EventId: -1, EventType: &protos.HistoryEvent_ExecutionStarted{ExecutionStarted: &protos.ExecutionStartedEvent{Name: "wf"}}}
+
+	tests := map[string]struct {
+		history  []*backend.HistoryEvent
+		new      []*backend.HistoryEvent
+		wantKind string
+		wantID   int32
+		stale    bool
+	}{
+		"no new operations": {
+			history: []*backend.HistoryEvent{started, task(0)},
+			new:     []*backend.HistoryEvent{completed(0)},
+		},
+		"new operation with a fresh id": {
+			history: []*backend.HistoryEvent{started, task(0), completed(0)},
+			new:     []*backend.HistoryEvent{task(1)},
+		},
+		"same id but different kind": {
+			history: []*backend.HistoryEvent{started, task(0), completed(0)},
+			new:     []*backend.HistoryEvent{timer(0)},
+		},
+		"task re-created (the F1 stale turn)": {
+			history:  []*backend.HistoryEvent{started, task(0), completed(0)},
+			new:      []*backend.HistoryEvent{task(0)},
+			wantKind: "task",
+			wantID:   0,
+			stale:    true,
+		},
+		"timer re-created": {
+			history:  []*backend.HistoryEvent{started, timer(3)},
+			new:      []*backend.HistoryEvent{task(4), timer(3)},
+			wantKind: "timer",
+			wantID:   3,
+			stale:    true,
+		},
+		"child re-created": {
+			history:  []*backend.HistoryEvent{started, child(2)},
+			new:      []*backend.HistoryEvent{child(2)},
+			wantKind: "child",
+			wantID:   2,
+			stale:    true,
+		},
+		"empty history": {
+			new: []*backend.HistoryEvent{task(0)},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			kind, id, stale := staleTurnDuplicate(&wfenginestate.State{History: test.history}, &backend.WorkflowRuntimeState{NewEvents: test.new})
+			assert.Equal(t, test.stale, stale)
+			assert.Equal(t, test.wantKind, kind)
+			assert.Equal(t, test.wantID, id)
+		})
+	}
+}

--- a/pkg/diagnostics/workflow_monitoring.go
+++ b/pkg/diagnostics/workflow_monitoring.go
@@ -43,12 +43,14 @@ const (
 	// A status read re-asserted the start reminder of an overdue pending
 	// start; ~0 in healthy steady state.
 	StatusPendingStartRedriven = "pending_start_redriven"
-	StatusTerminated           = "terminated"
-	StatusRecoverable          = "recoverable"
-	CreateWorkflow             = "create_workflow"
-	GetWorkflow                = "get_workflow"
-	AddEvent                   = "add_event"
-	PurgeWorkflow              = "purge_workflow"
+	// A turn rejected because its response answered a superseded work item.
+	StatusStaleTurnRejected = "stale_turn_rejected"
+	StatusTerminated        = "terminated"
+	StatusRecoverable       = "recoverable"
+	CreateWorkflow          = "create_workflow"
+	GetWorkflow             = "get_workflow"
+	AddEvent                = "add_event"
+	PurgeWorkflow           = "purge_workflow"
 
 	WorkflowEvent = "event"
 	Timer         = "timer"
@@ -234,7 +236,7 @@ func (w *workflowMetrics) Init(meter view.Meter, appID, namespace string, latenc
 		return err
 	}
 
-	for _, s := range []string{StatusArmDetached, StatusArmDetachedFailed, StatusArmDetachedSkipped, StatusPendingStartRedriven} {
+	for _, s := range []string{StatusArmDetached, StatusArmDetachedFailed, StatusArmDetachedSkipped, StatusPendingStartRedriven, StatusStaleTurnRejected} {
 		stats.RecordWithOptions(context.Background(),
 			stats.WithRecorder(w.meter),
 			stats.WithTags(diagUtils.WithTags(w.localWakeCount.Name(), appIDKey, appID, namespaceKey, namespace, statusKey, s)...),

--- a/pkg/runtime/wfengine/backends/actors/clustertasks.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks.go
@@ -17,6 +17,7 @@ package actors
 import (
 	"context"
 	"errors"
+	"time"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/protobuf/proto"
@@ -35,10 +36,17 @@ type ClusterTasksBackendOptions struct {
 	ExecutorActorType string
 }
 
+// ClusterTasksBackend rendezvouses work-item waiters with completions that
+// may arrive on any daprd (WorkflowsClusteredDeployment), through the executor
+// actor keyed by the work item. The waiter registers on that actor before the
+// engine dispatches the work item (see executor.MethodRegister).
 type ClusterTasksBackend struct {
 	actors            actors.Interface
 	executorActorType string
 }
+
+// registerTimeout bounds the registration call, which has no caller context.
+const registerTimeout = 30 * time.Second
 
 func NewClusterTasksBackend(opts ClusterTasksBackendOptions) *ClusterTasksBackend {
 	return &ClusterTasksBackend{
@@ -96,16 +104,20 @@ func (be *ClusterTasksBackend) CancelActivityTask(ctx context.Context, id api.In
 }
 
 func (be *ClusterTasksBackend) WaitForActivityCompletion(req *protos.ActivityRequest) func(context.Context) (*protos.ActivityResponse, error) {
+	key := backend.GetActivityExecutionKey(
+		req.GetWorkflowInstance().GetInstanceId(),
+		req.GetTaskId(),
+	)
+
+	// Called by the engine before the work item is dispatched.
+	be.register(key)
+
 	return func(ctx context.Context) (*protos.ActivityResponse, error) {
 		router, err := be.actors.Router(ctx)
 		if err != nil {
 			return nil, err
 		}
 
-		key := backend.GetActivityExecutionKey(
-			req.GetWorkflowInstance().GetInstanceId(),
-			req.GetTaskId(),
-		)
 		sreq := internalsv1pb.
 			NewInternalInvokeRequest(executor.MethodWatchComplete).
 			WithActor(be.executorActorType, key).
@@ -176,6 +188,9 @@ func (be *ClusterTasksBackend) CancelWorkflowTask(ctx context.Context, id api.In
 }
 
 func (be *ClusterTasksBackend) WaitForWorkflowTaskCompletion(req *protos.WorkflowRequest) func(context.Context) (*protos.WorkflowResponse, error) {
+	// Called by the engine before the work item is dispatched.
+	be.register(req.GetInstanceId())
+
 	return func(ctx context.Context) (*protos.WorkflowResponse, error) {
 		router, err := be.actors.Router(ctx)
 		if err != nil {
@@ -210,5 +225,26 @@ func (be *ClusterTasksBackend) WaitForWorkflowTaskCompletion(req *protos.Workflo
 		}
 
 		return &resp, nil
+	}
+}
+
+// register arms the executor actor for key so the next completion is held for
+// this waiter and a stale one is discarded rather than delivered to it. Best
+// effort: on failure (including an executor hosted by a daprd that predates
+// Register) the watch stream alone rendezvouses, as before.
+func (be *ClusterTasksBackend) register(key string) {
+	ctx, cancel := context.WithTimeout(context.Background(), registerTimeout)
+	defer cancel()
+
+	router, err := be.actors.Router(ctx)
+	if err == nil {
+		req := internalsv1pb.
+			NewInternalInvokeRequest(executor.MethodRegister).
+			WithActor(be.executorActorType, key).
+			WithContentType(invokev1.ProtobufContentType)
+		_, err = router.Call(ctx, req)
+	}
+	if err != nil {
+		log.Warnf("Failed to register completion waiter for '%s', relying on the watch stream alone: %v", key, err)
 	}
 }

--- a/pkg/runtime/wfengine/backends/actors/clustertasks_test.go
+++ b/pkg/runtime/wfengine/backends/actors/clustertasks_test.go
@@ -1,0 +1,81 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package actors
+
+import (
+	"context"
+	"errors"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/protobuf/proto"
+
+	actorsfake "github.com/dapr/dapr/pkg/actors/fake"
+	"github.com/dapr/dapr/pkg/actors/router"
+	routerfake "github.com/dapr/dapr/pkg/actors/router/fake"
+	"github.com/dapr/dapr/pkg/actors/targets/workflow/executor"
+	commonv1pb "github.com/dapr/dapr/pkg/proto/common/v1"
+	internalsv1pb "github.com/dapr/dapr/pkg/proto/internals/v1"
+	"github.com/dapr/durabletask-go/api/protos"
+)
+
+// Test_registerBestEffort pins the rolling-upgrade contract: a Register that
+// the executor host rejects (a daprd predating the method) must not fail the
+// wait; the watch stream alone rendezvouses, as before.
+func Test_registerBestEffort(t *testing.T) {
+	t.Parallel()
+
+	var registers atomic.Int32
+	var watchKey atomic.Pointer[string]
+
+	want := &protos.WorkflowResponse{InstanceId: "abc"}
+	data, err := proto.Marshal(want)
+	require.NoError(t, err)
+
+	rtr := routerfake.New().
+		WithCallFn(func(_ context.Context, req *internalsv1pb.InternalInvokeRequest) (*internalsv1pb.InternalInvokeResponse, error) {
+			assert.Equal(t, executor.MethodRegister, req.GetMessage().GetMethod())
+			registers.Add(1)
+			return nil, errors.New("error invoke actor method: unknown method: Register")
+		}).
+		WithCallStreamFn(func(_ context.Context, req *internalsv1pb.InternalInvokeRequest, stream func(*internalsv1pb.InternalInvokeResponse) (bool, error)) error {
+			assert.Equal(t, executor.MethodWatchComplete, req.GetMessage().GetMethod())
+			key := req.GetActor().GetActorId()
+			watchKey.Store(&key)
+			_, serr := stream(&internalsv1pb.InternalInvokeResponse{
+				Status:  &internalsv1pb.Status{Code: int32(codes.OK)},
+				Message: &commonv1pb.InvokeResponse{Data: internalsv1pb.NewInternalInvokeRequest("").WithData(data).GetMessage().GetData()},
+			})
+			return serr
+		})
+
+	be := NewClusterTasksBackend(ClusterTasksBackendOptions{
+		Actors: actorsfake.New().WithRouter(func(context.Context) (router.Interface, error) {
+			return rtr, nil
+		}),
+		ExecutorActorType: "dapr.internal.default.app.executor",
+	})
+
+	wait := be.WaitForWorkflowTaskCompletion(&protos.WorkflowRequest{InstanceId: "abc"})
+	assert.Equal(t, int32(1), registers.Load())
+
+	got, err := wait(t.Context())
+	require.NoError(t, err)
+	assert.Equal(t, "abc", got.GetInstanceId())
+	require.NotNil(t, watchKey.Load())
+	assert.Equal(t, "abc", *watchKey.Load())
+}

--- a/tests/integration/foo
+++ b/tests/integration/foo
@@ -1,1 +1,0 @@
-FAIL	github.com/dapr/dapr/tests/integration [build failed]

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -594,6 +594,17 @@ func (d *Daprd) SignalHUP(t *testing.T) {
 	d.exec.SignalHUP(t)
 }
 
+// ActiveActorCount returns the number of live actors of actorType reported by
+// the actor runtime, and whether the type is hosted at all.
+func (d *Daprd) ActiveActorCount(t assert.TestingT, ctx context.Context, actorType string) (int, bool) {
+	for _, a := range d.GetMetaActorRuntime(t, ctx).ActiveActors {
+		if a.Type == actorType {
+			return a.Count, true
+		}
+	}
+	return 0, false
+}
+
 // WaitUntilActorTypeHosted blocks until the actor runtime reports actorType
 // among its hosted types. A restarted daprd re-registers its actor types
 // after it becomes healthy, so an invocation right after WaitUntilRunning can

--- a/tests/integration/framework/workflow/workflow.go
+++ b/tests/integration/framework/workflow/workflow.go
@@ -15,6 +15,7 @@ package workflow
 
 import (
 	"context"
+	"sync"
 	"testing"
 	"time"
 
@@ -86,4 +87,32 @@ func ChildCompletions(t *testing.T, ctx context.Context, client *client.TaskHubG
 		}
 	}
 	return completed, failed
+}
+
+// WaitForAllCompleted waits for every instance to reach COMPLETED and fails
+// listing the ones that did not.
+func WaitForAllCompleted(t *testing.T, ctx context.Context, client *client.TaskHubGrpcClient, ids ...api.InstanceID) {
+	t.Helper()
+
+	var lock sync.Mutex
+	var wg sync.WaitGroup
+	failed := make(map[api.InstanceID]string)
+	for _, id := range ids {
+		wg.Add(1)
+		go func(id api.InstanceID) {
+			defer wg.Done()
+			meta, err := client.WaitForWorkflowCompletion(ctx, id)
+			lock.Lock()
+			defer lock.Unlock()
+			switch {
+			case err != nil:
+				failed[id] = err.Error()
+			case meta.GetRuntimeStatus() != protos.OrchestrationStatus_ORCHESTRATION_STATUS_COMPLETED:
+				failed[id] = meta.GetRuntimeStatus().String()
+			}
+		}(id)
+	}
+	wg.Wait()
+
+	assert.Empty(t, failed, "%d of %d instances did not complete", len(failed), len(ids))
 }

--- a/tests/integration/suite/daprd/workflow/loadbalance/canactivity.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/canactivity.go
@@ -1,0 +1,95 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(canactivity))
+}
+
+// canactivity runs ContinueAsNew loops with one activity per generation across
+// a clustered deployment.
+type canactivity struct {
+	workflow *workflow.Workflow
+}
+
+func (c *canactivity) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.NewClustered(t, 3)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *canactivity) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		daprds      = 3
+		generations = 5
+		instances   = 50
+	)
+
+	for i := range daprds {
+		reg := c.workflow.RegistryN(i)
+		require.NoError(t, reg.AddWorkflowN("can-activity", func(ctx *task.WorkflowContext) (any, error) {
+			var gen int
+			if err := ctx.GetInput(&gen); err != nil {
+				return nil, err
+			}
+			if err := ctx.CallActivity("noop", task.WithActivityInput(gen)).Await(nil); err != nil {
+				return nil, err
+			}
+			if gen < generations {
+				ctx.ContinueAsNew(gen + 1)
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddActivityN("noop", func(task.ActivityContext) (any, error) {
+			return nil, nil
+		}))
+	}
+
+	clients := make([]*client.TaskHubGrpcClient, daprds)
+	for i := range daprds {
+		clients[i] = c.workflow.BackendClientN(t, ctx, i)
+	}
+
+	ids := make([]api.InstanceID, instances)
+	for i := range instances {
+		ids[i] = api.InstanceID(fmt.Sprintf("can-activity-%d", i))
+		_, err := clients[i%daprds].ScheduleNewWorkflow(ctx, "can-activity",
+			api.WithInstanceID(ids[i]),
+			api.WithInput(0),
+		)
+		require.NoError(t, err)
+	}
+
+	fworkflow.WaitForAllCompleted(t, ctx, clients[0], ids...)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/canchild.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/canchild.go
@@ -1,0 +1,113 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(canchild))
+}
+
+// canchild runs ContinueAsNew loops that create a child workflow with an
+// activity per generation across a clustered deployment.
+type canchild struct {
+	workflow *workflow.Workflow
+}
+
+func (c *canchild) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.NewClustered(t, 3)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *canchild) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		daprds      = 3
+		generations = 4
+		instances   = 30
+	)
+
+	for i := range daprds {
+		reg := c.workflow.RegistryN(i)
+		require.NoError(t, reg.AddWorkflowN("can-parent", func(ctx *task.WorkflowContext) (any, error) {
+			var gen int
+			if err := ctx.GetInput(&gen); err != nil {
+				return nil, err
+			}
+			var out int
+			err := ctx.CallChildWorkflow("can-child",
+				task.WithChildWorkflowInput(gen),
+				task.WithChildWorkflowInstanceID(fmt.Sprintf("%s-child-%d", ctx.ID, gen)),
+			).Await(&out)
+			if err != nil {
+				return nil, err
+			}
+			if out != gen {
+				return nil, fmt.Errorf("child of generation %d returned %d", gen, out)
+			}
+			if gen < generations {
+				ctx.ContinueAsNew(gen + 1)
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddWorkflowN("can-child", func(ctx *task.WorkflowContext) (any, error) {
+			var gen int
+			if err := ctx.GetInput(&gen); err != nil {
+				return nil, err
+			}
+			if err := ctx.CallActivity("noop", task.WithActivityInput(gen)).Await(nil); err != nil {
+				return nil, err
+			}
+			return gen, nil
+		}))
+		require.NoError(t, reg.AddActivityN("noop", func(task.ActivityContext) (any, error) {
+			return nil, nil
+		}))
+	}
+
+	clients := make([]*client.TaskHubGrpcClient, daprds)
+	for i := range daprds {
+		clients[i] = c.workflow.BackendClientN(t, ctx, i)
+	}
+
+	ids := make([]api.InstanceID, instances)
+	for i := range instances {
+		ids[i] = api.InstanceID(fmt.Sprintf("can-child-%d", i))
+		_, err := clients[i%daprds].ScheduleNewWorkflow(ctx, "can-parent",
+			api.WithInstanceID(ids[i]),
+			api.WithInput(0),
+		)
+		require.NoError(t, err)
+	}
+
+	fworkflow.WaitForAllCompleted(t, ctx, clients[0], ids...)
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/executoridle.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/executoridle.go
@@ -1,0 +1,103 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(executoridle))
+}
+
+// executoridle runs a burst of clustered work items and requires every
+// executor rendezvous actor to be deactivated once the work is done.
+type executoridle struct {
+	workflow *workflow.Workflow
+}
+
+func (e *executoridle) Setup(t *testing.T) []framework.Option {
+	e.workflow = workflow.NewClustered(t, 3)
+
+	return []framework.Option{
+		framework.WithProcesses(e.workflow),
+	}
+}
+
+func (e *executoridle) Run(t *testing.T, ctx context.Context) {
+	e.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		daprds    = 3
+		instances = 150
+		fanWidth  = 4
+	)
+
+	for i := range daprds {
+		reg := e.workflow.RegistryN(i)
+		require.NoError(t, reg.AddWorkflowN("burst", func(ctx *task.WorkflowContext) (any, error) {
+			tasks := make([]task.Task, fanWidth)
+			for j := range fanWidth {
+				tasks[j] = ctx.CallActivity("noop", task.WithActivityInput(j))
+			}
+			for _, tk := range tasks {
+				if err := tk.Await(nil); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddActivityN("noop", func(task.ActivityContext) (any, error) {
+			return nil, nil
+		}))
+	}
+
+	clients := make([]*client.TaskHubGrpcClient, daprds)
+	for i := range daprds {
+		clients[i] = e.workflow.BackendClientN(t, ctx, i)
+	}
+
+	ids := make([]api.InstanceID, instances)
+	for i := range instances {
+		ids[i] = api.InstanceID(fmt.Sprintf("burst-%d", i))
+		_, err := clients[i%daprds].ScheduleNewWorkflow(ctx, "burst", api.WithInstanceID(ids[i]))
+		require.NoError(t, err)
+	}
+
+	fworkflow.WaitForAllCompleted(t, ctx, clients[0], ids...)
+
+	d := e.workflow.Dapr()
+	executorType := fmt.Sprintf("dapr.internal.%s.%s.executor", d.Namespace(), d.AppID())
+	for i := range daprds {
+		assert.EventuallyWithT(t, func(col *assert.CollectT) {
+			count, hosted := e.workflow.DaprN(i).ActiveActorCount(col, ctx, executorType)
+			assert.True(col, hosted, "executor actor type not hosted")
+			assert.Zero(col, count, "executor actors left active")
+		}, 30*time.Second, 10*time.Millisecond)
+	}
+}

--- a/tests/integration/suite/daprd/workflow/loadbalance/scatter.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/scatter.go
@@ -1,0 +1,139 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package loadbalance
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	fgrpc "github.com/dapr/dapr/tests/integration/framework/grpc"
+	"github.com/dapr/dapr/tests/integration/framework/iowriter/logger"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	fworkflow "github.com/dapr/dapr/tests/integration/framework/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/client"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(scatter))
+}
+
+// scatter runs workers behind a per-call round-robin load balancer over a
+// clustered deployment, so completion calls land on any daprd.
+type scatter struct {
+	workflow *workflow.Workflow
+}
+
+func (s *scatter) Setup(t *testing.T) []framework.Option {
+	s.workflow = workflow.NewClustered(t, 3)
+
+	return []framework.Option{
+		framework.WithProcesses(s.workflow),
+	}
+}
+
+func (s *scatter) Run(t *testing.T, ctx context.Context) {
+	s.workflow.WaitUntilRunning(t, ctx)
+
+	const (
+		daprds    = 3
+		perShape  = 20
+		fanWidth  = 5
+		seqLength = 5
+	)
+
+	for i := range daprds {
+		reg := s.workflow.RegistryN(i)
+		require.NoError(t, reg.AddWorkflowN("fanout", func(ctx *task.WorkflowContext) (any, error) {
+			tasks := make([]task.Task, fanWidth)
+			for j := range fanWidth {
+				tasks[j] = ctx.CallActivity("noop", task.WithActivityInput(j))
+			}
+			for _, tk := range tasks {
+				if err := tk.Await(nil); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddWorkflowN("sequential", func(ctx *task.WorkflowContext) (any, error) {
+			for j := range seqLength {
+				if err := ctx.CallActivity("slow", task.WithActivityInput(j)).Await(nil); err != nil {
+					return nil, err
+				}
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddWorkflowN("can", func(ctx *task.WorkflowContext) (any, error) {
+			var gen int
+			if err := ctx.GetInput(&gen); err != nil {
+				return nil, err
+			}
+			if err := ctx.CallActivity("noop", task.WithActivityInput(gen)).Await(nil); err != nil {
+				return nil, err
+			}
+			if gen < 3 {
+				ctx.ContinueAsNew(gen + 1)
+			}
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddActivityN("noop", func(task.ActivityContext) (any, error) {
+			return nil, nil
+		}))
+		require.NoError(t, reg.AddActivityN("slow", func(actx task.ActivityContext) (any, error) {
+			select {
+			case <-actx.Context().Done():
+				return nil, actx.Context().Err()
+			case <-time.After(20 * time.Millisecond):
+			}
+			return nil, nil
+		}))
+	}
+
+	for i := range daprds {
+		s.workflow.BackendClientN(t, ctx, i)
+	}
+
+	conns := make([]grpc.ClientConnInterface, daprds)
+	for i := range daprds {
+		conns[i] = s.workflow.DaprN(i).GRPCConn(t, ctx)
+	}
+
+	for i := range daprds {
+		lb := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t, conns...), logger.New(t))
+		require.NoError(t, lb.StartWorkItemListener(ctx, s.workflow.RegistryN(i)))
+	}
+
+	lbClient := client.NewTaskHubGrpcClient(fgrpc.LoadBalance(t, conns...), logger.New(t))
+
+	ids := make([]api.InstanceID, 0, perShape*3)
+	for _, shape := range []string{"fanout", "sequential", "can"} {
+		for i := range perShape {
+			id := api.InstanceID(fmt.Sprintf("scatter-%s-%d", shape, i))
+			_, err := lbClient.ScheduleNewWorkflow(ctx, shape, api.WithInstanceID(id), api.WithInput(0))
+			require.NoError(t, err)
+			ids = append(ids, id)
+		}
+	}
+
+	fworkflow.WaitForAllCompleted(t, ctx, lbClient, ids...)
+}


### PR DESCRIPTION
Under WorkflowsClusteredDeployment the app's execution results reach the waiting daprd through the per-instance executor rendezvous actor, since the completion RPC can land on any daprd. The actor matched a response to a waiter by instance ID only: a response arriving with no watcher was parked, and the next watcher for the same instance took it.

The ContinueAsNew tight loop issues two executions of one instance back to back. The executor actor was deactivated asynchronously after the first, so the second watcher raced the close and failed instantly with a permanent "closed" error the router does not retry. The abandon path recovered the new generation as a pending start, but the orphaned execution's response still arrived and was parked. Every later turn was then answered by the previous turn's response: the turn delivering TaskCompleted#0 received the stale ScheduleTask#0, skipped it as already resolved, persisted a duplicate TaskScheduled#0, and the real CompleteWorkflow(CONTINUED_AS_NEW) was parked with no consumer. The instance stayed RUNNING forever. Chaos round 3 (09/09/2026) stranded 17 to 18 of 50 continue-as-new instances per run on 1.18.4-rc.4 with the feature enabled and 0 of 50 without it; every stranded history is [OS, ES, TS0, OS, TC0, TS0] with an empty inbox. Activity waiters share the hazard since task IDs restart at 0 each generation.

Fix:

- The cluster tasks backend registers the waiter on the executor actor (new Register method) inside WaitFor*Completion, which the engine calls before dispatching the work item. A registration discards any parked response, which can only belong to a superseded execution, and the next completion is held for it. The rest of the rc.4 contract is unchanged: unregistered completions park as before, watchers on one key stay serialised, and a cancel with no watcher aborts the next one.
- Idle deactivation is skipped while a registration, watcher or parked response exists. A call landing on an actor closed by a concurrent deactivation returns the retriable closed error, so the router redelivers it to a fresh actor, and GetOrCreate never returns a closed executor. Halts still close forcibly. Cancel is idempotent; the double close of cancelCh could panic before.
- Registration is best effort, so a daprd predating Register keeps working during a rolling upgrade, and pre-Register waiters keep the previous parking behaviour on a fixed host.
- Backported from master: a turn whose response re-creates a task, timer or child operation already in committed history is rejected as a stale delivery and retried instead of persisting the duplicate. Counted as stale_turn_rejected on the local-wake metric.