### PR TITLE
docs: correct and complete the metrics reference

### DIFF
--- a/docs/development/dapr-metrics.md
+++ b/docs/development/dapr-metrics.md
@@ -1,6 +1,7 @@
 # Dapr metrics
 
-Dapr metric name starts with `dapr_` prefix except for health metrics.
+Dapr metric name starts with `dapr_` prefix except for health metrics. Names below are the names
+as scraped by a metrics exporter. The names in code use `/` separators, which the exporter replaces with `_`.
 
   * [Dapr Common metrics](#dapr-common-metrics)
   * [Dapr Operator metrics](#dapr-operator-metrics)
@@ -30,21 +31,21 @@ Dapr uses prometheus process and go collectors by default.
 
 ## Dapr Sidecar-injector metrics
 
-[monitoring metrics](../../pkg/injector/monitoring/metrics.go)
+[monitoring metrics](../../pkg/injector/service/metrics.go)
 
-* dapr_injector_sidecar_injection/requests_total: The total number of sidecar injection requests.
-* dapr_injector_sidecar_injection/succeeded_total: The total number of successful sidecar injections.
-* dapr_injector_sidecar_injection/failed_total: The total number of failed sidecar injections.
+* dapr_injector_sidecar_injection_requests_total: The total number of sidecar injection requests.
+* dapr_injector_sidecar_injection_succeeded_total: The total number of successful sidecar injections.
+* dapr_injector_sidecar_injection_failed_total: The total number of failed sidecar injections. Tagged with `reason`.
 
 ## Dapr Placement metrics
 
 [monitoring metrics](../../pkg/placement/monitoring/metrics.go)
 
 * dapr_placement_runtimes_total: The total number of hosts reported to placement service.
-* dapr_placement_actorruntimes_total: The total number of actor runtimes reported to placement service.
-* dapr_placement_actor_heartbeat_timestamp: The actor's heartbeat timestamp (in seconds) was last reported to the placement service.
+* dapr_placement_actor_runtimes_total: The total number of actor runtimes reported to placement service.
 * dapr_placement_leader_status: Leadership status of the placement service (1 for leader, 0 for not leader).
 * dapr_placement_raft_leader_status: Leadership status of the raft server (1 for leader, 0 for not leader).
+* dapr_placement_actor_heartbeat_timestamp: The actor's heartbeat timestamp (in seconds) last reported to the placement service. Not available from 1.17 onwards.
 
 ## Dapr Sentry metrics
 
@@ -63,10 +64,33 @@ Dapr uses prometheus process and go collectors by default.
 
 * dapr_scheduler_sidecars_connected: The total number of dapr sidecars connected to the scheduler service.
 * dapr_scheduler_jobs_created_total: The total number of jobs scheduled.
+* dapr_scheduler_jobs_created_failed_total: The total number of jobs that failed to be scheduled.
 * dapr_scheduler_jobs_triggered_total: The total number of successfully triggered jobs.
-* dapr_scheduler_trigger_jobs_failed_total: The total number of failed jobs.
-* dapr_scheduler_trigger_jobs_undelivered_total: The total number of undelivered jobs.
+* dapr_scheduler_jobs_failed_total: The total number of failed jobs.
+* dapr_scheduler_jobs_undelivered_total: The total number of undelivered jobs.
+* dapr_scheduler_jobs_deleted_total: The total number of deleted jobs.
+* dapr_scheduler_jobs_bulk_deleted_total: The total number of jobs deleted by bulk delete.
 * dapr_scheduler_trigger_latency: The total time it takes to trigger a job from the scheduler service.
+* dapr_scheduler_sidecar_errors_total: The total number of errors returned by sidecars when triggering jobs.
+* dapr_scheduler_concurrency_inflight: The number of job triggers currently in flight.
+* dapr_scheduler_concurrency_pending: The number of job triggers waiting on a concurrency slot.
+* dapr_scheduler_concurrency_throttled_total: The total number of job triggers throttled by concurrency limits.
+* dapr_scheduler_placement_leader: Leadership status of the scheduler's placement service (1 for leader, 0 for not leader).
+* dapr_scheduler_placement_streams_connected: The number of sidecar placement streams connected to the scheduler.
+* dapr_scheduler_placement_disseminations_total: The total number of placement table disseminations.
+* dapr_scheduler_placement_dissemination_latency: The time taken to disseminate a placement table.
+* dapr_scheduler_placement_table_updates_total: The total number of placement table updates.
+* dapr_scheduler_placement_incapable_sidecars: The number of connected sidecars that cannot use scheduler-hosted placement.
+
+The Scheduler also exposes the collectors registered by its embedded etcd server on the same
+endpoint. These register directly with the default Prometheus registry rather than through an
+OpenCensus view, so they do not carry the `dapr` namespace:
+
+* etcd_* : [etcd server metrics](https://etcd.io/docs/v3.5/metrics/), for example `etcd_server_has_leader`, `etcd_mvcc_db_total_size_in_bytes` and `etcd_server_quota_backend_bytes`
+* grpc_* : [go-grpc-prometheus](https://github.com/grpc-ecosystem/go-grpc-prometheus) server metrics, registered by etcd's gRPC server
+* os_* : etcd's file descriptor collector, `os_fd_used` and `os_fd_limit`
+
+Set `--etcd-metrics=extensive` to include etcd's histogram metrics; the default is `basic`.
 
 ## Dapr Runtime metrics
 
@@ -74,7 +98,7 @@ Dapr uses prometheus process and go collectors by default.
 
 [errorcode metrics](../../pkg/diagnostics/errorcode_monitoring.go)
 
-* error_code_count: Number of times an error with a specific error code occurred.
+* dapr_error_code_total: Number of times an error with a specific error code occurred. Only recorded when `spec.metrics.recordErrorCodes` is true on the associated Dapr Configuration resource.
 
 
 ### Service related metrics
@@ -104,17 +128,35 @@ Dapr uses prometheus process and go collectors by default.
 
 #### Actors
 
-* dapr_runtime_actor_status_report_total: The number of the successful status reports to placement service.
-* dapr_runtime_actor_status_report_fail_total: The number of the failed status reports to placement service
-* dapr_runtime_actor_table_operation_recv_total: The number of the received actor placement table operations.
+* dapr_runtime_actor_status_report_total: The number of the successful status reports to placement service. Not available from 1.17 onwards.
+* dapr_runtime_actor_status_report_fail_total: The number of the failed status reports to placement service. Not available from 1.17 onwards.
+* dapr_runtime_actor_table_operation_recv_total: The number of the received actor placement table operations. Not available from 1.17 onwards.
 * dapr_runtime_actor_rebalanced_total: The number of the actor rebalance requests.
 * dapr_runtime_actor_deactivated_total: The number of the successful actor deactivation.
 * dapr_runtime_actor_deactivated_failed_total: The number of the failed actor deactivation.
 * dapr_runtime_actor_pending_actor_calls: The number of pending actor calls waiting to acquire the per-actor lock.
 * dapr_runtime_actor_timers: The number of actor timers requests.
-* dapr_runtime_actor_reminders: The number of actor reminders requests.
+* dapr_runtime_actor_reminders: The number of actor reminders requests. Not available from 1.17 onwards.
 * dapr_runtime_actor_reminders_fired_total: The number of actor reminders fired requests.
 * dapr_runtime_actor_timers_fired_total: The number of actor timers fired requests.
+* dapr_runtime_actor_timers_dropped_total: The number of actor timers dropped.
+
+There is no metric for the number of currently active actors. Active actor counts per type are
+available from the [metadata API](https://docs.dapr.io/reference/api/metadata_api/)
+(`GET /v1.0/metadata`, under `actor_runtime.active_actors`).
+
+#### Access control
+
+Recorded only when access control policies are configured. The app and global policy metrics come
+from the [access control allow list](https://docs.dapr.io/operations/configuration/invoke-allowlist/)
+on the Configuration resource; the workflow metrics come from the WorkflowAccessPolicy resource.
+
+* dapr_runtime_acl_app_policy_action_allowed_total: The number of requests allowed by an app access control policy.
+* dapr_runtime_acl_app_policy_action_blocked_total: The number of requests blocked by an app access control policy.
+* dapr_runtime_acl_global_policy_action_allowed_total: The number of requests allowed by the global access control policy.
+* dapr_runtime_acl_global_policy_action_blocked_total: The number of requests blocked by the global access control policy.
+* dapr_runtime_workflow_acl_action_allowed_total: The number of workflow requests allowed by access control.
+* dapr_runtime_workflow_acl_action_denied_total: The number of workflow requests denied by access control.
 
 #### Resiliency
 
@@ -130,12 +172,26 @@ Dapr uses prometheus process and go collectors by default.
 * dapr_runtime_workflow_operation_count: The number of successful/failed workflow operation requests.
 * dapr_runtime_workflow_operation_latency: The latencies of responses for workflow operation requests.
 * dapr_runtime_workflow_execution_count: The number of successful/failed/terminated/recoverable workflow executions.
+* dapr_runtime_workflow_execution_latency: The end-to-end time taken to run a workflow to completion.
+* dapr_runtime_workflow_scheduling_latency: The delay between a workflow being requested and its execution starting.
 * dapr_runtime_workflow_activity_operation_count: The number of successful/failed/recoverable activity requests.
 * dapr_runtime_workflow_activity_operation_latency: The total time taken to run an activity request.
 * dapr_runtime_workflow_activity_execution_count: The number of successful/failed/recoverable activity executions.
 * dapr_runtime_workflow_activity_execution_latency: The total time taken to run an activity to completion.
 * dapr_runtime_workflow_payload_size_ratio: Workflow dispatch payload size as a fraction of the configured gRPC `--max-body-size`; values >0.95 trip the graceful stall, values >1 exceed the limit. Not recorded when `--max-body-size` is non-positive.
 * dapr_runtime_workflow_activity_payload_size_ratio: Activity dispatch payload size as a fraction of the configured gRPC `--max-body-size`; values >0.95 trip the graceful stall, values >1 exceed the limit. Not recorded when `--max-body-size` is non-positive.
+* dapr_runtime_workflow_completion_route_count: The number of workflow completions by route.
+* dapr_runtime_workflow_completions_fold_count: The number of folded workflow completions.
+* dapr_runtime_workflow_completions_fold_wait_latency: The time spent waiting to fold workflow completions.
+* dapr_runtime_workflow_local_wake_count: The number of local workflow wakes.
+* dapr_runtime_workflow_local_wake_drive_latency: The time taken to drive a local workflow wake.
+* dapr_runtime_workflow_local_activity_count: The number of local activity executions.
+* dapr_runtime_workflow_local_activity_drive_latency: The time taken to drive a local activity.
+* dapr_runtime_workflow_lock_wait: The time spent waiting on the workflow lock.
+* dapr_runtime_workflow_attestation_generated_count: The number of workflow attestations generated.
+* dapr_runtime_workflow_attestation_verified_count: The number of workflow attestations verified.
+* dapr_runtime_workflow_attestation_verify_latency: The time taken to verify a workflow attestation.
+* dapr_runtime_workflow_attestation_cert_cache_count: The number of workflow attestation certificate cache lookups.
 
 ### gRPC monitoring metrics
 
@@ -159,9 +215,7 @@ Dapr leverages opencensus ocgrpc plugin to generate gRPC server and client metri
 
 ### HTTP monitoring metrics
 
-We support only server side metrics.
-
-* [server metrics](../../pkg/diagnostics/http_monitoring.go)
+* [http metrics](../../pkg/diagnostics/http_monitoring.go)
 
 #### Server metrics
 > Note: Server metrics are prefixed by a forward slash character `/`
@@ -179,6 +233,11 @@ We support only server side metrics.
 * dapr_http_client_roundtrip_latency: End-to-end latency
 * dapr_http_client_completed_count: Count of completed requests
 
+#### App health probe metrics
+
+* dapr_http_healthprobes_completed_count: Count of completed app health probes
+* dapr_http_healthprobes_roundtrip_latency: End-to-end latency of app health probes
+
 ## Dapr Component Metrics
 
 ### Pub/Sub metrics
@@ -187,6 +246,15 @@ We support only server side metrics.
 * dapr_component_pubsub_ingress_count: The number of incoming messages arriving from the pub/sub component
 * dapr_component_pubsub_egress_count: The number of outgoing messages published to the pub/sub component
 * dapr_component_pubsub_egress_latencies: The latency of the response from the pub/sub component
+* dapr_component_pubsub_ingress_bulk_count: The number of incoming bulk requests arriving from the pub/sub component
+* dapr_component_pubsub_ingress_bulk_event_count: The number of individual events inside incoming bulk requests
+* dapr_component_pubsub_ingress_bulk_latencies: The consuming app bulk event processing latency
+* dapr_component_pubsub_egress_bulk_count: The number of outgoing bulk requests published to the pub/sub component
+* dapr_component_pubsub_egress_bulk_event_count: The number of individual events inside outgoing bulk requests
+* dapr_component_pubsub_egress_bulk_latencies: The latency of the response to bulk publishes
+
+Ingress metrics are tagged with `process_status` and `status`; egress metrics are tagged with
+`success`. Both carry `app_id`, `component`, `namespace` and `topic`.
 
 ### Bindings metrics
 
@@ -199,6 +267,16 @@ We support only server side metrics.
 
 * dapr_component_state_count: The number of operations performed on the state component
 * dapr_component_state_latencies: The latency of the response from the state component
+
+### Conversation metrics
+
+* dapr_component_conversation_count: The number of operations performed on the conversation component
+* dapr_component_conversation_latencies: The latency of the response from the conversation component
+
+### Cryptography metrics
+
+* dapr_component_crypto_count: The number of operations performed on the crypto component
+* dapr_component_crypto_latencies: The latency of the response from the crypto component
 
 ### Configuration metrics
 


### PR DESCRIPTION
Fixes #10495. Docs only.

Corrects metric names that do not match the registered views, adds the registered metrics that were missing, and marks those no longer available from 1.17 onwards.

## Corrections

| Documented | Registered |
| --- | --- |
| `dapr_injector_sidecar_injection/requests_total` (and `/succeeded_total`, `/failed_total`) | `dapr_injector_sidecar_injection_requests_total`, ... |
| `dapr_placement_actorruntimes_total` | `dapr_placement_actor_runtimes_total` |
| `dapr_scheduler_trigger_jobs_failed_total` | `dapr_scheduler_jobs_failed_total` |
| `dapr_scheduler_trigger_jobs_undelivered_total` | `dapr_scheduler_jobs_undelivered_total` |
| `error_code_count` | `dapr_error_code_total` |

The injector entries used the `/` separators from the view names, which the exporter replaces with `_`, so they were never scraped under the documented names. The HTTP section also said server-side metrics only, then listed the client metrics below it.

## Not available from 1.17 onwards

`dapr_runtime_actor_status_report_total`, `dapr_runtime_actor_status_report_fail_total`, `dapr_runtime_actor_table_operation_recv_total`, `dapr_runtime_actor_reminders` and `dapr_placement_actor_heartbeat_timestamp` produce no series on 1.17 or later. Marked in place rather than deleted, since 1.16 and earlier still have them.

Three of them are charted on the shipped `grafana/grafana-sidecar-dashboard.json`, so those panels are permanently empty. That is a code change and not in scope here.

## Additions

The missing metrics are enumerated in #10495 — workflow execution and scheduling latency, Scheduler job lifecycle / concurrency / placement metrics, bulk pub/sub, access control, conversation and crypto components, app health probes, and `dapr_runtime_actor_timers_dropped_total`.

## Verification

Every `dapr_*` name in the document was matched against the view-name literals registered in `pkg/diagnostics`, `pkg/scheduler/monitoring`, `pkg/placement/monitoring`, `pkg/sentry/monitoring`, `pkg/operator/monitoring` and `pkg/injector/service`. 130 of 132 match exactly; the other two are the OpenCensus `ocgrpc` plugin's views, defined outside this repo.

Cross-checked against a live 1.18.4 cluster, including an actor workload for the unavailable metrics. Under five activated actors, three reminders and three timers, those five have zero series while `dapr_runtime_actor_rebalanced_total`, `_deactivated_total`, `_reminders_fired_total`, `_timers_fired_total` and `_timers` all record normally — rebalancing cannot happen without the placement table operations that `table_operation_recv_total` fails to count.