### PR TITLE
fix: derive inbound pubsub resiliency runner from the component context

### DIFF
--- a/pkg/runtime/subscription/subscription.go
+++ b/pkg/runtime/subscription/subscription.go
@@ -355,7 +355,7 @@ func New(opts Options) (*Subscription, error) {
 			PubSub:       name,
 			SubscriberID: s.connectionID,
 		}
-		policyRunner := resiliency.NewRunner[any](context.Background(), policyDef)
+		policyRunner := resiliency.NewRunner[any](ctx, policyDef)
 		_, err = policyRunner(func(ctx context.Context) (any, error) {
 			pErr := s.postman.Deliver(ctx, sm)
 

--- a/pkg/runtime/subscription/subscription_rebalance_test.go
+++ b/pkg/runtime/subscription/subscription_rebalance_test.go
@@ -1,0 +1,128 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package subscription
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	contribpubsub "github.com/dapr/components-contrib/pubsub"
+	resiliencyV1alpha "github.com/dapr/dapr/pkg/apis/resiliency/v1alpha1"
+	"github.com/dapr/dapr/pkg/resiliency"
+	rterrors "github.com/dapr/dapr/pkg/runtime/errors"
+	runtimePubsub "github.com/dapr/dapr/pkg/runtime/pubsub"
+	fakepostman "github.com/dapr/dapr/pkg/runtime/subscription/postman/fake"
+)
+
+// TestRebalanceCancelsInboundDelivery covers dapr/components-contrib#4580.
+//
+// The context a component hands the inbound handler is that component's own
+// subscription context - for Kafka it is literally sarama's session.Context(),
+// which is cancelled the moment the consumer group starts a rebalance. If the
+// inbound resiliency runner does not derive from it, neither an in-flight app
+// invocation nor a retry backoff can be interrupted, ConsumeClaim cannot return,
+// the member is evicted, and a permanently-failing message oscillates between
+// consumers forever.
+func TestRebalanceCancelsInboundDelivery(t *testing.T) {
+	// deliverAndCancel delivers one message, waits until the app has been
+	// invoked, then cancels the context the component handed the handler
+	// (the rebalance). It returns the handler's error, or fails the test if
+	// the handler is still blocked 2s later.
+	deliverAndCancel := func(t *testing.T, prov resiliency.Provider, pubsubName string, deliverFn func(context.Context, *runtimePubsub.SubscribedMessage) error, invoked <-chan struct{}) error {
+		t.Helper()
+
+		comp := newPausablePubSub()
+		require.NoError(t, comp.Init(t.Context(), contribpubsub.Metadata{}))
+
+		_, err := New(Options{
+			Resiliency: prov,
+			Postman:    fakepostman.New().WithDeliverFn(deliverFn),
+			PubSub:     &runtimePubsub.PubsubItem{Component: comp},
+			AppID:      TestRuntimeConfigID,
+			PubSubName: pubsubName,
+			Topic:      "topic0",
+			Route: runtimePubsub.Subscription{
+				Rules: []*runtimePubsub.Rule{{Path: "orders"}},
+			},
+		})
+		require.NoError(t, err)
+
+		// Stand-in for sarama's session.Context().
+		sessionCtx, rebalance := context.WithCancel(t.Context())
+		done := make(chan error, 1)
+		go func() {
+			done <- comp.deliver(sessionCtx, "topic0", []byte(`{"data":"x"}`))
+		}()
+
+		select {
+		case <-invoked:
+		case <-time.After(time.Second * 5):
+			t.Fatal("the app was never invoked")
+		}
+
+		rebalance()
+
+		select {
+		case err := <-done:
+			return err
+		case <-time.After(time.Second * 2):
+			t.Fatal("handler still running 2s after the component cancelled its context: the inbound resiliency runner is ignoring it")
+			return nil
+		}
+	}
+
+	// A slow app: the in-flight invocation must be cancellable. No resiliency
+	// policy is involved, so this isolates the context plumbing itself.
+	t.Run("in-flight app invocation", func(t *testing.T) {
+		invoked := make(chan struct{})
+		var once sync.Once
+
+		err := deliverAndCancel(t, resiliency.New(log), "testpubsub",
+			func(ctx context.Context, _ *runtimePubsub.SubscribedMessage) error {
+				once.Do(func() { close(invoked) })
+				<-ctx.Done()
+				return ctx.Err()
+			}, invoked)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+
+	// A poison message under a long retry policy: the backoff sleep between
+	// attempts must be cancellable. This is the issue's exact configuration,
+	// scaled down.
+	t.Run("retry backoff between attempts", func(t *testing.T) {
+		prov := createResPolicyProvider(resiliencyV1alpha.CircuitBreaker{}, "5m",
+			resiliencyV1alpha.Retry{
+				Policy:     "constant",
+				Duration:   "40s",
+				MaxRetries: new(5),
+			})
+
+		invoked := make(chan struct{})
+		var once sync.Once
+
+		err := deliverAndCancel(t, prov, pubsubName,
+			func(_ context.Context, _ *runtimePubsub.SubscribedMessage) error {
+				once.Do(func() { close(invoked) })
+				return rterrors.NewRetriable(errors.New("app returned 500"))
+			}, invoked)
+
+		require.ErrorIs(t, err, context.Canceled)
+	})
+}

--- a/tests/integration/framework/process/pubsub/broker/broker.go
+++ b/tests/integration/framework/process/pubsub/broker/broker.go
@@ -121,6 +121,11 @@ func (b *Broker) PublishHelloWorld(topic string) <-chan *compv1.PullMessagesRequ
 	return b.pmrReqCh
 }
 
+// DropStream ends the in-flight PullMessages stream, cancelling the context
+// the component gave the runtime's inbound handler. Stands in for a Kafka
+// consumer group rebalance.
+func (b *Broker) DropStream() { b.inmem.DropStream() }
+
 // PauseCalled reports how many times the runtime invoked Pause on the
 // pluggable server. Used by tests asserting the pause-and-drain shutdown
 // path was exercised.

--- a/tests/integration/framework/process/pubsub/component.go
+++ b/tests/integration/framework/process/pubsub/component.go
@@ -48,6 +48,15 @@ type component struct {
 	// pausable opts in to Pause/Resume; default is non-pausable
 	// (returns codes.Unimplemented), matching most pubsub components.
 	pausable bool
+
+	// dropStreamCh, when closed, makes PullMessages return so the gRPC
+	// stream ends underneath the runtime while a message may still be in
+	// flight. This is the pluggable equivalent of a Kafka consumer group
+	// rebalance pulling a partition assignment out from under a consumer:
+	// the context the component gave the inbound handler is cancelled, and
+	// the runtime must stop retrying that message.
+	dropStreamCh  chan struct{}
+	dropStreamOnc sync.Once
 }
 
 func newComponent(t *testing.T, opts options) *component {
@@ -57,6 +66,7 @@ func newComponent(t *testing.T, opts options) *component {
 		pmrRespCh:    opts.pmrRespCh,
 		pauseStartCh: make(chan struct{}),
 		pausable:     opts.pausable,
+		dropStreamCh: make(chan struct{}),
 	}
 }
 
@@ -146,10 +156,17 @@ func (c *component) PullMessages(req compv1pb.PubSub_PullMessagesServer) error {
 			return c.waitForStreamEnd(req, recvErr)
 		case err := <-recvErr:
 			return cleanShutdown(err)
+		case <-c.dropStreamCh:
+			return nil
 		case <-req.Context().Done():
 			return nil
 		}
 	}
+}
+
+// dropStream ends the PullMessages stream, simulating a rebalance.
+func (c *component) dropStream() {
+	c.dropStreamOnc.Do(func() { close(c.dropStreamCh) })
 }
 
 // waitForStreamEnd is the paused state — no more pmrRespCh forwards;

