### PR TITLE
fix(pubsub): treat empty status in Deliver as retry to match DeliverBulk

### DIFF
--- a/pkg/runtime/subscription/postman/http/http.go
+++ b/pkg/runtime/subscription/postman/http/http.go
@@ -131,15 +131,15 @@ func (h *http) Deliver(ctx context.Context, msg *pubsub.SubscribedMessage) error
 
 		switch appResponse.Status {
 		case "":
-			// Consider empty status field as success
+			// Consider empty status field as retry
 			fallthrough
-		case contribpubsub.Success:
-			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Success)), "", msg.Topic, elapsed)
-			return nil
 		case contribpubsub.Retry:
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Retry)), "", msg.Topic, elapsed)
 			// TODO: add retry error info
 			return fmt.Errorf("RETRY status returned from app while processing pub/sub event %v: %w", cloudEvent[contribpubsub.IDField], rterrors.NewRetriable(nil))
+		case contribpubsub.Success:
+			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Success)), "", msg.Topic, elapsed)
+			return nil
 		case contribpubsub.Drop:
 			diag.DefaultComponentMonitoring.PubsubIngressEvent(ctx, msg.PubSub, strings.ToLower(string(contribpubsub.Drop)), strings.ToLower(string(contribpubsub.Success)), msg.Topic, elapsed)
 			log.Warnf("DROP status returned from app while processing pub/sub event %v", cloudEvent[contribpubsub.IDField])

--- a/pkg/runtime/subscription/postman/http/http_test.go
+++ b/pkg/runtime/subscription/postman/http/http_test.go
@@ -360,7 +360,7 @@ func TestOnNewPublishedMessage(t *testing.T) {
 
 		mockAppChannel.On("InvokeMethod", mock.MatchedBy(matchContextInterface), fakeReq).Return(fakeResp, nil)
 
-		require.NoError(t, h.Deliver(t.Context(), testPubSubMessage), "expected no error on empty status")
+		require.Error(t, h.Deliver(t.Context(), testPubSubMessage), "expected retry error on empty status")
 		mockAppChannel.AssertNumberOfCalls(t, "InvokeMethod", 1)
 	})
 


### PR DESCRIPTION
Closes #8737

In the HTTP subscription postman, `Deliver` and `DeliverBulk` handle empty status (``) differently. `Deliver` falls through to success while `DeliverBulk` falls through to retry. This was flagged by @cicoyle in the [#8692 review](https://github.com/dapr/dapr/pull/8692#discussion_r2099378669).

This PR makes `Deliver` consistent with `DeliverBulk` by treating empty status as retry — the safer default when an app returns no explicit status.

Changes:
- `pkg/runtime/subscription/postman/http/http.go`: change `case ""/>` fallthrough from `Success` to `Retry`
- `pkg/runtime/subscription/postman/http/http_test.go`: update empty-status test to expect retry error