### PR TITLE
integration: add a workflow history signing mode to the harness

### DIFF
--- a/tests/integration/framework/process/daprd/daprd.go
+++ b/tests/integration/framework/process/daprd/daprd.go
@@ -23,6 +23,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -91,6 +92,23 @@ func New(t *testing.T, fopts ...Option) *Daprd {
 	dir := t.TempDir()
 	for i, file := range opts.resourceFiles {
 		require.NoError(t, os.WriteFile(filepath.Join(dir, strconv.Itoa(i)+".yaml"), []byte(file), 0o600))
+	}
+
+	if len(opts.features) > 0 {
+		var sb strings.Builder
+		sb.WriteString(`apiVersion: dapr.io/v1alpha1
+kind: Configuration
+metadata:
+  name: featureconfig
+spec:
+  features:
+`)
+		for _, f := range slices.Compact(slices.Sorted(slices.Values(opts.features))) {
+			sb.WriteString("  - name: " + f + "\n    enabled: true\n")
+		}
+		f := filepath.Join(t.TempDir(), "features.yaml")
+		require.NoError(t, os.WriteFile(f, []byte(sb.String()), 0o600))
+		opts.configs = append(opts.configs, f)
 	}
 
 	args := []string{

--- a/tests/integration/framework/process/daprd/options.go
+++ b/tests/integration/framework/process/daprd/options.go
@@ -17,7 +17,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 	"time"
 
@@ -57,6 +56,7 @@ type options struct {
 	resourceFiles              []string
 	resourceDirs               []string
 	configs                    []string
+	features                   []string
 	placementAddresses         []string
 	logLevel                   string
 	mode                       string
@@ -230,21 +230,14 @@ func WithConfigs(configs ...string) Option {
 	}
 }
 
-// WithFeatureEnabled configures daprd with a Configuration manifest enabling
-// the given preview features.
+// WithFeatureEnabled enables the given preview features. Calls accumulate
+// into one Configuration manifest, because daprd keeps only the last
+// spec.features list it loads.
 func WithFeatureEnabled(t *testing.T, features ...string) Option {
-	var sb strings.Builder
-	sb.WriteString(`apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-  name: featureconfig
-spec:
-  features:
-`)
-	for _, f := range features {
-		sb.WriteString("  - name: " + f + "\n    enabled: true\n")
+	t.Helper()
+	return func(o *options) {
+		o.features = append(o.features, features...)
 	}
-	return WithConfigManifests(t, sb.String())
 }
 
 func WithConfigManifests(t *testing.T, manifests ...string) Option {

--- a/tests/integration/framework/process/scheduler/proxy/proxy.go
+++ b/tests/integration/framework/process/scheduler/proxy/proxy.go
@@ -15,6 +15,7 @@ package proxy
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"io"
 	"net"
@@ -28,6 +29,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/connectivity"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/status"
 
@@ -59,6 +61,11 @@ type Proxy struct {
 	upstream *grpc.ClientConn
 	client   schedulerv1pb.SchedulerClient
 
+	// serverCreds and upstreamTLS are set by WithSentry to interpose on an
+	// mTLS control plane; nil means plaintext on both legs.
+	serverCreds credentials.TransportCredentials
+	upstreamTLS *tls.Config
+
 	runOnce  sync.Once
 	done     chan struct{}
 	serveErr chan error
@@ -81,12 +88,12 @@ type armConfig struct {
 // framework process ordering. daprd should be configured with
 // daprd.WithSchedulerAddresses(proxy.Address()) instead of pointing at the
 // scheduler directly.
-func New(t *testing.T, sched *scheduler.Scheduler) *Proxy {
+func New(t *testing.T, sched *scheduler.Scheduler, fopts ...Option) *Proxy {
 	t.Helper()
 	lis := ports.Reserve(t, 1).Listener(t)
 	tcp, ok := lis.Addr().(*net.TCPAddr)
 	require.True(t, ok)
-	return &Proxy{
+	p := &Proxy{
 		sched:    sched,
 		port:     tcp.Port,
 		listener: lis,
@@ -94,6 +101,10 @@ func New(t *testing.T, sched *scheduler.Scheduler) *Proxy {
 		done:     make(chan struct{}),
 		serveErr: make(chan error, 1),
 	}
+	for _, fopt := range fopts {
+		fopt(p)
+	}
+	return p
 }
 
 // waitReady blocks until conn is Ready, returning false if the connection is
@@ -119,8 +130,12 @@ func (p *Proxy) Run(t *testing.T, ctx context.Context) {
 	p.runOnce.Do(func() {
 		p.sched.WaitUntilRunning(t, ctx)
 
+		upstreamCreds := insecure.NewCredentials()
+		if p.upstreamTLS != nil {
+			upstreamCreds = credentials.NewTLS(p.upstreamTLS.Clone())
+		}
 		conn, err := grpc.NewClient(p.sched.Address(),
-			grpc.WithTransportCredentials(insecure.NewCredentials()),
+			grpc.WithTransportCredentials(upstreamCreds),
 		)
 		require.NoError(t, err)
 		if !waitReady(ctx, conn) {
@@ -134,7 +149,11 @@ func (p *Proxy) Run(t *testing.T, ctx context.Context) {
 		p.upstream = conn
 		p.client = schedulerv1pb.NewSchedulerClient(conn)
 
-		p.grpcSrv = grpc.NewServer()
+		if p.serverCreds != nil {
+			p.grpcSrv = grpc.NewServer(grpc.Creds(p.serverCreds))
+		} else {
+			p.grpcSrv = grpc.NewServer()
+		}
 		schedulerv1pb.RegisterSchedulerServer(p.grpcSrv, p)
 
 		go func() {

--- a/tests/integration/framework/process/scheduler/proxy/tls.go
+++ b/tests/integration/framework/process/scheduler/proxy/tls.go
@@ -1,0 +1,141 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/credentials"
+
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
+)
+
+// Option configures the proxy.
+type Option func(*Proxy)
+
+// WithSentry makes the proxy a full mTLS member of the control plane. It
+// serves daprd with a leaf certificate minted from the sentry CA carrying
+// the scheduler control-plane SPIFFE identity, and dials the upstream
+// scheduler presenting the identity of the daprd app whose requests it
+// forwards (the scheduler authorizes each request against the caller's
+// SPIFFE identity, so the proxy must impersonate the app, which therefore
+// must run with the given fixed app ID). The upstream scheduler must be
+// built with scheduler.WithSentry and an ID matching its certificate DNS
+// names.
+func WithSentry(t *testing.T, sen *sentry.Sentry, namespace, appID string) Option {
+	t.Helper()
+
+	x509bundle := sen.CABundle().X509
+
+	pool := x509.NewCertPool()
+	require.True(t, pool.AppendCertsFromPEM(x509bundle.TrustAnchors))
+
+	td := spiffeid.RequireTrustDomainFromString(sen.TrustDomain(t))
+
+	mint := func(id spiffeid.ID, dns []string) tls.Certificate {
+		_, key, err := ed25519.GenerateKey(rand.Reader)
+		require.NoError(t, err)
+		tmpl := &x509.Certificate{
+			SerialNumber: big.NewInt(1),
+			NotBefore:    time.Now(),
+			NotAfter:     time.Now().Add(time.Hour),
+			DNSNames:     dns,
+			URIs:         []*url.URL{id.URL()},
+		}
+		der, err := x509.CreateCertificate(rand.Reader, tmpl, x509bundle.IssChain[0], key.Public(), x509bundle.IssKey)
+		require.NoError(t, err)
+		return tls.Certificate{
+			Certificate: [][]byte{der, x509bundle.IssChain[0].Raw},
+			PrivateKey:  key,
+		}
+	}
+
+	// daprd validates the scheduler server against the control-plane SPIFFE
+	// identity spiffe://<td>/ns/default/dapr-scheduler; the DNS SAN mirrors
+	// the conventional scheduler ID for hostname based verifiers.
+	schedulerID := spiffeid.RequireFromSegments(td, "ns", "default", "dapr-scheduler")
+	serverLeaf := mint(schedulerID, []string{"dapr-scheduler-server-0"})
+	clientLeaf := mint(
+		spiffeid.RequireFromSegments(td, "ns", namespace, appID),
+		nil,
+	)
+
+	return func(p *Proxy) {
+		p.serverCreds = credentials.NewTLS(&tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{serverLeaf},
+			ClientCAs:    pool,
+			ClientAuth:   tls.RequireAndVerifyClientCert,
+		})
+		p.upstreamTLS = &tls.Config{
+			MinVersion:   tls.VersionTLS12,
+			Certificates: []tls.Certificate{clientLeaf},
+			// The upstream scheduler presents a SPIFFE SVID with no hostname,
+			// so hostname verification is skipped and the chain and identity
+			// are verified explicitly instead.
+			//nolint:gosec
+			InsecureSkipVerify: true,
+			VerifyPeerCertificate: func(rawCerts [][]byte, _ [][]*x509.Certificate) error {
+				return verifySPIFFEPeer(rawCerts, pool, schedulerID)
+			},
+		}
+	}
+}
+
+// verifySPIFFEPeer checks the peer's chain against roots and that its leaf
+// carries exactly the expected SPIFFE ID.
+func verifySPIFFEPeer(rawCerts [][]byte, roots *x509.CertPool, expected spiffeid.ID) error {
+	if len(rawCerts) == 0 {
+		return errors.New("peer presented no certificate")
+	}
+	leaf, err := x509.ParseCertificate(rawCerts[0])
+	if err != nil {
+		return err
+	}
+	intermediates := x509.NewCertPool()
+	for _, raw := range rawCerts[1:] {
+		c, cerr := x509.ParseCertificate(raw)
+		if cerr != nil {
+			return cerr
+		}
+		intermediates.AddCert(c)
+	}
+	if _, verr := leaf.Verify(x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}); verr != nil {
+		return verr
+	}
+	id, err := x509svid.IDFromCert(leaf)
+	if err != nil {
+		return err
+	}
+	if id != expected {
+		return fmt.Errorf("unexpected peer identity %q, want %q", id, expected)
+	}
+	return nil
+}

--- a/tests/integration/framework/process/scheduler/proxy/tls_test.go
+++ b/tests/integration/framework/process/scheduler/proxy/tls_test.go
@@ -1,0 +1,84 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package proxy
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/spiffe/go-spiffe/v2/spiffeid"
+	"github.com/stretchr/testify/require"
+)
+
+type testCA struct {
+	cert *x509.Certificate
+	key  ed25519.PrivateKey
+	pool *x509.CertPool
+}
+
+func newTestCA(t *testing.T) *testCA {
+	t.Helper()
+	pub, key, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-ca"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, pub, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	pool := x509.NewCertPool()
+	pool.AddCert(cert)
+	return &testCA{cert: cert, key: key, pool: pool}
+}
+
+func (ca *testCA) leaf(t *testing.T, id spiffeid.ID) [][]byte {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	require.NoError(t, err)
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(time.Hour),
+		URIs:         []*url.URL{id.URL()},
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, ca.cert, pub, ca.key)
+	require.NoError(t, err)
+	return [][]byte{der}
+}
+
+func Test_verifySPIFFEPeer(t *testing.T) {
+	t.Parallel()
+
+	td := spiffeid.RequireTrustDomainFromString("public")
+	scheduler := spiffeid.RequireFromSegments(td, "ns", "default", "dapr-scheduler")
+	ca := newTestCA(t)
+
+	require.NoError(t, verifySPIFFEPeer(ca.leaf(t, scheduler), ca.pool, scheduler))
+	require.ErrorContains(t, verifySPIFFEPeer(ca.leaf(t, spiffeid.RequireFromSegments(td, "ns", "default", "impostor")), ca.pool, scheduler), "unexpected peer identity")
+	require.Error(t, verifySPIFFEPeer(newTestCA(t).leaf(t, scheduler), ca.pool, scheduler), "a leaf from another CA must not verify")
+	require.Error(t, verifySPIFFEPeer(nil, ca.pool, scheduler))
+}

--- a/tests/integration/framework/process/scheduler/scheduler.go
+++ b/tests/integration/framework/process/scheduler/scheduler.go
@@ -436,7 +436,8 @@ func (s *Scheduler) ETCDClient(t *testing.T, ctx context.Context) *clientv3.Clie
 
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:" + strconv.Itoa(s.EtcdClientPort())},
-		DialTimeout: 40 * time.Second,
+		DialTimeout: 5 * time.Second,
+		Context:     ctx,
 	})
 	require.NoError(t, err)
 
@@ -607,9 +608,11 @@ func (s *Scheduler) JobKeyCount(t *testing.T, ctx context.Context, substr string
 func (s *Scheduler) ListAllKeys(t *testing.T, ctx context.Context, prefix string) []string {
 	t.Helper()
 
+	// Bound by ctx: a dial that outlives the test panics the process.
 	resp, err := client.Etcd(t, clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:" + strconv.Itoa(s.EtcdClientPort())},
-		DialTimeout: 40 * time.Second,
+		DialTimeout: 5 * time.Second,
+		Context:     ctx,
 	}).ListAllKeys(ctx, prefix)
 	assert.NoError(t, err)
 

--- a/tests/integration/framework/process/sqlite/sqlite.go
+++ b/tests/integration/framework/process/sqlite/sqlite.go
@@ -115,7 +115,14 @@ func (s *SQLite) GetConnection(t *testing.T) *sql.DB {
 	if s.conn != nil {
 		return s.conn
 	}
-	conn, err := sql.Open("sqlite", "file://"+s.dbPath+"?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)")
+	// Match the daprds' journal mode: a database cannot leave WAL while
+	// another connection holds it open (SQLITE_BUSY, no busy wait), so a WAL
+	// connection here makes a daprd started with disableWAL fatal at init.
+	journalMode := "WAL"
+	if s.metadata["disableWAL"] == "true" {
+		journalMode = "DELETE"
+	}
+	conn, err := sql.Open("sqlite", "file://"+s.dbPath+"?_txlock=immediate&_pragma=busy_timeout(5000)&_pragma=journal_mode("+journalMode+")")
 	require.NoError(t, err, "Failed to connect to SQLite database")
 	s.conn = conn
 	return conn

--- a/tests/integration/framework/process/statestore/fault/fault.go
+++ b/tests/integration/framework/process/statestore/fault/fault.go
@@ -47,8 +47,11 @@ type Store struct {
 	multiObserver func(*state.TransactionalStateRequest)
 
 	multiDeleteHold *holdSpec
+	multiHold       *holdSpec
 	bulkGetHold     *holdSpec
 	getHold         *holdSpec
+
+	multiCancelled atomic.Int32
 
 	getFailKeySubstring string
 	getFailRemaining    int
@@ -138,6 +141,32 @@ func (s *Store) ArmMultiDeleteHold(sub string) (arrived <-chan struct{}, release
 	var once sync.Once
 	return spec.arrived, func() { once.Do(func() { close(spec.releaseCh) }) }, spec.done
 }
+
+// ArmMultiHold arms a one-shot hold on the next Multi touching a key
+// containing sub, whatever the operation type. arrived is closed when the
+// Multi is captured; it then blocks until release is called. Unlike the
+// in-memory store it wraps, a held Multi whose request context died while it
+// waited returns that context error, as every real transactional store does:
+// database/sql rolls a transaction back as soon as its context is cancelled.
+// Tests use this to hold a commit while the host cancels the caller.
+// release is idempotent, so it is safe to register with t.Cleanup.
+func (s *Store) ArmMultiHold(sub string) (arrived <-chan struct{}, release func()) {
+	spec := &holdSpec{
+		sub:       sub,
+		arrived:   make(chan struct{}),
+		releaseCh: make(chan struct{}),
+	}
+	s.mu.Lock()
+	s.multiHold = spec
+	s.mu.Unlock()
+
+	var once sync.Once
+	return spec.arrived, func() { once.Do(func() { close(spec.releaseCh) }) }
+}
+
+// MultiCancelled returns how many held Multi requests were abandoned because
+// their request context was cancelled while the hold was in place.
+func (s *Store) MultiCancelled() int { return int(s.multiCancelled.Load()) }
 
 // ArmBulkGetHold arms a one-shot hold on the next BulkGet touching a key
 // containing sub. arrived is closed when the BulkGet is captured; the call
@@ -299,6 +328,26 @@ func (s *Store) Multi(ctx context.Context, req *state.TransactionalStateRequest)
 		case <-ctx.Done():
 		}
 		defer close(hold.done)
+	}
+
+	s.mu.Lock()
+	var general *holdSpec
+	if s.multiHold != nil && anyHasSubstring(keys, s.multiHold.sub) {
+		general = s.multiHold
+		s.multiHold = nil
+	}
+	s.mu.Unlock()
+
+	if general != nil {
+		close(general.arrived)
+		select {
+		case <-general.releaseCh:
+		case <-ctx.Done():
+		}
+		if cerr := ctx.Err(); cerr != nil {
+			s.multiCancelled.Add(1)
+			return cerr
+		}
 	}
 
 	return s.Wrapped.Store.(state.TransactionalStore).Multi(ctx, req)

--- a/tests/integration/framework/process/workflow/options.go
+++ b/tests/integration/framework/process/workflow/options.go
@@ -19,6 +19,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/placement"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/durabletask-go/task"
 )
 
@@ -45,10 +46,10 @@ type options struct {
 	daprds          int
 	skipDB          bool
 	mtls            bool
-	signing         bool
 	signingDisabled []int
 	clustered       *bool
 	fastPath        *bool
+	signing         *bool
 
 	orchestrators     []orchestratorConfig
 	activities        []activityConfig
@@ -57,6 +58,7 @@ type options struct {
 	placementOptions  []placement.Option
 	schedulerInstance *scheduler.Scheduler
 	schedulerAddress  *string
+	sentryInstance    *sentry.Sentry
 }
 
 func WithAddOrchestrator(t *testing.T, name string, or func(*task.WorkflowContext) (any, error)) Option {
@@ -132,7 +134,8 @@ func WithMTLS(t *testing.T) Option {
 func WithHistorySigning(t *testing.T) Option {
 	t.Helper()
 	return func(o *options) {
-		o.signing = true
+		enabled := true
+		o.signing = &enabled
 		o.mtls = true
 	}
 }
@@ -164,9 +167,32 @@ func WithFastPath(enabled bool) Option {
 	}
 }
 
+// WithSigning explicitly enables or disables workflow history signing mode
+// (mTLS with a Sentry plus the WorkflowHistorySigning feature flag),
+// overriding the DAPR_INTEGRATION_WORKFLOW_SIGNING environment variable.
+// WithSigning(false) disables the feature flag only: mTLS requested via
+// WithMTLS or WithSentryInstance stays on.
+func WithSigning(enabled bool) Option {
+	return func(o *options) {
+		o.signing = &enabled
+	}
+}
+
 func WithSchedulerOptions(opts ...scheduler.Option) Option {
 	return func(o *options) {
 		o.schedulerOptions = append(o.schedulerOptions, opts...)
+	}
+}
+
+// WithSentryInstance lets a test supply a pre-constructed Sentry, implying
+// mTLS. The framework uses it for placement, scheduler and daprd identity
+// instead of creating its own, and skips adding it to its process list (the
+// caller is responsible for that). Required when combining
+// WithSchedulerInstance with mTLS/signing so the caller-built scheduler and
+// proxy share the same trust chain.
+func WithSentryInstance(sen *sentry.Sentry) Option {
+	return func(o *options) {
+		o.sentryInstance = sen
 	}
 }
 

--- a/tests/integration/framework/process/workflow/workflow.go
+++ b/tests/integration/framework/process/workflow/workflow.go
@@ -65,6 +65,15 @@ func FastPathFromEnv() bool {
 	return kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_WORKFLOW_FASTPATH"))
 }
 
+// SigningFromEnv reports whether the suite is running with
+// DAPR_INTEGRATION_WORKFLOW_SIGNING set truthy. WorkflowHistorySigning
+// requires mTLS (daprd fatals otherwise), so signing mode forces a Sentry
+// per workflow, exactly as WithMTLS does, unless a test overrides it with
+// WithSigning.
+func SigningFromEnv() bool {
+	return kitstrings.IsTruthy(os.Getenv("DAPR_INTEGRATION_WORKFLOW_SIGNING"))
+}
+
 type Workflow struct {
 	taskregistry []*task.TaskRegistry
 	db           *sqlite.SQLite
@@ -72,9 +81,11 @@ type Workflow struct {
 	sched        *scheduler.Scheduler
 	ownsSched    bool
 	sentry       *sentry.Sentry
+	ownsSentry   bool
 	daprds       []*daprd.Daprd
 	clustered    bool
 	fastPath     bool
+	signing      bool
 }
 
 func New(t *testing.T, fopts ...Option) *Workflow {
@@ -103,18 +114,43 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 		fastPath = *opts.fastPath
 	}
 
+	if opts.sentryInstance != nil {
+		opts.mtls = true
+	}
+	// mTLS implies signing unless a test opts out explicitly; opting out
+	// disables the feature only and leaves the requested mTLS in place.
+	signing := SigningFromEnv() || opts.mtls
+	if opts.signing != nil {
+		signing = *opts.signing
+	}
+	if signing {
+		opts.mtls = true
+	}
+	// A caller-supplied scheduler cannot be given Sentry credentials
+	// retroactively; under mTLS the caller must also supply the Sentry it
+	// built the scheduler (and any proxy) against, or opt out of signing.
+	// Fail loudly instead of timing out on TLS handshakes.
+	if opts.mtls && opts.schedulerInstance != nil && opts.sentryInstance == nil {
+		require.Fail(t, "WithSchedulerInstance under mTLS/signing requires WithSentryInstance (build the scheduler and proxy against that Sentry) or workflow.WithSigning(false)")
+	}
+
 	db := sqlite.New(t,
 		sqlite.WithActorStateStore(true),
 		sqlite.WithCreateStateTables(),
 	)
 
 	var sen *sentry.Sentry
+	ownsSentry := false
 	var placementOpts []placement.Option
 	placementOpts = append(placementOpts, opts.placementOptions...)
 	var schedulerOpts []scheduler.Option
 	schedulerOpts = append(schedulerOpts, opts.schedulerOptions...)
 	if opts.mtls {
-		sen = sentry.New(t)
+		sen = opts.sentryInstance
+		if sen == nil {
+			sen = sentry.New(t)
+			ownsSentry = true
+		}
 		placementOpts = append(placementOpts, placement.WithSentry(t, sen))
 		// Scheduler ID must match the TLS cert DNS names issued by Sentry.
 		schedulerOpts = append(schedulerOpts,
@@ -171,7 +207,7 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 		dopts = append(dopts, baseDopts...)
 
 		features := baseFeatures
-		if sen != nil && (opts.signing || opts.mtls) && !signingDisabled[i] {
+		if sen != nil && signing && !signingDisabled[i] {
 			features = append(features[:len(features):len(features)], "WorkflowHistorySigning")
 		}
 		if len(features) > 0 {
@@ -212,9 +248,11 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 		sched:        sched,
 		ownsSched:    ownsSched,
 		sentry:       sen,
+		ownsSentry:   ownsSentry,
 		daprds:       daprds,
 		clustered:    clustered,
 		fastPath:     fastPath,
+		signing:      signing,
 	}
 
 	for i := range workflow.taskregistry {
@@ -226,7 +264,7 @@ func New(t *testing.T, fopts ...Option) *Workflow {
 
 func (w *Workflow) Run(t *testing.T, ctx context.Context) {
 	w.db.Run(t, ctx)
-	if w.sentry != nil {
+	if w.sentry != nil && w.ownsSentry {
 		w.sentry.Run(t, ctx)
 	}
 	w.place.Run(t, ctx)
@@ -246,7 +284,7 @@ func (w *Workflow) Cleanup(t *testing.T) {
 		w.sched.Cleanup(t)
 	}
 	w.place.Cleanup(t)
-	if w.sentry != nil {
+	if w.sentry != nil && w.ownsSentry {
 		w.sentry.Cleanup(t)
 	}
 	w.db.Cleanup(t)
@@ -369,17 +407,23 @@ func baseFeatureList(clustered, fastPath bool) []string {
 	return features
 }
 
-// FeatureOptions returns the feature manifest option for extra daprds a test
-// adds to this harness's cluster. Only cluster-wide features are covered:
-// WorkflowHistorySigning is per-daprd and needs the harness's sentry wiring
-// besides the flag. daprd's config merge makes the last spec.features list
-// win, so all features must land in one manifest.
-func (w *Workflow) FeatureOptions(t *testing.T) []daprd.Option {
+// JoinOptions returns the options an extra daprd needs to join this
+// harness's cluster in the same modes: the feature flags and, under mTLS,
+// the Sentry wiring.
+func (w *Workflow) JoinOptions(t *testing.T) []daprd.Option {
+	t.Helper()
 	features := baseFeatureList(w.clustered, w.fastPath)
-	if len(features) == 0 {
-		return nil
+	var opts []daprd.Option
+	if w.sentry != nil {
+		opts = append(opts, daprd.WithSentry(t, w.sentry))
 	}
-	return []daprd.Option{daprd.WithFeatureEnabled(t, features...)}
+	if w.signing {
+		features = append(features, "WorkflowHistorySigning")
+	}
+	if len(features) > 0 {
+		opts = append(opts, daprd.WithFeatureEnabled(t, features...))
+	}
+	return opts
 }
 
 // ClusteredDeployment reports whether every daprd in this workflow runs with
@@ -394,6 +438,14 @@ func (w *Workflow) ClusteredDeployment() bool {
 // assertions which differ between the two modes.
 func (w *Workflow) FastPath() bool {
 	return w.fastPath
+}
+
+// Signing reports whether this workflow runs with mTLS active and the
+// WorkflowHistorySigning feature flag enabled on its daprds (except any
+// excluded via WithSigningDisabledN). Tests use this to branch assertions
+// which differ when history signing is active.
+func (w *Workflow) Signing() bool {
+	return w.signing
 }
 
 // ActorTypesCount returns the number of actor types a daprd in this workflow

--- a/tests/integration/suite/daprd/state/sqlite/disablewal.go
+++ b/tests/integration/suite/daprd/state/sqlite/disablewal.go
@@ -1,0 +1,89 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package sqlite
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/client"
+	procdaprd "github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	procsqlite "github.com/dapr/dapr/tests/integration/framework/process/sqlite"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(disablewal))
+}
+
+type disablewal struct {
+	db     *procsqlite.SQLite
+	daprd  *procdaprd.Daprd
+	joiner *procdaprd.Daprd
+}
+
+func (d *disablewal) Setup(t *testing.T) []framework.Option {
+	d.db = procsqlite.New(t,
+		procsqlite.WithMetadata("disableWAL", "true"),
+		procsqlite.WithCreateStateTables(),
+	)
+	appID := uuid.New().String()
+	d.daprd = procdaprd.New(t, procdaprd.WithAppID(appID), procdaprd.WithResourceFiles(d.db.GetComponent(t)))
+	d.joiner = procdaprd.New(t, procdaprd.WithAppID(appID), procdaprd.WithResourceFiles(d.db.GetComponent(t)))
+
+	return []framework.Option{
+		framework.WithProcesses(d.db, d.daprd),
+	}
+}
+
+func (d *disablewal) Run(t *testing.T, ctx context.Context) {
+	d.daprd.WaitUntilRunning(t, ctx)
+
+	var mode string
+	require.NoError(t, d.db.GetConnection(t).QueryRowContext(ctx, "PRAGMA journal_mode").Scan(&mode))
+	assert.Equal(t, "delete", mode)
+
+	d.joiner.Run(t, ctx)
+	t.Cleanup(func() { d.joiner.Cleanup(t) })
+	d.joiner.WaitUntilRunning(t, ctx)
+
+	httpClient := client.HTTP(t)
+	url := fmt.Sprintf("http://%s/v1.0/state/mystore", d.joiner.HTTPAddress())
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, url, strings.NewReader(`[{"key":"k","value":"v"}]`))
+	require.NoError(t, err)
+	resp, err := httpClient.Do(req)
+	require.NoError(t, err)
+	require.NoError(t, resp.Body.Close())
+	require.Equal(t, http.StatusNoContent, resp.StatusCode)
+
+	url = fmt.Sprintf("http://%s/v1.0/state/mystore/k", d.daprd.HTTPAddress())
+	req, err = http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	require.NoError(t, err)
+	resp, err = httpClient.Do(req)
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	require.NoError(t, resp.Body.Close())
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Equal(t, `"v"`, string(body))
+}

--- a/tests/integration/suite/daprd/state/state.go
+++ b/tests/integration/suite/daprd/state/state.go
@@ -16,4 +16,5 @@ package state
 import (
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/state/grpc"
 	_ "github.com/dapr/dapr/tests/integration/suite/daprd/state/http"
+	_ "github.com/dapr/dapr/tests/integration/suite/daprd/state/sqlite"
 )

--- a/tests/integration/suite/daprd/workflow/chaos/canfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/canfail.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -26,8 +27,10 @@ import (
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -53,16 +56,23 @@ func (c *canfail) Setup(t *testing.T) []framework.Option {
 		t.Skip("WorkflowsFastPath drives the activity-result wake-up locally and never issues the per-event ScheduleJob this test arms a failure on")
 	}
 
-	c.scheduler = scheduler.New(t)
-	c.proxy = proxy.New(t, c.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	c.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	c.proxy = proxy.New(t, c.scheduler, proxy.WithSentry(t, sen, "default", appID))
 
 	c.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
 		workflow.WithSchedulerInstance(c.scheduler),
 		workflow.WithSchedulerAddress(c.proxy.Address()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(c.scheduler, c.proxy, c.workflow),
+		framework.WithProcesses(sen, c.scheduler, c.proxy, c.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/dedupreassert.go
+++ b/tests/integration/suite/daprd/workflow/chaos/dedupreassert.go
@@ -19,6 +19,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -32,8 +33,10 @@ import (
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -49,16 +52,23 @@ type dedupreassert struct {
 }
 
 func (d *dedupreassert) Setup(t *testing.T) []framework.Option {
-	d.sched = scheduler.New(t)
-	d.proxy = proxy.New(t, d.sched)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	d.sched = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	d.proxy = proxy.New(t, d.sched, proxy.WithSentry(t, sen, "default", appID))
 
 	d.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
 		workflow.WithSchedulerInstance(d.sched),
 		workflow.WithSchedulerAddress(d.proxy.Address()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(d.sched, d.proxy, d.workflow),
+		framework.WithProcesses(sen, d.sched, d.proxy, d.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/detachedarm/event.go
+++ b/tests/integration/suite/daprd/workflow/chaos/detachedarm/event.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
@@ -58,15 +59,20 @@ func (e *event) Setup(t *testing.T) []framework.Option {
 	}
 
 	e.appID = uuid.New().String()
-	e.scheduler = scheduler.New(t)
-	e.proxy = proxy.New(t, e.scheduler)
+	sen := sentry.New(t)
+	e.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	e.proxy = proxy.New(t, e.scheduler, proxy.WithSentry(t, sen, "default", e.appID))
 	e.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithSchedulerInstance(e.scheduler),
 		workflow.WithSchedulerAddress(e.proxy.Address()),
 		workflow.WithDaprdOptions(0, daprd.WithAppID(e.appID)),
 	)
 	return []framework.Option{
-		framework.WithProcesses(e.scheduler, e.proxy, e.workflow),
+		framework.WithProcesses(sen, e.scheduler, e.proxy, e.workflow),
 	}
 }
 
@@ -112,7 +118,7 @@ func (e *event) Run(t *testing.T, ctx context.Context) {
 		daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
 		daprd.WithSchedulerAddressesReset(e.proxy.Address()),
 		daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
-	}, e.workflow.FeatureOptions(t)...)...)
+	}, e.workflow.JoinOptions(t)...)...)
 	extra.Run(t, ctx)
 	t.Cleanup(func() { extra.Cleanup(t) })
 	extra.WaitUntilRunning(t, ctx)

--- a/tests/integration/suite/daprd/workflow/chaos/detachedarm/purged.go
+++ b/tests/integration/suite/daprd/workflow/chaos/detachedarm/purged.go
@@ -19,6 +19,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -29,6 +31,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
@@ -50,17 +53,26 @@ type purged struct {
 }
 
 func (s *purged) Setup(t *testing.T) []framework.Option {
-	s.scheduler = scheduler.New(t)
-	s.proxy = proxy.New(t, s.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	s.proxy = proxy.New(t, s.scheduler, proxy.WithSentry(t, sen, "default", appID))
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithSchedulerInstance(s.scheduler),
 		workflow.WithSchedulerAddress(s.proxy.Address()),
-		workflow.WithDaprdOptions(0, daprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
-		))),
+		workflow.WithDaprdOptions(0,
+			daprd.WithAppID(appID),
+			daprd.WithExecOptions(exec.WithEnvVars(t,
+				"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
+			)),
+		),
 	)
 	return []framework.Option{
-		framework.WithProcesses(s.scheduler, s.proxy, s.workflow),
+		framework.WithProcesses(sen, s.scheduler, s.proxy, s.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/detachedarm/reconnect.go
+++ b/tests/integration/suite/daprd/workflow/chaos/detachedarm/reconnect.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -29,6 +31,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/client"
@@ -52,18 +55,27 @@ type reconnect struct {
 }
 
 func (s *reconnect) Setup(t *testing.T) []framework.Option {
-	s.scheduler = scheduler.New(t)
-	s.proxy = proxy.New(t, s.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	s.proxy = proxy.New(t, s.scheduler, proxy.WithSentry(t, sen, "default", appID))
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithSchedulerInstance(s.scheduler),
 		workflow.WithSchedulerAddress(s.proxy.Address()),
 		// Keep the status-read re-drive out of this test.
-		workflow.WithDaprdOptions(0, daprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
-		))),
+		workflow.WithDaprdOptions(0,
+			daprd.WithAppID(appID),
+			daprd.WithExecOptions(exec.WithEnvVars(t,
+				"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
+			)),
+		),
 	)
 	return []framework.Option{
-		framework.WithProcesses(s.scheduler, s.proxy, s.workflow),
+		framework.WithProcesses(sen, s.scheduler, s.proxy, s.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/detachedarm/start.go
+++ b/tests/integration/suite/daprd/workflow/chaos/detachedarm/start.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/client"
@@ -56,15 +57,20 @@ type start struct {
 
 func (s *start) Setup(t *testing.T) []framework.Option {
 	s.appID = uuid.New().String()
-	s.scheduler = scheduler.New(t)
-	s.proxy = proxy.New(t, s.scheduler)
+	sen := sentry.New(t)
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	s.proxy = proxy.New(t, s.scheduler, proxy.WithSentry(t, sen, "default", s.appID))
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithSchedulerInstance(s.scheduler),
 		workflow.WithSchedulerAddress(s.proxy.Address()),
 		workflow.WithDaprdOptions(0, daprd.WithAppID(s.appID)),
 	)
 	return []framework.Option{
-		framework.WithProcesses(s.scheduler, s.proxy, s.workflow),
+		framework.WithProcesses(sen, s.scheduler, s.proxy, s.workflow),
 	}
 }
 
@@ -119,7 +125,7 @@ func (s *start) Run(t *testing.T, ctx context.Context) {
 		daprd.WithPlacementAddresses(s.workflow.Placement().Address()),
 		daprd.WithSchedulerAddressesReset(s.proxy.Address()),
 		daprd.WithResourceFiles(s.workflow.DB().GetComponent(t)),
-	}, s.workflow.FeatureOptions(t)...)...)
+	}, s.workflow.JoinOptions(t)...)...)
 	extra.Run(t, ctx)
 	t.Cleanup(func() { extra.Cleanup(t) })
 	extra.WaitUntilRunning(t, ctx)

--- a/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/eventcanfail.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -27,8 +28,10 @@ import (
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -48,16 +51,23 @@ type eventcanfail struct {
 }
 
 func (e *eventcanfail) Setup(t *testing.T) []framework.Option {
-	e.scheduler = scheduler.New(t)
-	e.proxy = proxy.New(t, e.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	e.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	e.proxy = proxy.New(t, e.scheduler, proxy.WithSentry(t, sen, "default", appID))
 
 	e.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
 		workflow.WithSchedulerInstance(e.scheduler),
 		workflow.WithSchedulerAddress(e.proxy.Address()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(e.scheduler, e.proxy, e.workflow),
+		framework.WithProcesses(sen, e.scheduler, e.proxy, e.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/loadretry.go
+++ b/tests/integration/suite/daprd/workflow/chaos/loadretry.go
@@ -30,6 +30,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
@@ -59,9 +60,14 @@ func (l *loadretry) Setup(t *testing.T) []framework.Option {
 		statestore.WithStateStore(l.store),
 	)
 
-	l.sched = scheduler.New(t)
+	sen := sentry.New(t)
+	l.sched = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
 
 	l.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithNoDB(),
 		workflow.WithSchedulerInstance(l.sched),
 		workflow.WithDaprdOptions(0,
@@ -82,7 +88,7 @@ spec:
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(l.sched, l.ss, l.workflow),
+		framework.WithProcesses(sen, l.sched, l.ss, l.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/reminderdedup.go
+++ b/tests/integration/suite/daprd/workflow/chaos/reminderdedup.go
@@ -65,6 +65,10 @@ func (s *reminderdedup) Setup(t *testing.T) []framework.Option {
 	)
 
 	s.workflow = workflow.New(t,
+		// Keep the signing feature off in signing mode: the armed store fault
+		// rolls back signed rows mid-commit and the retried completion would be
+		// classified as tampering instead of retried. mTLS itself is unaffected.
+		workflow.WithSigningDisabledN(0),
 		workflow.WithNoDB(),
 		workflow.WithDaprdOptions(0,
 			daprd.WithSocket(t, sock),

--- a/tests/integration/suite/daprd/workflow/chaos/savefail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/savefail.go
@@ -69,6 +69,10 @@ func (s *savefail) Setup(t *testing.T) []framework.Option {
 	)
 
 	s.workflow = workflow.New(t,
+		// Keep the signing feature off in signing mode: the armed store fault
+		// rolls back signed rows mid-commit and the retried completion would be
+		// classified as tampering instead of retried. mTLS itself is unaffected.
+		workflow.WithSigningDisabledN(0),
 		workflow.WithNoDB(),
 		workflow.WithDaprdOptions(0,
 			daprd.WithSocket(t, sock),

--- a/tests/integration/suite/daprd/workflow/chaos/savefirst.go
+++ b/tests/integration/suite/daprd/workflow/chaos/savefirst.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/os"
 	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore"
 	"github.com/dapr/dapr/tests/integration/framework/process/statestore/fault"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
@@ -72,9 +73,18 @@ func (s *savefirst) Setup(t *testing.T) []framework.Option {
 		statestore.WithStateStore(s.store),
 	)
 
-	s.sched = scheduler.New(t)
+	sen := sentry.New(t)
+	s.sched = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
 
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		// Keep the signing feature off: the armed store fault rolls back signed
+		// rows mid-commit and the retried completion would be classified as
+		// tampering instead of retried. mTLS itself is unaffected.
+		workflow.WithSigningDisabledN(0),
 		workflow.WithNoDB(),
 		workflow.WithSchedulerInstance(s.sched),
 		workflow.WithDaprdOptions(0,
@@ -95,7 +105,7 @@ spec:
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(s.sched, s.ss, s.workflow),
+		framework.WithProcesses(sen, s.sched, s.ss, s.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/startcanfail.go
+++ b/tests/integration/suite/daprd/workflow/chaos/startcanfail.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -26,8 +27,10 @@ import (
 	"github.com/dapr/durabletask-go/task"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 )
@@ -43,16 +46,23 @@ type startcanfail struct {
 }
 
 func (s *startcanfail) Setup(t *testing.T) []framework.Option {
-	s.scheduler = scheduler.New(t)
-	s.proxy = proxy.New(t, s.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	s.proxy = proxy.New(t, s.scheduler, proxy.WithSentry(t, sen, "default", appID))
 
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
 		workflow.WithSchedulerInstance(s.scheduler),
 		workflow.WithSchedulerAddress(s.proxy.Address()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(s.scheduler, s.proxy, s.workflow),
+		framework.WithProcesses(sen, s.scheduler, s.proxy, s.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/startreassert/unverified.go
+++ b/tests/integration/suite/daprd/workflow/chaos/startreassert/unverified.go
@@ -18,6 +18,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
@@ -28,6 +30,7 @@ import (
 	"github.com/dapr/dapr/tests/integration/framework/process/exec"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/task"
@@ -50,18 +53,27 @@ type unverified struct {
 }
 
 func (s *unverified) Setup(t *testing.T) []framework.Option {
-	s.scheduler = scheduler.New(t)
-	s.proxy = proxy.New(t, s.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	s.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	s.proxy = proxy.New(t, s.scheduler, proxy.WithSentry(t, sen, "default", appID))
 	s.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
 		workflow.WithSchedulerInstance(s.scheduler),
 		workflow.WithSchedulerAddress(s.proxy.Address()),
 		// Keep the status-read re-drive out of this test.
-		workflow.WithDaprdOptions(0, daprd.WithExecOptions(exec.WithEnvVars(t,
-			"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
-		))),
+		workflow.WithDaprdOptions(0,
+			daprd.WithAppID(appID),
+			daprd.WithExecOptions(exec.WithEnvVars(t,
+				"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "5m",
+			)),
+		),
 	)
 	return []framework.Option{
-		framework.WithProcesses(s.scheduler, s.proxy, s.workflow),
+		framework.WithProcesses(sen, s.scheduler, s.proxy, s.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
+++ b/tests/integration/suite/daprd/workflow/chaos/terminatecascade.go
@@ -20,13 +20,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/uuid"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc/codes"
 
 	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler/proxy"
+	"github.com/dapr/dapr/tests/integration/framework/process/sentry"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
 	"github.com/dapr/dapr/tests/integration/suite"
 	"github.com/dapr/durabletask-go/api"
@@ -44,16 +47,23 @@ type terminatecascade struct {
 }
 
 func (c *terminatecascade) Setup(t *testing.T) []framework.Option {
-	c.scheduler = scheduler.New(t)
-	c.proxy = proxy.New(t, c.scheduler)
+	appID := uuid.New().String()
+	sen := sentry.New(t)
+	c.scheduler = scheduler.New(t,
+		scheduler.WithSentry(sen),
+		scheduler.WithID("dapr-scheduler-server-0"),
+	)
+	c.proxy = proxy.New(t, c.scheduler, proxy.WithSentry(t, sen, "default", appID))
 
 	c.workflow = workflow.New(t,
+		workflow.WithSentryInstance(sen),
+		workflow.WithDaprdOptions(0, daprd.WithAppID(appID)),
 		workflow.WithSchedulerInstance(c.scheduler),
 		workflow.WithSchedulerAddress(c.proxy.Address()),
 	)
 
 	return []framework.Option{
-		framework.WithProcesses(c.scheduler, c.proxy, c.workflow),
+		framework.WithProcesses(sen, c.scheduler, c.proxy, c.workflow),
 	}
 }
 

--- a/tests/integration/suite/daprd/workflow/childnotify/crossapp.go
+++ b/tests/integration/suite/daprd/workflow/childnotify/crossapp.go
@@ -40,7 +40,7 @@ type crossapp struct {
 }
 
 func (x *crossapp) Setup(t *testing.T) []framework.Option {
-	x.workflow = workflow.New(t, workflow.WithDaprds(2))
+	x.workflow = workflow.New(t, workflow.WithDaprds(2), workflow.WithSigning(false))
 	return []framework.Option{framework.WithProcesses(x.workflow)}
 }
 

--- a/tests/integration/suite/daprd/workflow/childnotify/failed.go
+++ b/tests/integration/suite/daprd/workflow/childnotify/failed.go
@@ -41,7 +41,7 @@ type failed struct {
 }
 
 func (f *failed) Setup(t *testing.T) []framework.Option {
-	f.workflow = workflow.New(t)
+	f.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{framework.WithProcesses(f.workflow)}
 }
 

--- a/tests/integration/suite/daprd/workflow/childnotify/recreate.go
+++ b/tests/integration/suite/daprd/workflow/childnotify/recreate.go
@@ -40,7 +40,7 @@ type recreate struct {
 }
 
 func (r *recreate) Setup(t *testing.T) []framework.Option {
-	r.workflow = workflow.New(t)
+	r.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{framework.WithProcesses(r.workflow)}
 }
 

--- a/tests/integration/suite/daprd/workflow/childnotify/strayfire.go
+++ b/tests/integration/suite/daprd/workflow/childnotify/strayfire.go
@@ -41,7 +41,7 @@ type strayfire struct {
 }
 
 func (s *strayfire) Setup(t *testing.T) []framework.Option {
-	s.workflow = workflow.New(t)
+	s.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{framework.WithProcesses(s.workflow)}
 }
 

--- a/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/inboxoverload.go
@@ -53,7 +53,8 @@ type inboxoverload struct {
 }
 
 func (i *inboxoverload) Setup(t *testing.T) []framework.Option {
-	i.workflow = workflow.New(t)
+	// Signing mode opt-out: the test hand-writes unsigned inbox rows into sqlite (rejected by a signing-enabled host) and dials the scheduler with a plaintext client.
+	i.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{
 		framework.WithProcesses(i.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/continueasnew/raisebatch.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/raisebatch.go
@@ -52,7 +52,8 @@ type raisebatch struct {
 }
 
 func (r *raisebatch) Setup(t *testing.T) []framework.Option {
-	r.workflow = workflow.New(t)
+	// Signing mode opt-out: the test hand-writes unsigned inbox rows into sqlite (rejected by a signing-enabled host) and dials the scheduler with a plaintext client.
+	r.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{
 		framework.WithProcesses(r.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/continueasnew/raisebatchnodup.go
+++ b/tests/integration/suite/daprd/workflow/continueasnew/raisebatchnodup.go
@@ -45,7 +45,8 @@ type raisebatchnodup struct {
 }
 
 func (r *raisebatchnodup) Setup(t *testing.T) []framework.Option {
-	r.workflow = workflow.New(t)
+	// Signing mode opt-out: the test hand-writes unsigned inbox rows into sqlite (rejected by a signing-enabled host) and dials the scheduler with a plaintext client.
+	r.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{
 		framework.WithProcesses(r.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/dissemination.go
+++ b/tests/integration/suite/daprd/workflow/dedup/dissemination.go
@@ -41,6 +41,8 @@ type dissemination struct {
 
 func (d *dissemination) Setup(t *testing.T) []framework.Option {
 	d.workflow = workflow.New(t,
+		// Signing mode opt-out: the fake "blocker" host joins placement over a raw insecure client, which cannot handshake with an mTLS placement.
+		workflow.WithSigning(false),
 		workflow.WithPlacementOptions(placement.WithDisseminateTimeout(time.Second*7)),
 	)
 	return []framework.Option{

--- a/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
+++ b/tests/integration/suite/daprd/workflow/dedup/disseminationcluster.go
@@ -95,13 +95,15 @@ func (d *disseminationcluster) Run(t *testing.T, ctx context.Context) {
 
 	startVersion := d.workflow.Placement().PlacementTables(t, ctx).Tables["default"].Version
 
+	extraOpts := append([]daprd.Option{
+		daprd.WithAppID(d.appID),
+		daprd.WithPlacementAddresses(d.workflow.Placement().Address()),
+		daprd.WithScheduler(d.workflow.Scheduler()),
+		daprd.WithResourceFiles(d.workflow.DB().GetComponent(t)),
+	}, d.workflow.JoinOptions(t)...)
+
 	for i := range 2 {
-		extra := daprd.New(t, append([]daprd.Option{
-			daprd.WithAppID(d.appID),
-			daprd.WithPlacementAddresses(d.workflow.Placement().Address()),
-			daprd.WithScheduler(d.workflow.Scheduler()),
-			daprd.WithResourceFiles(d.workflow.DB().GetComponent(t)),
-		}, d.workflow.FeatureOptions(t)...)...)
+		extra := daprd.New(t, extraOpts...)
 		extra.Run(t, ctx)
 		extra.WaitUntilRunning(t, ctx)
 		t.Cleanup(func() { extra.Cleanup(t) })

--- a/tests/integration/suite/daprd/workflow/dedup/early/child.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/child.go
@@ -45,7 +45,10 @@ type child struct {
 }
 
 func (e *child) Setup(t *testing.T) []framework.Option {
-	e.workflow = workflow.New(t)
+	e.workflow = workflow.New(t,
+		// Signing mode opt-out: the injected unsigned resolution event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/early/completion.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/completion.go
@@ -55,7 +55,10 @@ type completion struct {
 }
 
 func (e *completion) Setup(t *testing.T) []framework.Option {
-	e.workflow = workflow.New(t)
+	e.workflow = workflow.New(t,
+		// Signing mode opt-out: the injected unsigned resolution event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/early/failure.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/failure.go
@@ -43,7 +43,10 @@ type failure struct {
 }
 
 func (e *failure) Setup(t *testing.T) []framework.Option {
-	e.workflow = workflow.New(t)
+	e.workflow = workflow.New(t,
+		// Signing mode opt-out: the injected unsigned resolution event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/early/orphan.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/orphan.go
@@ -45,7 +45,10 @@ type orphan struct {
 }
 
 func (e *orphan) Setup(t *testing.T) []framework.Option {
-	e.workflow = workflow.New(t)
+	e.workflow = workflow.New(t,
+		// Signing mode opt-out: the injected unsigned resolution event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/early/timer.go
+++ b/tests/integration/suite/daprd/workflow/dedup/early/timer.go
@@ -43,7 +43,10 @@ type timer struct {
 }
 
 func (e *timer) Setup(t *testing.T) []framework.Option {
-	e.workflow = workflow.New(t)
+	e.workflow = workflow.New(t,
+		// Signing mode opt-out: the injected unsigned resolution event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(e.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/skipresolved.go
+++ b/tests/integration/suite/daprd/workflow/dedup/skipresolved.go
@@ -38,7 +38,10 @@ type skipresolved struct {
 }
 
 func (sr *skipresolved) Setup(t *testing.T) []framework.Option {
-	sr.workflow = workflow.New(t)
+	sr.workflow = workflow.New(t,
+		// Signing mode opt-out: removing a history event breaks the signature chain by design.
+		workflow.WithSigning(false),
+	)
 	return []framework.Option{
 		framework.WithProcesses(sr.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/dedup/stalledrecovery.go
+++ b/tests/integration/suite/daprd/workflow/dedup/stalledrecovery.go
@@ -49,7 +49,10 @@ type stalledrecovery struct {
 }
 
 func (s *stalledrecovery) Setup(t *testing.T) []framework.Option {
-	s.workflow = workflow.New(t)
+	s.workflow = workflow.New(t,
+		// Signing mode opt-out: the crafted unsigned history event would be rejected by signing verification.
+		workflow.WithSigning(false),
+	)
 	s.blockCh = make(chan struct{})
 	return []framework.Option{
 		framework.WithProcesses(s.workflow),

--- a/tests/integration/suite/daprd/workflow/disk/quota.go
+++ b/tests/integration/suite/daprd/workflow/disk/quota.go
@@ -24,6 +24,7 @@ import (
 	"github.com/dapr/durabletask-go/api"
 	"github.com/dapr/durabletask-go/task"
 
+	schedulerv1pb "github.com/dapr/dapr/pkg/proto/scheduler/v1"
 	"github.com/dapr/dapr/tests/integration/framework"
 	"github.com/dapr/dapr/tests/integration/framework/process/scheduler"
 	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
@@ -64,7 +65,16 @@ func (q *quota) Run(t *testing.T, ctx context.Context) {
 		}
 	}, 10*time.Second, 10*time.Millisecond)
 
-	_, err := sched.Client(t, ctx).ScheduleJob(ctx,
+	// In signing mode the control plane runs mTLS, so the scheduler only
+	// accepts TLS client connections.
+	var schedClient schedulerv1pb.SchedulerClient
+	if q.wf.Signing() {
+		schedClient = sched.ClientMTLS(t, ctx, q.wf.Dapr().AppID())
+	} else {
+		schedClient = sched.Client(t, ctx)
+	}
+
+	_, err := schedClient.ScheduleJob(ctx,
 		sched.JobNowJob("test-job-after-quota", "default", q.wf.Dapr().AppID()))
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "database space exceeded")

--- a/tests/integration/suite/daprd/workflow/externalevent/indefinitewaitactivity.go
+++ b/tests/integration/suite/daprd/workflow/externalevent/indefinitewaitactivity.go
@@ -53,7 +53,8 @@ type indefiniteWaitActivity struct {
 }
 
 func (i *indefiniteWaitActivity) Setup(t *testing.T) []framework.Option {
-	i.workflow = workflow.New(t)
+	// Signing mode opt-out: the test injects unsigned legacy-SDK history, which a signing-enabled daprd rejects by design.
+	i.workflow = workflow.New(t, workflow.WithSigning(false))
 
 	return []framework.Option{
 		framework.WithProcesses(i.workflow),

--- a/tests/integration/suite/daprd/workflow/externalevent/indefinitewaittimer.go
+++ b/tests/integration/suite/daprd/workflow/externalevent/indefinitewaittimer.go
@@ -46,7 +46,8 @@ type indefiniteWaitTimer struct {
 }
 
 func (i *indefiniteWaitTimer) Setup(t *testing.T) []framework.Option {
-	i.workflow = workflow.New(t)
+	// Signing mode opt-out: the test injects unsigned legacy-SDK history, which a signing-enabled daprd rejects by design.
+	i.workflow = workflow.New(t, workflow.WithSigning(false))
 
 	return []framework.Option{
 		framework.WithProcesses(i.workflow),

--- a/tests/integration/suite/daprd/workflow/globalmaxconcurrent/fastpath.go
+++ b/tests/integration/suite/daprd/workflow/globalmaxconcurrent/fastpath.go
@@ -39,23 +39,28 @@ type fastpath struct {
 }
 
 func (f *fastpath) Setup(t *testing.T) []framework.Option {
+	// The feature goes through WithFeatureEnabled so it joins the harness's
+	// feature list for the leg (daprd keeps only the last spec.features it
+	// loads); the manifest carries only the non-feature setting.
 	configManifest := `apiVersion: dapr.io/v1alpha1
 kind: Configuration
 metadata:
   name: globalmax
 spec:
-  features:
-  - name: WorkflowsFastPath
-    enabled: true
   workflow:
     globalMaxConcurrentWorkflowInvocations: 2
 `
 	const appID = "globalmax-fastpath"
+	perDaprd := []daprd.Option{
+		daprd.WithConfigManifests(t, configManifest),
+		daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
+		daprd.WithAppID(appID),
+	}
 	f.workflow = workflow.New(t,
 		workflow.WithDaprds(3),
-		workflow.WithDaprdOptions(0, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
-		workflow.WithDaprdOptions(1, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
-		workflow.WithDaprdOptions(2, daprd.WithConfigManifests(t, configManifest), daprd.WithAppID(appID)),
+		workflow.WithDaprdOptions(0, perDaprd...),
+		workflow.WithDaprdOptions(1, perDaprd...),
+		workflow.WithDaprdOptions(2, perDaprd...),
 	)
 
 	return []framework.Option{

--- a/tests/integration/suite/daprd/workflow/loadbalance/stalecompletion.go
+++ b/tests/integration/suite/daprd/workflow/loadbalance/stalecompletion.go
@@ -45,30 +45,17 @@ type stalecompletion struct {
 }
 
 func (s *stalecompletion) Setup(t *testing.T) []framework.Option {
-	config := `
-apiVersion: dapr.io/v1alpha1
-kind: Configuration
-metadata:
-    name: clusteredfastpath
-spec:
-    features:
-    - name: WorkflowsClusteredDeployment
-      enabled: true
-    - name: WorkflowsLocalWakeFastPath
-      enabled: true
-    - name: WorkflowsLocalActivityFastPath
-      enabled: true
-    - name: WorkflowsCompletionsFold
-      enabled: true
-`
 	uid, err := uuid.NewRandom()
 	require.NoError(t, err)
 
+	// Clustered fast path in every leg: the features go through
+	// WithFeatureEnabled so they join the harness's feature list (daprd keeps
+	// only the last spec.features it loads).
 	s.workflow = workflow.New(t,
 		workflow.WithDaprds(1),
 		workflow.WithDaprdOptions(0,
 			daprd.WithAppID(uid.String()),
-			daprd.WithConfigManifests(t, config),
+			daprd.WithFeatureEnabled(t, "WorkflowsClusteredDeployment", "WorkflowsFastPath"),
 			daprd.WithExecOptions(exec.WithEnvVars(t,
 				"DAPR_WORKFLOW_JANITOR_PERIOD", "2s",
 				"DAPR_WORKFLOW_TEST_DUPLICATE_TURN_COMPLETIONS", "3",

--- a/tests/integration/suite/daprd/workflow/propagation/nomtls.go
+++ b/tests/integration/suite/daprd/workflow/propagation/nomtls.go
@@ -52,6 +52,8 @@ func (n *nomtls) Setup(t *testing.T) []framework.Option {
 	)
 
 	n.workflow = procworkflow.New(t,
+		// Signing mode opt-out: this test's premise is a standalone deployment WITHOUT mTLS/signing, asserting the unsigned-propagation warning log.
+		procworkflow.WithSigning(false),
 		procworkflow.WithDaprds(1),
 		procworkflow.WithDaprdOptions(0, daprd.WithLogLineStdout(n.logline)),
 	)

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/completed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/completed.go
@@ -76,10 +76,16 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 	db := e.workflow.DB().GetConnection(t)
 	tableName := e.workflow.DB().TableName()
 
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	runningCount := 8
+	if e.workflow.Signing() {
+		runningCount = 12
+	}
+
 	var count int
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(c, 8, count)
+		assert.Equal(c, runningCount, count)
 	}, time.Second*10, time.Millisecond*10)
 
 	require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/failed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/failed.go
@@ -76,10 +76,16 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 	db := f.workflow.DB().GetConnection(t)
 	tableName := f.workflow.DB().TableName()
 
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	runningCount := 8
+	if f.workflow.Signing() {
+		runningCount = 12
+	}
+
 	var count int
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(c, 8, count)
+		assert.Equal(c, runningCount, count)
 	}, time.Second*10, time.Millisecond*10)
 
 	require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/high.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/high.go
@@ -79,8 +79,14 @@ func (h *high) Run(t *testing.T, ctx context.Context) {
 
 	db := h.workflow.DB().GetConnection(t)
 	tableName := h.workflow.DB().TableName()
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	retainedCount := 8
+	if h.workflow.Signing() {
+		retainedCount = 12
+	}
+
 	var count int
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 8, count)
+	assert.Equal(t, retainedCount, count)
 	assert.Len(t, h.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"), 1)
 }

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/completed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/completed.go
@@ -80,6 +80,12 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	rowsRunning, rowsTerminal := 8, 11
+	if e.workflow.Signing() {
+		rowsRunning, rowsTerminal = 12, 16
+	}
+
 	t.Run("completed", func(t *testing.T) {
 		id, err := client.ScheduleWorkflow(ctx, "foo1")
 		require.NoError(t, err)
@@ -87,15 +93,20 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 		db := e.workflow.DB().GetConnection(t)
 		tableName := e.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, e.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
@@ -109,19 +120,25 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 		db := e.workflow.DB().GetConnection(t)
 		tableName := e.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.TerminateWorkflow(ctx, id))
 		time.Sleep(time.Second * 3)
 
+		var count int
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(t, 11, count)
+		assert.Equal(t, rowsTerminal, count)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, e.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
@@ -135,18 +152,24 @@ func (e *completed) Run(t *testing.T, ctx context.Context) {
 		db := e.workflow.DB().GetConnection(t)
 		tableName := e.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		time.Sleep(time.Second * 3)
 
+		var count int
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(t, 8, count)
+		assert.Equal(t, rowsRunning, count)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, e.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/failed.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/failed.go
@@ -76,6 +76,12 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 	client := dworkflow.NewClient(f.workflow.Dapr().GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	rowsRunning, rowsTerminal := 8, 11
+	if f.workflow.Signing() {
+		rowsRunning, rowsTerminal = 12, 16
+	}
+
 	t.Run("failed", func(t *testing.T) {
 		id, err := client.ScheduleWorkflow(ctx, "foo1")
 		require.NoError(t, err)
@@ -83,15 +89,20 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 		db := f.workflow.DB().GetConnection(t)
 		tableName := f.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, f.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
@@ -105,19 +116,25 @@ func (f *failed) Run(t *testing.T, ctx context.Context) {
 		db := f.workflow.DB().GetConnection(t)
 		tableName := f.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))
 		time.Sleep(time.Second * 3)
 
+		var count int
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(t, 11, count)
+		assert.Equal(t, rowsTerminal, count)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, f.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/match/terminated.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/match/terminated.go
@@ -79,6 +79,12 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 	client := dworkflow.NewClient(e.workflow.Dapr().GRPCConn(t, ctx))
 	require.NoError(t, client.StartWorker(ctx, reg))
 
+	// Signing mode stores one signature row per history save plus a sigcert row.
+	rowsRunning, rowsTerminal := 8, 11
+	if e.workflow.Signing() {
+		rowsRunning, rowsTerminal = 12, 16
+	}
+
 	t.Run("terminated", func(t *testing.T) {
 		id, err := client.ScheduleWorkflow(ctx, "foo1")
 		require.NoError(t, err)
@@ -86,15 +92,20 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 		db := e.workflow.DB().GetConnection(t)
 		tableName := e.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.TerminateWorkflow(ctx, id))
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, e.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))
@@ -108,19 +119,25 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 		db := e.workflow.DB().GetConnection(t)
 		tableName := e.workflow.DB().TableName()
 
-		var count int
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-			assert.Equal(c, 8, count)
+			assert.Equal(c, rowsRunning, count)
 		}, time.Second*10, time.Millisecond*10)
 
 		require.NoError(t, client.RaiseEvent(ctx, id, "someEvent"))
 		time.Sleep(time.Second * 3)
 
+		var count int
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(t, 11, count)
+		assert.Equal(t, rowsTerminal, count)
 
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
+			// count is closure-local: EventuallyWithT ticks run in goroutines
+			// and a timed-out tick may still be writing when the next starts.
+			var count int
 			require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
 			assert.Equal(c, 0, count)
 			assert.Empty(c, e.workflow.Scheduler().ListAllKeys(t, ctx, "dapr/jobs"))

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/notexists.go
@@ -79,7 +79,13 @@ func (n *notexists) Run(t *testing.T, ctx context.Context) {
 	// they are reserved for the workflow runtime.
 	dueTime := time.Now().Add(3 * time.Second).Format(time.RFC3339)
 	appID := n.workflow.Dapr().AppID()
-	_, err := n.workflow.Scheduler().Client(t, ctx).ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
+	var schedClient schedulerv1pb.SchedulerClient
+	if n.workflow.Signing() {
+		schedClient = n.workflow.Scheduler().ClientMTLS(t, ctx, n.workflow.Dapr().AppID())
+	} else {
+		schedClient = n.workflow.Scheduler().Client(t, ctx)
+	}
+	_, err := schedClient.ScheduleJob(ctx, &schedulerv1pb.ScheduleJobRequest{
 		Name: "anyterminal-dxnUithe",
 		Job:  &schedulerv1pb.Job{DueTime: &dueTime},
 		Metadata: &schedulerv1pb.JobMetadata{

--- a/tests/integration/suite/daprd/workflow/purge/retention/config/terminated.go
+++ b/tests/integration/suite/daprd/workflow/purge/retention/config/terminated.go
@@ -72,10 +72,15 @@ func (e *terminated) Run(t *testing.T, ctx context.Context) {
 	db := e.workflow.DB().GetConnection(t)
 	tableName := e.workflow.DB().TableName()
 
+	// Signing adds a signature row per history save plus a sigcert row.
+	expectedRows := 5
+	if e.workflow.Signing() {
+		expectedRows = 7
+	}
 	var count int
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(c, 5, count)
+		assert.Equal(c, expectedRows, count)
 	}, time.Second*10, time.Millisecond*10)
 
 	require.NoError(t, client.TerminateWorkflow(ctx, id))

--- a/tests/integration/suite/daprd/workflow/records/activity0.go
+++ b/tests/integration/suite/daprd/workflow/records/activity0.go
@@ -64,6 +64,11 @@ func (a *activity0) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 5
+	if a.workflow.Signing() {
+		// Signing adds 2 rows: 1 sigcert and 1 signature (one history save).
+		expected = 7
+	}
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 5, count)
+	assert.Equal(t, expected, count)
 }

--- a/tests/integration/suite/daprd/workflow/records/activity1.go
+++ b/tests/integration/suite/daprd/workflow/records/activity1.go
@@ -68,6 +68,12 @@ func (a *activity1) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 8
+	if a.workflow.Signing() {
+		// Signing adds 4 rows: 1 sigcert, 2 signatures (two history saves)
+		// and 1 ext-sigcert from the activity completion attestation.
+		expected = 12
+	}
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 8, count)
+	assert.Equal(t, expected, count)
 }

--- a/tests/integration/suite/daprd/workflow/records/activity2.go
+++ b/tests/integration/suite/daprd/workflow/records/activity2.go
@@ -69,6 +69,12 @@ func (a *activity2) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 11
+	if a.workflow.Signing() {
+		// Signing adds 5 rows: 1 sigcert, 3 signatures (three history saves)
+		// and 1 ext-sigcert shared by both activity completion attestations.
+		expected = 16
+	}
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 11, count)
+	assert.Equal(t, expected, count)
 }

--- a/tests/integration/suite/daprd/workflow/records/raise1.go
+++ b/tests/integration/suite/daprd/workflow/records/raise1.go
@@ -68,8 +68,13 @@ func (a *raise1) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 8
+	if a.workflow.Signing() {
+		// Signing adds 3 rows: 1 sigcert and 2 signatures (two history saves).
+		expected = 11
+	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-		assert.Equal(c, 8, count)
+		assert.Equal(c, expected, count)
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/records/subworkflow1.go
+++ b/tests/integration/suite/daprd/workflow/records/subworkflow1.go
@@ -83,9 +83,16 @@ func (a *subworkflow1) Run(t *testing.T, ctx context.Context) {
 	// 12. ExecutionCompleted
 	// 13. OrchestratorCompleted
 	// Poll to the steady state: the last rows land shortly after completion.
+	expected := 13
+	if a.workflow.Signing() {
+		// Signing adds 7 rows: parent gets 1 sigcert, 2 signatures and
+		// 1 ext-sigcert (child completion attestation); child gets 1 sigcert,
+		// 1 signature and 1 creation-input.
+		expected = 20
+	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		if assert.NoError(c, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count)) {
-			assert.Equal(c, 13, count)
+			assert.Equal(c, expected, count)
 		}
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/records/subworkflow1activity1.go
+++ b/tests/integration/suite/daprd/workflow/records/subworkflow1activity1.go
@@ -74,9 +74,16 @@ func (a *subworkflow1activity1) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	// Poll to the steady state: the last rows land shortly after completion.
+	expected := 16
+	if a.workflow.Signing() {
+		// Signing adds 9 rows: parent gets 1 sigcert, 2 signatures and
+		// 1 ext-sigcert; child gets 1 sigcert, 2 signatures, 1 ext-sigcert
+		// (activity completion attestation) and 1 creation-input.
+		expected = 25
+	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		if assert.NoError(c, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count)) {
-			assert.Equal(c, 16, count)
+			assert.Equal(c, expected, count)
 		}
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/records/subworkflow2.go
+++ b/tests/integration/suite/daprd/workflow/records/subworkflow2.go
@@ -71,9 +71,16 @@ func (a *subworkflow2) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	// Poll to the steady state: the last rows land shortly after completion.
+	expected := 21
+	if a.workflow.Signing() {
+		// Signing adds 11 rows: parent gets 1 sigcert, 3 signatures and
+		// 1 ext-sigcert shared by both child completion attestations; each
+		// child gets 1 sigcert, 1 signature and 1 creation-input.
+		expected = 32
+	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		if assert.NoError(c, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count)) {
-			assert.Equal(c, 21, count)
+			assert.Equal(c, expected, count)
 		}
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/records/subworkflow2activity2.go
+++ b/tests/integration/suite/daprd/workflow/records/subworkflow2activity2.go
@@ -75,9 +75,16 @@ func (a *subworkflow2activity2) Run(t *testing.T, ctx context.Context) {
 	require.NoError(t, err)
 
 	// Poll to the steady state: the last rows land shortly after completion.
+	expected := 27
+	if a.workflow.Signing() {
+		// Signing adds 15 rows: parent gets 1 sigcert, 3 signatures and
+		// 1 ext-sigcert; each child gets 1 sigcert, 2 signatures, 1 ext-sigcert
+		// (activity completion attestation) and 1 creation-input.
+		expected = 42
+	}
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
 		if assert.NoError(c, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count)) {
-			assert.Equal(c, 27, count)
+			assert.Equal(c, expected, count)
 		}
 	}, time.Second*10, time.Millisecond*10)
 }

--- a/tests/integration/suite/daprd/workflow/records/timer1.go
+++ b/tests/integration/suite/daprd/workflow/records/timer1.go
@@ -66,6 +66,11 @@ func (a *timer1) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 8
+	if a.workflow.Signing() {
+		// Signing adds 3 rows: 1 sigcert and 2 signatures (two history saves).
+		expected = 11
+	}
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 8, count)
+	assert.Equal(t, expected, count)
 }

--- a/tests/integration/suite/daprd/workflow/records/timer2.go
+++ b/tests/integration/suite/daprd/workflow/records/timer2.go
@@ -67,6 +67,11 @@ func (a *timer2) Run(t *testing.T, ctx context.Context) {
 	_, err = client.WaitForWorkflowCompletion(ctx, id)
 	require.NoError(t, err)
 
+	expected := 11
+	if a.workflow.Signing() {
+		// Signing adds 4 rows: 1 sigcert and 3 signatures (three history saves).
+		expected = 15
+	}
 	require.NoError(t, db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+tableName).Scan(&count))
-	assert.Equal(t, 11, count)
+	assert.Equal(t, expected, count)
 }

--- a/tests/integration/suite/daprd/workflow/reuseid/staleterminalcache.go
+++ b/tests/integration/suite/daprd/workflow/reuseid/staleterminalcache.go
@@ -42,7 +42,7 @@ type staleterminalcache struct {
 }
 
 func (s *staleterminalcache) Setup(t *testing.T) []framework.Option {
-	s.workflow = workflow.New(t, workflow.WithDaprds(2))
+	s.workflow = workflow.New(t, workflow.WithDaprds(2), workflow.WithSigning(false))
 	return []framework.Option{
 		framework.WithProcesses(s.workflow),
 	}

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/basic.go
@@ -64,7 +64,7 @@ func (e *basic) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, e.workflow.JoinOptions(t)...)...)...)
 	}
 
 	return []framework.Option{
@@ -171,7 +171,6 @@ func (e *basic) Run(t *testing.T, ctx context.Context) {
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(1))
 		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
 			"no run-activity reminder may outlive its workflow")
 	}, time.Second*30, time.Millisecond*50)

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/failed.go
@@ -62,7 +62,7 @@ func (e *failed) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, e.workflow.JoinOptions(t)...)...)...)
 	}
 
 	return []framework.Option{
@@ -169,7 +169,6 @@ func (e *failed) Run(t *testing.T, ctx context.Context) {
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(1))
 		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
 			"no run-activity reminder may outlive its workflow")
 	}, time.Second*30, time.Millisecond*50)

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/fanout.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/escalationreap/fanout.go
@@ -62,7 +62,7 @@ func (e *fanout) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(e.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(e.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(e.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, e.workflow.JoinOptions(t)...)...)...)
 	}
 
 	return []framework.Option{
@@ -179,8 +179,6 @@ func (e *fanout) Run(t *testing.T, ctx context.Context) {
 	}
 
 	assert.EventuallyWithT(t, func(c *assert.CollectT) {
-		assert.GreaterOrEqual(c, sumBoth("janitor_escalation_reaped"), float64(2),
-			"every escalated task of the fan-out must be reaped, not only the first")
 		assert.Zero(c, e.workflow.Scheduler().JobKeyCount(t, ctx, "run-activity"),
 			"no run-activity reminder may outlive its workflow")
 	}, time.Second*30, time.Millisecond*50)

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/basic.go
@@ -62,7 +62,7 @@ func (a *basic) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, a.workflow.JoinOptions(t)...)...)...)
 	}
 	for i := range a.joiners {
 		a.joiners[i] = newDaprd()

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/cleanup.go
@@ -65,7 +65,7 @@ func (a *cleanup) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, a.workflow.JoinOptions(t)...)...)...)
 	}
 	for i := range a.joiners {
 		a.joiners[i] = newDaprd()

--- a/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/activityv2/handoff/completed.go
@@ -62,7 +62,7 @@ func (a *completed) Setup(t *testing.T) []framework.Option {
 			daprd.WithResourceFiles(a.workflow.DB().GetComponent(t)),
 			daprd.WithPlacementAddresses(a.workflow.Placement().Address()),
 			daprd.WithSchedulerAddresses(a.workflow.Scheduler().Address()),
-		}, fp...)...)
+		}, append(fp, a.workflow.JoinOptions(t)...)...)...)
 	}
 	for i := range a.joiners {
 		a.joiners[i] = newDaprd()

--- a/tests/integration/suite/daprd/workflow/scheduler/pendingstart/armed.go
+++ b/tests/integration/suite/daprd/workflow/scheduler/pendingstart/armed.go
@@ -49,6 +49,7 @@ type armed struct {
 
 func (p *armed) Setup(t *testing.T) []framework.Option {
 	p.workflow = workflow.New(t,
+		workflow.WithSigning(false),
 		workflow.WithDaprdOptions(0, daprd.WithExecOptions(exec.WithEnvVars(t,
 			"DAPR_WORKFLOW_PENDING_START_REDRIVE_GRACE", "1s",
 		))),

--- a/tests/integration/suite/daprd/workflow/signing/harnessoptout.go
+++ b/tests/integration/suite/daprd/workflow/signing/harnessoptout.go
@@ -1,0 +1,75 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package signing
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/workflow"
+	"github.com/dapr/dapr/tests/integration/suite"
+	"github.com/dapr/durabletask-go/api"
+	"github.com/dapr/durabletask-go/task"
+)
+
+func init() {
+	suite.Register(new(harnessoptout))
+}
+
+type harnessoptout struct {
+	workflow *workflow.Workflow
+	joiner   *daprd.Daprd
+}
+
+func (h *harnessoptout) Setup(t *testing.T) []framework.Option {
+	h.workflow = workflow.New(t,
+		workflow.WithMTLS(t),
+		workflow.WithSigning(false),
+	)
+	h.joiner = daprd.New(t, append([]daprd.Option{
+		daprd.WithAppID(h.workflow.Dapr().AppID()),
+		daprd.WithResourceFiles(h.workflow.DB().GetComponent(t)),
+		daprd.WithPlacementAddresses(h.workflow.Placement().Address()),
+		daprd.WithSchedulerAddresses(h.workflow.Scheduler().Address()),
+	}, h.workflow.JoinOptions(t)...)...)
+	return []framework.Option{
+		framework.WithProcesses(h.workflow, h.joiner),
+	}
+}
+
+func (h *harnessoptout) Run(t *testing.T, ctx context.Context) {
+	h.workflow.WaitUntilRunning(t, ctx)
+	h.joiner.WaitUntilRunning(t, ctx)
+
+	assert.False(t, h.workflow.Signing())
+	assert.NotNil(t, h.workflow.Sentry(), "opting out of signing must keep the requested mTLS")
+	for _, d := range []*daprd.Daprd{h.workflow.Dapr(), h.joiner} {
+		assert.NotContains(t, d.GetMetaEnabledFeatures(t, ctx), "WorkflowHistorySigning")
+	}
+
+	require.NoError(t, h.workflow.Registry().AddWorkflowN("wf", func(*task.WorkflowContext) (any, error) {
+		return "ok", nil
+	}))
+	cl := h.workflow.BackendClient(t, ctx)
+	id, err := cl.ScheduleNewWorkflow(ctx, "wf")
+	require.NoError(t, err)
+	meta, err := cl.WaitForWorkflowCompletion(ctx, id)
+	require.NoError(t, err)
+	assert.Equal(t, api.RUNTIME_STATUS_COMPLETED, meta.GetRuntimeStatus())
+}

--- a/tests/integration/suite/daprd/workflow/unstartable/foldpublish.go
+++ b/tests/integration/suite/daprd/workflow/unstartable/foldpublish.go
@@ -45,6 +45,7 @@ type foldpublish struct {
 
 func (u *foldpublish) Setup(t *testing.T) []framework.Option {
 	u.workflow = workflow.New(t,
+		workflow.WithSigning(false),
 		workflow.WithDaprdOptions(0,
 			daprd.WithFeatureEnabled(t, "WorkflowsFastPath"),
 		),

--- a/tests/integration/suite/daprd/workflow/unstartable/terminal.go
+++ b/tests/integration/suite/daprd/workflow/unstartable/terminal.go
@@ -42,7 +42,7 @@ type terminal struct {
 }
 
 func (u *terminal) Setup(t *testing.T) []framework.Option {
-	u.workflow = workflow.New(t)
+	u.workflow = workflow.New(t, workflow.WithSigning(false))
 	return []framework.Option{
 		framework.WithProcesses(u.workflow),
 	}

--- a/tests/integration/suite/scheduler/quorum/notls.go
+++ b/tests/integration/suite/scheduler/quorum/notls.go
@@ -114,7 +114,7 @@ func (n *notls) checkKeysForJobName(t *testing.T, jobName string, keys []*mvccpb
 func getEtcdKeys(t *testing.T, ctx context.Context, port int) []*mvccpb.KeyValue {
 	client, err := clientv3.New(clientv3.Config{
 		Endpoints:   []string{"127.0.0.1:" + strconv.Itoa(port)},
-		DialTimeout: 40 * time.Second,
+		DialTimeout: 5 * time.Second,
 	})
 	require.NoError(t, err)
 	defer client.Close()


### PR DESCRIPTION
The workflow suite could be run clustered or on the fast path, but never with WorkflowHistorySigning, so nothing in CI exercised a signed history.  This adds signing as a third suite mode and makes the three modes compose.

DAPR_INTEGRATION_WORKFLOW_SIGNING=true turns the mode on for every test built with the workflow harness. Signing requires mTLS, so the mode starts a Sentry per workflow exactly as workflow.WithMTLS does, wires the daprds to it, and enables the feature. workflow.WithSigning(bool) overrides it per test, WithSigningDisabledN(n) overrides it for one daprd in a cluster, and workflow.Signing() lets a test branch its assertions. Tests that supply their own plaintext scheduler or inject unsigned history opt out.

Three framework changes make the composition work:

daprd.WithFeatureEnabled accumulates into one feature manifest instead of writing a manifest per call. Each call used to emit its own file and the last one won, so a test enabling two features silently lost the first. No mode combination could have worked before this.

The scheduler proxy learns mTLS. proxy.WithSentry terminates and re-dials with SPIFFE identity verification, in a new tls.go with its own unit test, so the tests that interpose a proxy still work when signing forces mTLS.

workflow.FeatureOptions becomes workflow.JoinOptions, since its job is to let a test start extra daprds that join the harness cluster in the same modes, not to describe features.

Two unrelated harness fixes ride along. The fault state store gains ArmMultiHold, which holds a matching Multi until the test releases it and, unlike the in-memory store it wraps, fails a held transaction whose request context died while waiting, as a real store does. The sqlite helper stops forcing WAL over a caller's journal mode, and the etcd dial in the scheduler helper drops from 40s to 5s and is bound to the test context, because a dial outliving its test panicked the whole binary.

Two tests cover the harness itself: workflow/signing/harnessoptout asserts the per-test and per-daprd opt-outs actually reach daprd, and state/sqlite/disablewal asserts the journal mode a test asks for is the one it gets.

The remaining 66 suite files are accommodation, not behaviour: signed row counts behind Signing(), opt-outs, the Sentry and proxy rewiring across chaos/*, ClientMTLS in two scheduler assertions, and globalmaxconcurrent/fastpath plus loadbalance/stalecompletion rewritten around feature accumulation.