### PR TITLE
feat: add missing actor list reminders to http api

### DIFF
--- a/pkg/api/http/actors.go
+++ b/pkg/api/http/actors.go
@@ -207,6 +207,16 @@ func (a *api) constructActorEndpoints() []endpoints.Endpoint {
 				Name: "GetActorTimer",
 			},
 		},
+		{
+			Methods: []string{http.MethodGet},
+			Route:   "actors/{actorType}/{actorId}/reminders",
+			Version: apiVersionV1,
+			Group:   endpointGroupActorV1Misc,
+			Handler: a.onListActorReminders(),
+			Settings: endpoints.EndpointSettings{
+				Name: "ListActorReminders",
+			},
+		},
 	}
 }
 
@@ -386,41 +396,80 @@ func (a *api) onActorStateTransaction(w http.ResponseWriter, r *http.Request) {
 	respondWithEmpty(w)
 }
 
+// actorReminderJSON is the HTTP representation of a reminder, shared by the
+// get and list endpoints. Name is only populated by the list endpoint.
+type actorReminderJSON struct {
+	Name      string          `json:"name,omitempty"`
+	ActorID   string          `json:"actorID,omitempty"`
+	ActorType string          `json:"actorType,omitempty"`
+	Data      json.RawMessage `json:"data,omitempty"`
+	DueTime   *string         `json:"dueTime,omitempty"`
+	Period    *string         `json:"period,omitempty"`
+	TTL       *string         `json:"ttl,omitempty"`
+}
+
+func newActorReminderJSON(name, actorType, actorID string, dueTime, period, ttl *string, data *anypb.Any) (actorReminderJSON, error) {
+	d, err := anyToRawJSON(data)
+	if err != nil {
+		return actorReminderJSON{}, err
+	}
+	return actorReminderJSON{
+		Name:      name,
+		ActorID:   actorID,
+		ActorType: actorType,
+		Data:      d,
+		DueTime:   dueTime,
+		Period:    period,
+		TTL:       ttl,
+	}, nil
+}
+
 func (a *api) onGetActorReminder() http.HandlerFunc {
 	return UniversalHTTPHandler(
 		a.universal.GetActorReminder,
 		UniversalHTTPHandlerOpts[*runtimev1pb.GetActorReminderRequest, *runtimev1pb.GetActorReminderResponse]{
 			SkipInputBody: true,
 			OutModifier: func(out *runtimev1pb.GetActorReminderResponse) (any, error) {
-				//nolint:protogetter
-				m := struct {
-					ActorID   string          `json:"actorID,omitempty"`
-					ActorType string          `json:"actorType,omitempty"`
-					Data      json.RawMessage `json:"data,omitempty"`
-					DueTime   *string         `json:"dueTime,omitempty"`
-					Period    *string         `json:"period,omitempty"`
-					TTL       *string         `json:"ttl,omitempty"`
-				}{
-					ActorID:   out.ActorId,
-					ActorType: out.ActorType,
-					DueTime:   out.DueTime,
-					Period:    out.Period,
-					TTL:       out.Ttl,
-				}
-
-				var err error
-				m.Data, err = anyToRawJSON(out.GetData())
-				if err != nil {
-					return nil, err
-				}
-
-				return m, nil
+				return newActorReminderJSON("", out.GetActorType(), out.GetActorId(), out.DueTime, out.Period, out.Ttl, out.GetData())
 			},
 			InModifier: func(r *http.Request, in *runtimev1pb.GetActorReminderRequest) (*runtimev1pb.GetActorReminderRequest, error) {
 				in.ActorType = chi.URLParam(r, actorTypeParam)
 				in.ActorId = chi.URLParam(r, actorIDParam)
 				in.Name = chi.URLParam(r, nameParam)
 				return in, nil
+			},
+		},
+	)
+}
+
+// onListActorReminders lists the reminders of a single actor. The gRPC
+// ListActorReminders also supports listing a whole actor type; that has no
+// natural route in the actors HTTP API, so it is not exposed here.
+func (a *api) onListActorReminders() http.HandlerFunc {
+	return UniversalHTTPHandler(
+		a.universal.ListActorReminders,
+		UniversalHTTPHandlerOpts[*runtimev1pb.ListActorRemindersRequest, *runtimev1pb.ListActorRemindersResponse]{
+			SkipInputBody: true,
+			InModifier: func(r *http.Request, in *runtimev1pb.ListActorRemindersRequest) (*runtimev1pb.ListActorRemindersRequest, error) {
+				in.ActorType = chi.URLParam(r, actorTypeParam)
+				in.ActorId = new(chi.URLParam(r, actorIDParam))
+				return in, nil
+			},
+			OutModifier: func(out *runtimev1pb.ListActorRemindersResponse) (any, error) {
+				// Always a non-nil slice so an empty list serializes as [].
+				reminders := make([]actorReminderJSON, 0, len(out.GetReminders()))
+				for _, nr := range out.GetReminders() {
+					r := nr.GetReminder()
+					m, err := newActorReminderJSON(nr.GetName(), r.GetActorType(), r.GetActorId(), r.DueTime, r.Period, r.Ttl, r.GetData())
+					if err != nil {
+						return nil, err
+					}
+					reminders = append(reminders, m)
+				}
+
+				return struct {
+					Reminders []actorReminderJSON `json:"reminders"`
+				}{Reminders: reminders}, nil
 			},
 		},
 	)

--- a/pkg/api/http/actors_tracing_test.go
+++ b/pkg/api/http/actors_tracing_test.go
@@ -44,6 +44,7 @@ func TestAppendActorReminderTimerSpanAttributesFn(t *testing.T) {
 		{"create reminder", http.MethodPost, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "RegisterActorReminder", "RegisterActorReminder/OrderActor"},
 		{"delete reminder", http.MethodDelete, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "UnregisterActorReminder", "UnregisterActorReminder/OrderActor"},
 		{"get reminder", http.MethodGet, "/v1.0/actors/OrderActor/order-123/reminders/CancelOrder", "GetActorReminder", "GetActorReminder/OrderActor"},
+		{"list reminders", http.MethodGet, "/v1.0/actors/OrderActor/order-123/reminders", "ListActorReminders", "ListActorReminders/OrderActor"},
 		{"create timer", http.MethodPost, "/v1.0/actors/OrderActor/order-123/timers/Refresh", "RegisterActorTimer", "RegisterActorTimer/OrderActor"},
 		{"delete timer", http.MethodDelete, "/v1.0/actors/OrderActor/order-123/timers/Refresh", "UnregisterActorTimer", "UnregisterActorTimer/OrderActor"},
 		{"list timers", http.MethodGet, "/v1.0/actors/OrderActor/order-123/timers", "ListActorTimers", "ListActorTimers/OrderActor"},

--- a/pkg/api/http/http_test.go
+++ b/pkg/api/http/http_test.go
@@ -1069,6 +1069,7 @@ func TestV1ActorEndpoints(t *testing.T) {
 	t.Run("Actor runtime is not initialized", func(t *testing.T) {
 		apisAndMethods := map[string][]string{
 			"v1.0/actors/fakeActorType/fakeActorID/reminders/reminder1": {"POST", "PUT", "GET", "DELETE"},
+			"v1.0/actors/fakeActorType/fakeActorID/reminders":           {"GET"},
 			"v1.0/actors/fakeActorType/fakeActorID/method/method1":      {"POST", "PUT", "GET", "DELETE"},
 			"v1.0/actors/fakeActorType/fakeActorID/timers/timer1":       {"POST", "PUT", "GET", "DELETE"},
 			"v1.0/actors/fakeActorType/fakeActorID/timers":              {"GET"},
@@ -1421,6 +1422,108 @@ func TestV1ActorEndpoints(t *testing.T) {
 		// assert
 		assert.Equal(t, 403, resp.StatusCode)
 		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
+	})
+
+	t.Run("Reminder List - 200 OK", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders"
+		period := actorsapi.NewSchedulerReminderPeriod("@every 2s", 0)
+		data, err := anypb.New(wrapperspb.Bytes([]byte(`{"foo":"bar"}`)))
+		require.NoError(t, err)
+
+		actors.WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remindersfake.New().WithList(func(_ context.Context, req *actorsapi.ListRemindersRequest) ([]*actorsapi.Reminder, error) {
+				assert.Equal(t, "fakeActorType", req.ActorType)
+				require.NotNil(t, req.ActorID)
+				assert.Equal(t, "fakeActorID", *req.ActorID)
+				return []*actorsapi.Reminder{
+					{
+						ActorType: "fakeActorType",
+						ActorID:   "fakeActorID",
+						Name:      "reminder1",
+						DueTime:   "1s",
+						Period:    period,
+						Data:      data,
+					},
+					{
+						ActorType: "fakeActorType",
+						ActorID:   "fakeActorID",
+						Name:      "reminder2",
+					},
+				}, nil
+			}), nil
+		})
+
+		// act
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.JSONEq(t, `{"reminders":[
+			{"name":"reminder1","actorType":"fakeActorType","actorID":"fakeActorID","dueTime":"1s","period":"@every 2s","data":{"foo":"bar"}},
+			{"name":"reminder2","actorType":"fakeActorType","actorID":"fakeActorID"}
+		]}`, string(resp.RawBody))
+	})
+
+	t.Run("Reminder List - 200 empty list", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders"
+		actors.WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remindersfake.New(), nil
+		})
+
+		// act
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 200, resp.StatusCode)
+		assert.JSONEq(t, `{"reminders":[]}`, string(resp.RawBody))
+	})
+
+	t.Run("Reminder List - 403 when actor type is not hosted", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders"
+		actors.WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remindersfake.New().WithList(func(context.Context, *actorsapi.ListRemindersRequest) ([]*actorsapi.Reminder, error) {
+				return nil, reminders.ErrReminderOpActorNotHosted
+			}), nil
+		})
+
+		// act
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_REMINDER_NON_HOSTED", resp.ErrorBody["errorCode"])
+	})
+
+	t.Run("Reminder List - 403 on reserved internal actor type", func(t *testing.T) {
+		apiPath := "v1.0/actors/dapr.internal.default.fakeAPI.workflow/fakeActorID/reminders"
+		actors.WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remindersfake.New().WithList(func(context.Context, *actorsapi.ListRemindersRequest) ([]*actorsapi.Reminder, error) {
+				t.Fatal("reserved actor types must be rejected before reaching the reminders layer")
+				return nil, nil
+			}), nil
+		})
+
+		// act
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 403, resp.StatusCode)
+		assert.Equal(t, "ERR_ACTOR_TYPE_RESERVED", resp.ErrorBody["errorCode"])
+	})
+
+	t.Run("Reminder List - 500 on upstream error", func(t *testing.T) {
+		apiPath := "v1.0/actors/fakeActorType/fakeActorID/reminders"
+		actors.WithReminders(func(context.Context) (reminders.Interface, error) {
+			return remindersfake.New().WithList(func(context.Context, *actorsapi.ListRemindersRequest) ([]*actorsapi.Reminder, error) {
+				return nil, errors.New("UPSTREAM_ERROR")
+			}), nil
+		})
+
+		// act
+		resp := fakeServer(t).DoRequest("GET", apiPath, nil, nil)
+
+		// assert
+		assert.Equal(t, 500, resp.StatusCode)
 	})
 
 	t.Run("Reminder Get - 200 OK", func(t *testing.T) {

--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -565,6 +565,10 @@ func (d *Daprd) ActorReminderURL(actorType, actorID, method string) string {
 	return fmt.Sprintf("http://%s/v1.0/actors/%s/%s/reminders/%s", d.HTTPAddress(), actorType, actorID, method)
 }
 
+func (d *Daprd) ActorRemindersURL(actorType, actorID string) string {
+	return fmt.Sprintf("http://%s/v1.0/actors/%s/%s/reminders", d.HTTPAddress(), actorType, actorID)
+}
+
 func (d *Daprd) ActorTimerURL(actorType, actorID, name string) string {
 	return fmt.Sprintf("http://%s/v1.0/actors/%s/%s/timers/%s", d.HTTPAddress(), actorType, actorID, name)
 }

--- a/tests/integration/suite/actors/reminders/listhttp.go
+++ b/tests/integration/suite/actors/reminders/listhttp.go
@@ -1,0 +1,163 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package reminders
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	rtv1 "github.com/dapr/dapr/pkg/proto/runtime/v1"
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd/actors"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(listhttp))
+}
+
+// listhttp asserts that the reminders of a single actor can be listed over
+// HTTP, that the list is scoped to the actor, that it agrees with the gRPC
+// list, and that it tracks registrations and deletions.
+type listhttp struct {
+	actors *actors.Actors
+}
+
+func (l *listhttp) Setup(t *testing.T) []framework.Option {
+	l.actors = actors.New(t,
+		actors.WithActorTypes("foo"),
+		actors.WithActorTypeHandler("foo", func(http.ResponseWriter, *http.Request) {}),
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(l.actors),
+	}
+}
+
+func (l *listhttp) Run(t *testing.T, ctx context.Context) {
+	l.actors.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+	gclient := l.actors.Daprd().GRPCClient(t, ctx)
+
+	httpDo := func(t *testing.T, method, url, body string) (int, string) {
+		t.Helper()
+		var r io.Reader
+		if body != "" {
+			r = strings.NewReader(body)
+		}
+		req, err := http.NewRequestWithContext(ctx, method, url, r)
+		require.NoError(t, err)
+		resp, err := httpClient.Do(req)
+		require.NoError(t, err)
+		b, err := io.ReadAll(resp.Body)
+		require.NoError(t, err)
+		require.NoError(t, resp.Body.Close())
+		return resp.StatusCode, strings.TrimSpace(string(b))
+	}
+	httpList := func(t *testing.T, actorType, actorID string) (int, string) {
+		t.Helper()
+		return httpDo(t, http.MethodGet, l.actors.Daprd().ActorRemindersURL(actorType, actorID), "")
+	}
+	register := func(t *testing.T, actorID, name, body string) {
+		t.Helper()
+		code, _ := httpDo(t, http.MethodPost, l.actors.Daprd().ActorReminderURL("foo", actorID, name), body)
+		require.Equal(t, http.StatusNoContent, code)
+	}
+	assertErrorCode := func(t *testing.T, body, want string) {
+		t.Helper()
+		var apiErr struct {
+			ErrorCode string `json:"errorCode"`
+		}
+		require.NoError(t, json.Unmarshal([]byte(body), &apiErr))
+		assert.Equal(t, want, apiErr.ErrorCode)
+	}
+
+	// No reminders registered yet.
+	code, body := httpList(t, "foo", "abc-1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.JSONEq(t, `{"reminders":[]}`, body)
+
+	// Registered reminders are listed with the same representation as GET.
+	register(t, "abc-1", "r1", `{"dueTime":"1000s","period":"10s","data":"hello"}`)
+	register(t, "abc-1", "r0", `{"dueTime":"1000s","data":{"k":[1,2]}}`)
+
+	code, body = httpList(t, "foo", "abc-1")
+	assert.Equal(t, http.StatusOK, code)
+	var listed struct {
+		Reminders []map[string]any `json:"reminders"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(body), &listed))
+	require.Len(t, listed.Reminders, 2)
+	byName := make(map[string]map[string]any, 2)
+	for _, r := range listed.Reminders {
+		name, ok := r["name"].(string)
+		require.True(t, ok)
+		byName[name] = r
+	}
+	require.Contains(t, byName, "r0")
+	require.Contains(t, byName, "r1")
+	assert.Equal(t, map[string]any{
+		"name": "r1", "actorType": "foo", "actorID": "abc-1",
+		"dueTime": "1000s", "period": "@every 10s", "data": "hello",
+	}, byName["r1"])
+	assert.Equal(t, map[string]any{
+		"name": "r0", "actorType": "foo", "actorID": "abc-1",
+		"dueTime": "1000s", "data": map[string]any{"k": []any{float64(1), float64(2)}},
+	}, byName["r0"])
+
+	// HTTP and gRPC agree.
+	gresp, err := gclient.ListActorReminders(ctx, &rtv1.ListActorRemindersRequest{ActorType: "foo", ActorId: new("abc-1")})
+	require.NoError(t, err)
+	assert.Len(t, gresp.GetReminders(), 2)
+
+	// The list is scoped to the exact actor ID, not a prefix.
+	code, body = httpList(t, "foo", "abc-")
+	assert.Equal(t, http.StatusOK, code)
+	assert.JSONEq(t, `{"reminders":[]}`, body)
+
+	register(t, "abc-2", "r1", `{"dueTime":"1000s"}`)
+	code, body = httpList(t, "foo", "abc-2")
+	assert.Equal(t, http.StatusOK, code)
+	assert.JSONEq(t, `{"reminders":[{"name":"r1","actorType":"foo","actorID":"abc-2","dueTime":"1000s"}]}`, body)
+	code, body = httpList(t, "foo", "abc-1")
+	assert.Equal(t, http.StatusOK, code)
+	require.NoError(t, json.Unmarshal([]byte(body), &listed))
+	assert.Len(t, listed.Reminders, 2)
+
+	// A non-hosted actor type and a reserved internal type are rejected.
+	code, body = httpList(t, "bar", "abc-1")
+	assert.Equal(t, http.StatusForbidden, code)
+	assertErrorCode(t, body, "ERR_ACTOR_REMINDER_NON_HOSTED")
+
+	code, body = httpList(t, "dapr.internal.default."+l.actors.AppID()+".workflow", "abc-1")
+	assert.Equal(t, http.StatusForbidden, code)
+	assertErrorCode(t, body, "ERR_ACTOR_TYPE_RESERVED")
+
+	// Deleting a reminder removes it from the list.
+	code, _ = httpDo(t, http.MethodDelete, l.actors.Daprd().ActorReminderURL("foo", "abc-1", "r1"), "")
+	require.Equal(t, http.StatusNoContent, code)
+
+	code, body = httpList(t, "foo", "abc-1")
+	assert.Equal(t, http.StatusOK, code)
+	assert.JSONEq(t, `{"reminders":[{"name":"r0","actorType":"foo","actorID":"abc-1","dueTime":"1000s","data":{"k":[1,2]}}]}`, body)
+}


### PR DESCRIPTION
# Description

The gRPC API already has ListActorReminders, but the HTTP API has no equivalent, so REST clients can register, unregister and get a single reminder but cannot enumerate them. This PR adds GET /v1.0/actors/{actorType}/{actorId}/reminders, which lists the reminders registered for one actor.

This completes the HTTP/gRPC parity for reminders, matching what #10461 did for timers.

## Issue reference

-

## Checklist

Please make sure you've completed the relevant tasks for this PR, out of the following list:

- [x] Code compiles correctly
- [x] Created/updated tests
- [x] Unit tests passing
- [x] End-to-end tests passing
- [ ] Extended the documentation / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Specification has been updated / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
- [ ] Provided sample for the feature / Created issue in the <https://github.com/dapr/docs/> repo: dapr/docs#_[issue number]_
