### PR TITLE
[1.18] Workflow: fix when instance ID contains "::"

### DIFF
--- a/docs/release_notes/v1.18.5.md
+++ b/docs/release_notes/v1.18.5.md
@@ -1,0 +1,26 @@
+# Dapr 1.18.5
+
+This update contains the following bug fixes:
+- [Workflow activity results delivered to the wrong instance when the instance ID contained "::"](#workflow-activity-results-delivered-to-the-wrong-instance-when-the-instance-id-contained-)
+
+## Workflow activity results delivered to the wrong instance when the instance ID contained "::"
+
+### Problem
+
+A workflow whose instance ID contained the character sequence `::` never completed once it called an activity.
+The activity body ran, but its result was reported to a workflow instance that did not exist, was dropped with `workflow actor instance not found when reporting activity result`, and the calling workflow stayed `RUNNING` forever.
+
+### Impact
+
+You were affected if you created workflows with instance IDs containing `::` through a workflow SDK client, which uses the TaskHub gRPC API.
+The Dapr HTTP and gRPC workflow APIs reject such IDs on create, so workflows created through them were not affected.
+Affected instances could not complete and had to be purged and recreated with a different ID.
+
+### Root Cause
+
+An activity runs as an actor whose ID is the parent instance ID followed by `::<task ID>::<generation>`.
+The activity actor recovered the parent instance ID by cutting the actor ID at the first `::`, so an instance ID that itself contained `::` was truncated, and the activity addressed its completion to the truncated, nonexistent instance.
+
+### Solution
+
+The activity actor now cuts the actor ID at the last two separators, which always delimit the numeric task ID and generation, so the full parent instance ID is recovered whatever characters it contains.

--- a/pkg/actors/targets/workflow/activity/execute.go
+++ b/pkg/actors/targets/workflow/activity/execute.go
@@ -34,7 +34,12 @@ func (a *activity) executeActivity(ctx context.Context, name string, invocation 
 		return fmt.Errorf("invalid activity task event: '%s'", taskEvent.String())
 	}
 
-	endIndex := strings.Index(a.actorID, "::")
+	// The actor ID is "<instanceID>::<taskID>::<generation>". The instance ID
+	// may itself contain "::"; the two trailing components never do.
+	endIndex := strings.LastIndex(a.actorID, "::")
+	if endIndex > 0 {
+		endIndex = strings.LastIndex(a.actorID[:endIndex], "::")
+	}
 	if endIndex < 0 {
 		return fmt.Errorf("invalid activity actor ID: '%s'", a.actorID)
 	}

--- a/tests/integration/suite/daprd/workflow/basic/colonid.go
+++ b/tests/integration/suite/daprd/workflow/basic/colonid.go
@@ -1,0 +1,76 @@
+/*
+Copyright 2025 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package basic
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(colonid))
+}
+
+// colonid pins that an activity of an instance whose ID contains the activity
+// actor ID separator ("::") reports its result to that instance: the parent
+// ID is everything before the last separator, not the first.
+type colonid struct {
+	workflow *workflow.Workflow
+}
+
+func (c *colonid) Setup(t *testing.T) []framework.Option {
+	c.workflow = workflow.New(t)
+
+	return []framework.Option{
+		framework.WithProcesses(c.workflow),
+	}
+}
+
+func (c *colonid) Run(t *testing.T, ctx context.Context) {
+	c.workflow.WaitUntilRunning(t, ctx)
+
+	c.workflow.Registry().AddWorkflowN("withactivity", func(wctx *task.WorkflowContext) (any, error) {
+		var out string
+		if err := wctx.CallActivity("echo", task.WithActivityInput("in")).Await(&out); err != nil {
+			return nil, err
+		}
+		return out, nil
+	})
+	c.workflow.Registry().AddActivityN("echo", func(actx task.ActivityContext) (any, error) {
+		var in string
+		if err := actx.GetInput(&in); err != nil {
+			return nil, err
+		}
+		return in + "-done", nil
+	})
+	cl := c.workflow.BackendClient(t, ctx)
+
+	for _, id := range []api.InstanceID{"colon::id", "a::b::c", "trailing::"} {
+		_, err := cl.ScheduleNewWorkflow(ctx, "withactivity", api.WithInstanceID(id))
+		require.NoError(t, err)
+		meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+		require.NoError(t, err, id)
+		assert.Equal(t, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus(), id)
+		assert.Equal(t, `"in-done"`, meta.GetOutput().GetValue(), id)
+	}
+}


### PR DESCRIPTION
Workflow activity results delivered to the wrong instance when the instance ID contained "::"

A workflow whose instance ID contained the character sequence `::` never completed once it called an activity. The activity body ran, but its result was reported to a workflow instance that did not exist, was dropped with `workflow actor instance not found when reporting activity result`, and the calling workflow stayed `RUNNING` forever.

You were affected if you created workflows with instance IDs containing `::`. Affected instances could not complete and had to be purged and recreated with a different ID.

Root Cause

An activity runs as an actor whose ID is the parent instance ID followed by `::<task ID>::<generation>`. The activity actor recovered the parent instance ID by cutting the actor ID at the first `::`, so an instance ID that itself contained `::` was truncated, and the activity addressed its completion to the truncated, nonexistent instance.

Solution

The activity actor now cuts the actor ID at the last two separators, which always delimit the numeric task ID and generation, so the full parent instance ID is recovered whatever characters it contains.