--- a/tests/integration/framework/process/pubsub/pubsub.go
+++ b/tests/integration/framework/process/pubsub/pubsub.go
@@ -104,5 +104,10 @@ func (p *PubSub) PauseCalled() int64 { return p.component.pauseCalled.Load() }
 // paused state.
 func (p *PubSub) IsPaused() bool { return p.component.paused.Load() }
 
+// DropStream ends the in-flight PullMessages stream, which cancels the
+// context the component handed the runtime's inbound handler. Stands in for
+// a Kafka consumer group rebalance.
+func (p *PubSub) DropStream() { p.component.dropStream() }
+
 // PauseStarted returns a channel closed the first time Pause is called.
 func (p *PubSub) PauseStarted() <-chan struct{} { return p.component.pauseStartCh }

--- a/tests/integration/suite/daprd/pubsub/pluggable/rebalance.go
+++ b/tests/integration/suite/daprd/pubsub/pluggable/rebalance.go
@@ -1,0 +1,125 @@
+/*
+Copyright 2026 The Dapr Authors
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package pluggable
+
+import (
+	"context"
+	nethttp "net/http"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/dapr/dapr/tests/integration/framework"
+	"github.com/dapr/dapr/tests/integration/framework/os"
+	"github.com/dapr/dapr/tests/integration/framework/process/daprd"
+	"github.com/dapr/dapr/tests/integration/framework/process/http/app"
+	"github.com/dapr/dapr/tests/integration/framework/process/pubsub/broker"
+	"github.com/dapr/dapr/tests/integration/suite"
+)
+
+func init() {
+	suite.Register(new(rebalance))
+}
+
+type rebalance struct {
+	daprd  *daprd.Daprd
+	broker *broker.Broker
+
+	attempts atomic.Int64
+}
+
+func (r *rebalance) Setup(t *testing.T) []framework.Option {
+	os.SkipWindows(t)
+
+	app := app.New(t,
+		app.WithSubscribe(`[{"pubsubname":"mypub","topic":"a","route":"/a"}]`),
+		app.WithHandlerFunc("/a", func(w nethttp.ResponseWriter, _ *nethttp.Request) {
+			r.attempts.Add(1)
+			w.WriteHeader(nethttp.StatusInternalServerError)
+		}),
+	)
+
+	r.broker = broker.New(t)
+
+	r.daprd = daprd.New(t,
+		r.broker.DaprdOptions(t, "mypub",
+			daprd.WithAppPort(app.Port()),
+			daprd.WithResourceFiles(`apiVersion: dapr.io/v1alpha1
+kind: Resiliency
+metadata:
+  name: pubsub-retry
+spec:
+  policies:
+    retries:
+      pubsubRetry:
+        duration: 2s
+        maxRetries: 20
+        policy: constant
+  targets:
+    components:
+      mypub:
+        inbound:
+          retry: pubsubRetry
+`),
+		)...,
+	)
+
+	return []framework.Option{
+		framework.WithProcesses(app, r.broker, r.daprd),
+	}
+}
+
+func (r *rebalance) Run(t *testing.T, ctx context.Context) {
+	r.daprd.WaitUntilRunning(t, ctx)
+
+	assert.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.Len(c, r.daprd.GetMetaSubscriptions(c, ctx), 1)
+	}, time.Second*10, time.Millisecond*10)
+
+	r.broker.PublishHelloWorld("a")
+
+	// Wait until the retry loop is properly under way.
+	require.Eventually(t, func() bool {
+		return r.attempts.Load() >= 2
+	}, time.Second*30, time.Millisecond*10,
+		"the app should be retried on the poison message")
+
+	// The rebalance.
+	r.broker.DropStream()
+
+	// The retry loop owns a message the component no longer holds, so it must
+	// stop. Look for a window with no new delivery attempts; with the runner
+	// rooted at a context the component cannot cancel, attempts keep landing
+	// every 2s for the whole 40s retry budget.
+	var quiet bool
+	deadline := time.Now().Add(time.Second * 30)
+	for time.Now().Before(deadline) {
+		before := r.attempts.Load()
+		select {
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		case <-time.After(time.Second * 6):
+		}
+		if r.attempts.Load() == before {
+			quiet = true
+			break
+		}
+	}
+
+	require.True(t, quiet,
+		"app was still being retried after the component cancelled the handler context: the inbound resiliency runner is ignoring it")
+}


### PR DESCRIPTION
The inbound resiliency runner was built on context.Background(), so nothing it drove could be cancelled: not the retry backoff sleeps, not the in-flight app invocation. The context the component hands the inbound handler is that component's own subscription context, which for Kafka is sarama's session.Context(), cancelled the moment a consumer group rebalance starts.

Fixes dapr/components-contrib#4580.

A permanently-failing message keeps being retried against the app long after the partition has moved on, ConsumeClaim cannot return, the member is evicted, rejoining triggers another rebalance, and two consumers trade the same message indefinitely. A health check blip under 10 seconds was enough to start it, and it never stopped on its own.

Derive the runner from the handler context instead, matching what the bulk path in bulkresiliency.go already does. A rebalance now aborts the retry loop and the in-flight invocation, the message is left unacked, and it is redelivered to whichever consumer takes over the partition.

Behaviour note for components that scope the handler context: Azure Service Bus (handlerTimeoutInSec, default 60s) and Redis Streams (processingTimeout, default 60s) wrap it in a timeout. That timeout previously had no effect on this path; it now bounds inbound retries, and exceeding it routes the message to the dead letter topic, as the bulk path has always done.